### PR TITLE
refactor: replace hand-made file tools with ai-ide equivalents, add d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31887,15 +31887,39 @@
         "@theia/ai-core": "1.70.0",
         "@theia/cooklang-account": "1.70.0",
         "@theia/core": "1.70.0",
-        "@theia/editor": "1.70.0",
         "@theia/filesystem": "1.70.0",
         "@theia/monaco": "1.70.0",
         "@theia/workspace": "1.70.0",
-        "minimatch": "^10.0.3",
+        "ignore": "^5.0.0",
+        "minimatch": "^9.0.0",
         "tslib": "^2.6.2"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.70.0"
+      }
+    },
+    "packages/cooklang-ai/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "packages/cooklang-ai/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/cooklang-branding": {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -191,6 +191,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
     const pendingRef = React.useRef<HTMLElement | undefined>(undefined);
     const allowedRef = React.useRef<HTMLElement | undefined>(undefined);
 
+    const displayName = toolRequest?.displayName ?? response.name;
     const argsLabel = getArgumentsLabel(response.name, response.arguments);
 
     const formatReason = (reason: unknown): string => {
@@ -234,16 +235,16 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
         <div className='theia-toolCall'>
             {confirmationState === 'rejected' ? (
                 <span className='theia-toolCall-rejected'>
-                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/rejected', 'Execution canceled')}: {response.name}
+                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/rejected', 'Execution canceled')}: {displayName}
                     {reasonText ? <span> — {reasonText}</span> : undefined}
                 </span>
             ) : requestCanceled && !response.finished ? (
                 <span className='theia-toolCall-rejected'>
-                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/rejected', 'Execution canceled')}: {response.name}
+                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/rejected', 'Execution canceled')}: {displayName}
                 </span>
             ) : confirmationState === 'denied' ? (
                 <span className='theia-toolCall-denied'>
-                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/denied', 'Execution denied')}: {response.name}
+                    <span className={codicon('error')}></span> {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/denied', 'Execution denied')}: {displayName}
                     {ToolCallChatResponseContent.isDenialResult(response.result) && response.result.reason ? <span> — {response.result.reason}</span> : undefined}
                 </span>
             ) : response.finished ? (
@@ -252,7 +253,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
                         ref={(el: HTMLElement | null) => { summaryRef.current = el ?? undefined; }}
                         onMouseEnter={() => showArgsTooltip(response, summaryRef.current)}
                     >
-                        {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/finished', 'Ran')} {response.name}
+                        {nls.localize('theia/ai/chat-ui/toolcall-part-renderer/finished', 'Ran')} {displayName}
                         (<span className='theia-toolCall-args-label'>{argsLabel}</span>)
                     </summary>
                     <div className='theia-toolCall-response-result'>
@@ -264,7 +265,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
                     ref={(el: HTMLElement | null) => { pendingRef.current = el ?? undefined; }}
                     onMouseEnter={() => showArgsTooltip(response, pendingRef.current)}
                 >
-                    <Spinner /> {response.name}
+                    <Spinner /> {displayName}
                     (<span className='theia-toolCall-args-label'>{argsLabel}</span>)
                 </span>
             ) : (
@@ -273,7 +274,7 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
                         ref={(el: HTMLElement | null) => { allowedRef.current = el ?? undefined; }}
                         onMouseEnter={() => showArgsTooltip(response, allowedRef.current)}
                     >
-                        <Spinner /> {nls.localizeByDefault('Running')} {response.name}
+                        <Spinner /> {nls.localizeByDefault('Running')} {displayName}
                         (<span className='theia-toolCall-args-label'>{argsLabel}</span>)
                     </span>
                 )

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -122,6 +122,8 @@ export interface ToolRequestParameters {
 export interface ToolRequest<TContext extends ToolInvocationContext = ToolInvocationContext> {
     id: string;
     name: string;
+    /** Human-readable label shown in the chat UI instead of the raw tool name. */
+    displayName?: string;
     parameters: ToolRequestParameters
     description?: string;
     handler: (arg_string: string, ctx?: TContext) => Promise<ToolCallResult>;

--- a/packages/cooklang-ai/package.json
+++ b/packages/cooklang-ai/package.json
@@ -8,9 +8,12 @@
     "@theia/cooklang-account": "1.70.0",
     "@theia/core": "1.70.0",
     "@theia/filesystem": "1.70.0",
+    "@theia/monaco": "1.70.0",
     "@theia/workspace": "1.70.0",
     "@grpc/grpc-js": "^1.12.0",
     "@grpc/proto-loader": "^0.7.0",
+    "ignore": "^5.0.0",
+    "minimatch": "^9.0.0",
     "tslib": "^2.6.2"
   },
   "main": "lib/common",

--- a/packages/cooklang-ai/src/browser/cookbot-chat-agent.ts
+++ b/packages/cooklang-ai/src/browser/cookbot-chat-agent.ts
@@ -13,7 +13,7 @@ import { LanguageModelRequirement, ToolInvocationRegistry } from '@theia/ai-core
 export class CookbotChatAgent extends AbstractStreamParsingChatAgent {
 
     override id = 'cookbot';
-    override name = 'Cooklang Assistant';
+    override name = 'Cookbot';
     override description = 'AI assistant for Cooklang recipe writing, meal planning, and recipe management';
     override languageModelRequirements: LanguageModelRequirement[] = [
         {

--- a/packages/cooklang-ai/src/browser/cookbot-server-tools.ts
+++ b/packages/cooklang-ai/src/browser/cookbot-server-tools.ts
@@ -7,10 +7,6 @@
 
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import URI from '@theia/core/lib/common/uri';
-import { FileStat } from '@theia/filesystem/lib/common/files';
 import { CookbotServerToolsService } from '../common/cookbot-server-tools-protocol';
 
 function parseArgs(argString: string): Record<string, string> {
@@ -21,260 +17,11 @@ function parseArgs(argString: string): Record<string, string> {
     }
 }
 
-function validatePath(filePath: string, root: FileStat): URI {
-    const fileUri = root.resource.resolve(filePath);
-    const rootPath = root.resource.path.toString();
-    const resolved = fileUri.path.normalize().toString();
-    if (!resolved.startsWith(rootPath + '/') && resolved !== rootPath) {
-        throw new Error('Path escapes workspace root');
-    }
-    return fileUri;
-}
-
-// ── File tools ──────────────────────────────────────────────────────────
-
-@injectable()
-export class CookbotListFilesTool implements ToolProvider {
-    static ID = 'list_files';
-
-    @inject(FileService)
-    protected readonly fileService: FileService;
-
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
-    getTool(): ToolRequest {
-        return {
-            id: CookbotListFilesTool.ID,
-            name: CookbotListFilesTool.ID,
-            description: 'List files in the recipes directory. Use glob patterns to filter.',
-            parameters: {
-                type: 'object',
-                properties: {
-                    pattern: {
-                        type: 'string',
-                        description: 'Glob pattern to filter files (e.g. "**/*.cook")',
-                    },
-                    limit: {
-                        type: 'number',
-                        description: 'Maximum number of files to return',
-                    },
-                },
-            },
-            handler: async (argString: string) => this.execute(argString),
-        };
-    }
-
-    private async execute(argString: string): Promise<string> {
-        const args = parseArgs(argString);
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length === 0) {
-            return 'No workspace open';
-        }
-        const root = roots[0];
-        const pattern = args.pattern || '**/*';
-        const limit = args.limit ? parseInt(args.limit, 10) : 500;
-        const rootPath = root.resource.path.toString();
-
-        const files: string[] = [];
-        await this.collectFiles(root.resource, rootPath, pattern, files, limit);
-        return JSON.stringify(files);
-    }
-
-    private async collectFiles(dirUri: URI, rootPath: string, pattern: string, files: string[], limit: number, depth: number = 0): Promise<void> {
-        if (depth > 20 || files.length >= limit) {
-            return;
-        }
-        try {
-            const stat = await this.fileService.resolve(dirUri);
-            if (!stat.children) {
-                return;
-            }
-            for (const child of stat.children) {
-                if (files.length >= limit) {
-                    break;
-                }
-                const relativePath = child.resource.path.toString().substring(rootPath.length + 1);
-                if (child.isDirectory) {
-                    await this.collectFiles(child.resource, rootPath, pattern, files, limit, depth + 1);
-                } else if (this.matchGlob(relativePath, pattern)) {
-                    files.push(relativePath);
-                }
-            }
-        } catch {
-            // Directory may not exist or be inaccessible
-        }
-    }
-
-    private matchGlob(filePath: string, pattern: string): boolean {
-        // Simple glob matching: support *, **, and ?
-        const regexStr = pattern
-            .replace(/\*\*/g, '{{GLOBSTAR}}')
-            .replace(/\*/g, '[^/]*')
-            .replace(/\?/g, '[^/]')
-            .replace(/{{GLOBSTAR}}/g, '.*');
-        return new RegExp(`^${regexStr}$`).test(filePath);
-    }
-}
-
-@injectable()
-export class CookbotReadFileTool implements ToolProvider {
-    static ID = 'read_file';
-
-    @inject(FileService)
-    protected readonly fileService: FileService;
-
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
-    getTool(): ToolRequest {
-        return {
-            id: CookbotReadFileTool.ID,
-            name: CookbotReadFileTool.ID,
-            description: 'Read the contents of a file in the recipes directory.',
-            parameters: {
-                type: 'object',
-                properties: {
-                    path: {
-                        type: 'string',
-                        description: 'Relative path to the file from workspace root',
-                    },
-                },
-                required: ['path'],
-            },
-            handler: async (argString: string) => this.execute(argString),
-        };
-    }
-
-    private async execute(argString: string): Promise<string> {
-        const args = parseArgs(argString);
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length === 0) {
-            return 'No workspace open';
-        }
-        const fileUri = validatePath(args.path, roots[0]);
-        try {
-            const content = await this.fileService.read(fileUri);
-            return content.value;
-        } catch (e) {
-            return `Error reading file: ${e instanceof Error ? e.message : String(e)}`;
-        }
-    }
-}
-
-@injectable()
-export class CookbotWriteFileTool implements ToolProvider {
-    static ID = 'write_file';
-
-    @inject(FileService)
-    protected readonly fileService: FileService;
-
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
-    getTool(): ToolRequest {
-        return {
-            id: CookbotWriteFileTool.ID,
-            name: CookbotWriteFileTool.ID,
-            description: 'Create or overwrite a file in the recipes directory.',
-            parameters: {
-                type: 'object',
-                properties: {
-                    path: {
-                        type: 'string',
-                        description: 'Relative path to the file from workspace root',
-                    },
-                    content: {
-                        type: 'string',
-                        description: 'File content to write',
-                    },
-                },
-                required: ['path', 'content'],
-            },
-            handler: async (argString: string) => this.execute(argString),
-        };
-    }
-
-    private async execute(argString: string): Promise<string> {
-        const args = parseArgs(argString);
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length === 0) {
-            return 'No workspace open';
-        }
-        const fileUri = validatePath(args.path, roots[0]);
-        try {
-            await this.fileService.write(fileUri, args.content);
-            return `File written: ${args.path}`;
-        } catch (e) {
-            return `Error writing file: ${e instanceof Error ? e.message : String(e)}`;
-        }
-    }
-}
-
-@injectable()
-export class CookbotEditFileTool implements ToolProvider {
-    static ID = 'edit_file';
-
-    @inject(FileService)
-    protected readonly fileService: FileService;
-
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
-    getTool(): ToolRequest {
-        return {
-            id: CookbotEditFileTool.ID,
-            name: CookbotEditFileTool.ID,
-            description: 'Edit a file by replacing text. Use find/replace for modifications.',
-            parameters: {
-                type: 'object',
-                properties: {
-                    path: {
-                        type: 'string',
-                        description: 'Relative path to the file from workspace root',
-                    },
-                    find: {
-                        type: 'string',
-                        description: 'Text to find in the file',
-                    },
-                    replace: {
-                        type: 'string',
-                        description: 'Text to replace with',
-                    },
-                },
-                required: ['path', 'find', 'replace'],
-            },
-            handler: async (argString: string) => this.execute(argString),
-        };
-    }
-
-    private async execute(argString: string): Promise<string> {
-        const args = parseArgs(argString);
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length === 0) {
-            return 'No workspace open';
-        }
-        const fileUri = validatePath(args.path, roots[0]);
-        try {
-            const existing = await this.fileService.read(fileUri);
-            const content = existing.value;
-            if (!content.includes(args.find)) {
-                return `Error: text to find not found in ${args.path}`;
-            }
-            const updated = content.replace(args.find, args.replace);
-            await this.fileService.write(fileUri, updated);
-            return `File edited: ${args.path}`;
-        } catch (e) {
-            return `Error editing file: ${e instanceof Error ? e.message : String(e)}`;
-        }
-    }
-}
-
 // ── Server tools ────────────────────────────────────────────────────────
 
 @injectable()
 export class CookbotSearchWebTool implements ToolProvider {
-    static ID = 'search_web';
+    static ID = 'searchWeb';
 
     @inject(CookbotServerToolsService)
     protected readonly serverTools: CookbotServerToolsService;
@@ -283,6 +30,7 @@ export class CookbotSearchWebTool implements ToolProvider {
         return {
             id: CookbotSearchWebTool.ID,
             name: CookbotSearchWebTool.ID,
+            displayName: 'Search Web',
             description: 'Search the web for recipes and cooking information using semantic search.',
             parameters: {
                 type: 'object',
@@ -318,7 +66,7 @@ export class CookbotSearchWebTool implements ToolProvider {
 
 @injectable()
 export class CookbotFetchUrlTool implements ToolProvider {
-    static ID = 'fetch_url';
+    static ID = 'fetchUrl';
 
     @inject(CookbotServerToolsService)
     protected readonly serverTools: CookbotServerToolsService;
@@ -327,6 +75,7 @@ export class CookbotFetchUrlTool implements ToolProvider {
         return {
             id: CookbotFetchUrlTool.ID,
             name: CookbotFetchUrlTool.ID,
+            displayName: 'Fetch URL',
             description: 'Fetch the content of a URL. Useful for reading recipe pages.',
             parameters: {
                 type: 'object',
@@ -358,7 +107,7 @@ export class CookbotFetchUrlTool implements ToolProvider {
 
 @injectable()
 export class CookbotConvertUrlTool implements ToolProvider {
-    static ID = 'convert_url_to_cooklang';
+    static ID = 'convertUrlToCooklang';
 
     @inject(CookbotServerToolsService)
     protected readonly serverTools: CookbotServerToolsService;
@@ -367,6 +116,7 @@ export class CookbotConvertUrlTool implements ToolProvider {
         return {
             id: CookbotConvertUrlTool.ID,
             name: CookbotConvertUrlTool.ID,
+            displayName: 'Convert URL to Cooklang',
             description: 'Convert a recipe from a URL into Cooklang format.',
             parameters: {
                 type: 'object',
@@ -398,7 +148,7 @@ export class CookbotConvertUrlTool implements ToolProvider {
 
 @injectable()
 export class CookbotConvertTextTool implements ToolProvider {
-    static ID = 'convert_text_to_cooklang';
+    static ID = 'convertTextToCooklang';
 
     @inject(CookbotServerToolsService)
     protected readonly serverTools: CookbotServerToolsService;
@@ -407,6 +157,7 @@ export class CookbotConvertTextTool implements ToolProvider {
         return {
             id: CookbotConvertTextTool.ID,
             name: CookbotConvertTextTool.ID,
+            displayName: 'Convert Text to Cooklang',
             description: 'Convert a plain text recipe into Cooklang format.',
             parameters: {
                 type: 'object',

--- a/packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
+++ b/packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
@@ -8,13 +8,31 @@
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ChatAgent, DefaultChatAgentId } from '@theia/ai-chat/lib/common';
 import { Agent, bindToolProvider } from '@theia/ai-core/lib/common';
+import { PreferenceContribution } from '@theia/core/lib/common/preferences/preference-schema';
 import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { CookbotServerToolsPath, CookbotServerToolsService } from '../common/cookbot-server-tools-protocol';
 import { CookbotChatAgent } from './cookbot-chat-agent';
 import {
-    CookbotListFilesTool, CookbotReadFileTool, CookbotWriteFileTool, CookbotEditFileTool,
     CookbotSearchWebTool, CookbotFetchUrlTool, CookbotConvertUrlTool, CookbotConvertTextTool,
 } from './cookbot-server-tools';
+import { WorkspaceFunctionScope } from './file-tools/workspace-function-scope';
+import { WorkspacePreferencesSchema } from './file-tools/workspace-preferences';
+import {
+    GetWorkspaceDirectoryStructure,
+    FileContentFunction,
+    GetWorkspaceFileList,
+    FindFilesByPattern,
+} from './file-tools/workspace-functions';
+import {
+    SuggestFileContent,
+    SuggestFileReplacements,
+    ReplaceContentInFileFunctionHelper,
+    ReplaceContentInFileFunctionHelperV2,
+    FileChangeSetTitleProvider,
+    DefaultFileChangeSetTitleProvider,
+    ClearFileChanges,
+    GetProposedFileState,
+} from './file-tools/file-changeset-functions';
 
 export default new ContainerModule(bind => {
     // Chat agent
@@ -28,11 +46,28 @@ export default new ContainerModule(bind => {
         ServiceConnectionProvider.createProxy(ctx.container, CookbotServerToolsPath)
     ).inSingletonScope();
 
-    // File tools (execute locally via Theia FileService)
-    bindToolProvider(CookbotListFilesTool, bind);
-    bindToolProvider(CookbotReadFileTool, bind);
-    bindToolProvider(CookbotWriteFileTool, bind);
-    bindToolProvider(CookbotEditFileTool, bind);
+    // Workspace function scope (shared helper for all file tools)
+    bind(WorkspaceFunctionScope).toSelf().inSingletonScope();
+
+    // Preferences
+    bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
+
+    // File tools — workspace exploration
+    bindToolProvider(GetWorkspaceFileList, bind);
+    bindToolProvider(FileContentFunction, bind);
+    bindToolProvider(GetWorkspaceDirectoryStructure, bind);
+    bindToolProvider(FindFilesByPattern, bind);
+
+    // File tools — changeset infrastructure
+    bind(ReplaceContentInFileFunctionHelper).toSelf().inSingletonScope();
+    bind(ReplaceContentInFileFunctionHelperV2).toSelf().inSingletonScope();
+    bind(FileChangeSetTitleProvider).to(DefaultFileChangeSetTitleProvider).inSingletonScope();
+
+    // File tools — suggest & replace (user reviews before applying)
+    bindToolProvider(SuggestFileContent, bind);
+    bindToolProvider(SuggestFileReplacements, bind);
+    bindToolProvider(ClearFileChanges, bind);
+    bindToolProvider(GetProposedFileState, bind);
 
     // Server-side tool providers (execute via gRPC)
     bindToolProvider(CookbotSearchWebTool, bind);

--- a/packages/cooklang-ai/src/browser/file-tools/file-changeset-functions.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/file-changeset-functions.ts
@@ -1,0 +1,467 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls, URI } from '@theia/core';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ToolProvider, ToolRequest, ToolRequestParameters, ToolInvocationContext } from '@theia/ai-core/lib/common';
+import { assertChatContext, ChatToolContext } from '@theia/ai-chat/lib/common/chat-tool-request-service';
+import { ChangeSetFileElement, ChangeSetFileElementFactory } from '@theia/ai-chat/lib/browser/change-set-file-element';
+import { ContentReplacer, ContentReplacerV1Impl, Replacement } from '@theia/core/lib/common/content-replacer';
+import { ContentReplacerV2Impl } from '@theia/core/lib/common/content-replacer-v2-impl';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceFunctionScope } from './workspace-function-scope';
+import {
+    SUGGEST_FILE_CONTENT_ID,
+    SUGGEST_FILE_REPLACEMENTS_ID,
+    CLEAR_FILE_CHANGES_ID,
+    GET_PROPOSED_CHANGES_ID,
+} from './function-ids';
+
+function createPathShortLabel(args: string, hasMore: boolean): { label: string; hasMore: boolean } | undefined {
+    try {
+        const parsed = JSON.parse(args);
+        if (parsed && typeof parsed === 'object' && 'path' in parsed) {
+            return { label: String(parsed.path), hasMore };
+        }
+    } catch {
+        // ignore parse errors
+    }
+    return undefined;
+}
+
+// ── FileChangeSetTitleProvider ──────────────────────────────────────────
+
+export const FileChangeSetTitleProvider = Symbol('FileChangeSetTitleProvider');
+export interface FileChangeSetTitleProvider {
+    getChangeSetTitle(ctx: ChatToolContext): string;
+}
+
+@injectable()
+export class DefaultFileChangeSetTitleProvider implements FileChangeSetTitleProvider {
+    getChangeSetTitle(_ctx: ChatToolContext): string {
+        return nls.localize('theia/ai-chat/fileChangeSetTitle', 'Changes proposed');
+    }
+}
+
+// ── SuggestFileContent ──────────────────────────────────────────────────
+
+@injectable()
+export class SuggestFileContent implements ToolProvider {
+    static ID = SUGGEST_FILE_CONTENT_ID;
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceFunctionScope: WorkspaceFunctionScope;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(ChangeSetFileElementFactory)
+    protected readonly fileChangeFactory: ChangeSetFileElementFactory;
+
+    @inject(FileChangeSetTitleProvider)
+    protected readonly fileChangeSetTitleProvider: FileChangeSetTitleProvider;
+
+    getTool(): ToolRequest {
+        return {
+            id: SuggestFileContent.ID,
+            name: SuggestFileContent.ID,
+            displayName: 'Write File',
+            description:
+                'Proposes writing complete content to a file for user review. If the file exists, it will be overwritten when accepted. ' +
+                'If the file does not exist, it will be created. This tool will automatically create any directories needed to write the file. ' +
+                'If the new content is empty, the file will be deleted when accepted. To move a file, delete it and re-create it at the new location. ' +
+                'Use this for creating new files or complete file rewrites. ' +
+                'For targeted edits, prefer suggestFileReplacements - it\'s more efficient and less error-prone. ' +
+                'The user will review the proposed changes and can accept or reject them.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts", "config/settings.json").',
+                    },
+                    content: {
+                        type: 'string',
+                        description:
+                            'The COMPLETE content to write to the file. You MUST include ALL parts of the file, even if they haven\'t been modified. ' +
+                            'Do not truncate or omit any sections. Use empty string "" to delete the file.',
+                    },
+                },
+                required: ['path', 'content'],
+            },
+            handler: async (args: string, ctx?: ToolInvocationContext) => {
+                assertChatContext(ctx);
+                if (ctx.cancellationToken?.isCancellationRequested) {
+                    return JSON.stringify({ error: 'Operation cancelled by user' });
+                }
+                const { path, content } = JSON.parse(args);
+                const chatSessionId = ctx.request.session.id;
+                const uri = await this.workspaceFunctionScope.resolveRelativePath(path);
+                let type: 'add' | 'modify' | 'delete' = 'modify';
+                if (content === '') {
+                    type = 'delete';
+                }
+                if (!(await this.fileService.exists(uri))) {
+                    type = 'add';
+                }
+                ctx.request.session.changeSet.addElements(this.fileChangeFactory({
+                    uri,
+                    type,
+                    state: 'pending',
+                    targetState: content,
+                    requestId: ctx.request.id,
+                    chatSessionId,
+                }));
+                ctx.request.session.changeSet.setTitle(this.fileChangeSetTitleProvider.getChangeSetTitle(ctx));
+                return `Proposed writing to file ${path}. The user will review and potentially apply the changes.`;
+            },
+            getArgumentsShortLabel: (args: string) => createPathShortLabel(args, true),
+        };
+    }
+}
+
+// ── ReplaceContentInFileFunctionHelper ──────────────────────────────────
+
+@injectable()
+export class ReplaceContentInFileFunctionHelper {
+
+    protected replacer: ContentReplacer = new ContentReplacerV1Impl();
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceFunctionScope: WorkspaceFunctionScope;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(ChangeSetFileElementFactory)
+    protected readonly fileChangeFactory: ChangeSetFileElementFactory;
+
+    @inject(FileChangeSetTitleProvider)
+    protected readonly fileChangeSetTitleProvider: FileChangeSetTitleProvider;
+
+    setReplacer(replacer: ContentReplacer): void {
+        this.replacer = replacer;
+    }
+
+    getToolMetadata(supportMultipleReplace = false): { description: string; parameters: ToolRequestParameters } {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const replacementProperties: Record<string, any> = {
+            oldContent: {
+                type: 'string',
+                description: 'The exact content to be replaced. Must match exactly, including whitespace, comments, etc.',
+            },
+            newContent: {
+                type: 'string',
+                description: 'The new content to insert in place of matched old content.',
+            },
+        };
+        if (supportMultipleReplace) {
+            replacementProperties.multiple = {
+                type: 'boolean',
+                description: 'Set to true if multiple occurrences of the oldContent are expected to be replaced.',
+            };
+        }
+        const replacementParameters: ToolRequestParameters = {
+            type: 'object',
+            properties: {
+                path: {
+                    type: 'string',
+                    description: 'Relative path to the file within the workspace (e.g., "src/index.ts"). Must read the file with getFileContent first.',
+                },
+                replacements: {
+                    type: 'array',
+                    items: {
+                        type: 'object',
+                        properties: replacementProperties,
+                        required: ['oldContent', 'newContent'],
+                    },
+                    description: 'An array of replacement objects, each containing oldContent and newContent strings.',
+                },
+                reset: {
+                    type: 'boolean',
+                    description: 'Set to true to clear any existing pending changes for this file and start fresh. Default is false, which merges with existing changes.',
+                },
+            },
+            required: ['path', 'replacements'],
+        };
+
+        const replacementSentence = supportMultipleReplace
+            ? 'By default, a single occurrence of each old content in the tuples is expected to be replaced. If the optional \'multiple\' flag is set to true, all occurrences will be replaced. In either case, if the number of occurrences in the file does not match the expectation the function will return an error. In that case try a different approach.'
+            : 'A single occurrence of each old content in the tuples is expected to be replaced. If the number of occurrences in the file does not match the expectation, the function will return an error. In that case try a different approach.';
+
+        const replacementDescription =
+            `Propose to replace sections of content in an existing file by providing a list of tuples with old content to be matched and replaced. ` +
+            `${replacementSentence} For deletions, use an empty new content in the tuple. ` +
+            `Make sure you use the same line endings and whitespace as in the original file content. ` +
+            `The proposed changes will be shown to the user for review before being applied. ` +
+            `Multiple calls for the same file will merge replacements unless the reset parameter is set to true. ` +
+            `Use the reset parameter to clear previous changes and start fresh if needed.\n\n` +
+            `IMPORTANT: Each oldContent must match exactly (including whitespace and indentation). ` +
+            `If replacements fail with "Expected 1 occurrence but found 0": re-read the file, the content may have changed or whitespace differs. ` +
+            `If replacements fail with "found 2+": include more surrounding context in oldContent to make it unique. ` +
+            `Always use getFileContent to read the current file state before making replacements.`;
+
+        return {
+            description: replacementDescription,
+            parameters: replacementParameters,
+        };
+    }
+
+    async createChangesetFromToolCall(toolCallString: string, ctx: ChatToolContext): Promise<string> {
+        try {
+            if (ctx.cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const result = await this.processReplacementsCommon(toolCallString, ctx, this.fileChangeSetTitleProvider.getChangeSetTitle(ctx));
+            if (result.errors.length > 0) {
+                return `Errors encountered: ${result.errors.join('; ')}`;
+            }
+            if (result.fileElement) {
+                const action = result.reset ? 'reset and ' : '';
+                return `Proposed ${action}replacements to file ${result.path}. The user will review and potentially apply the changes.`;
+            } else {
+                return `No changes needed for file ${result.path}. Content already matches the requested state.`;
+            }
+        } catch (error) {
+            console.debug('Error processing replacements:', (error as Error).message);
+            return JSON.stringify({ error: (error as Error).message });
+        }
+    }
+
+    protected async processReplacementsCommon(
+        toolCallString: string,
+        ctx: ChatToolContext,
+        changeSetTitle: string,
+    ): Promise<{ fileElement: ChangeSetFileElement | undefined; path: string; reset: boolean; errors: string[] }> {
+        if (ctx.cancellationToken?.isCancellationRequested) {
+            throw new Error('Operation cancelled by user');
+        }
+        const { path, replacements, reset } = JSON.parse(toolCallString) as {
+            path: string;
+            replacements: Replacement[];
+            reset?: boolean;
+        };
+        const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+        let startingContent: string;
+
+        if (reset || !ctx.request.session.changeSet) {
+            startingContent = (await this.fileService.read(fileUri)).value.toString();
+        } else {
+            const existingElement = this.findExistingChangeElement(ctx.request.session.changeSet, fileUri);
+            if (existingElement) {
+                startingContent = existingElement.targetState || (await this.fileService.read(fileUri)).value.toString();
+            } else {
+                startingContent = (await this.fileService.read(fileUri)).value.toString();
+            }
+        }
+
+        if (ctx.cancellationToken?.isCancellationRequested) {
+            throw new Error('Operation cancelled by user');
+        }
+
+        const { updatedContent, errors } = this.replacer.applyReplacements(startingContent, replacements);
+        if (errors.length > 0) {
+            return { fileElement: undefined, path, reset: reset || false, errors };
+        }
+
+        const originalContent = (await this.fileService.read(fileUri)).value.toString();
+        if (updatedContent !== originalContent) {
+            ctx.request.session.changeSet.setTitle(changeSetTitle);
+            const fileElement = this.fileChangeFactory({
+                uri: fileUri,
+                type: 'modify',
+                state: 'pending',
+                targetState: updatedContent,
+                requestId: ctx.request.id,
+                chatSessionId: ctx.request.session.id,
+            });
+            ctx.request.session.changeSet.addElements(fileElement);
+            return { fileElement, path, reset: reset || false, errors: [] };
+        } else {
+            return { fileElement: undefined, path, reset: reset || false, errors: [] };
+        }
+    }
+
+    protected findExistingChangeElement(changeSet: { getElementByURI(uri: URI): unknown }, fileUri: URI): ChangeSetFileElement | undefined {
+        const element = changeSet.getElementByURI(fileUri);
+        if (element instanceof ChangeSetFileElement) {
+            return element;
+        }
+        return undefined;
+    }
+
+    async clearFileChanges(path: string, ctx: ChatToolContext): Promise<string> {
+        try {
+            if (ctx.cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+            if (ctx.request.session.changeSet.removeElements(fileUri)) {
+                return `Cleared pending change(s) for file ${path}.`;
+            } else {
+                return `No pending changes found for file ${path}.`;
+            }
+        } catch (error) {
+            console.debug('Error clearing file changes:', (error as Error).message);
+            return JSON.stringify({ error: (error as Error).message });
+        }
+    }
+
+    async getProposedFileState(path: string, ctx: ChatToolContext): Promise<string> {
+        try {
+            if (ctx.cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+            if (!ctx.request.session.changeSet) {
+                const originalContent = (await this.fileService.read(fileUri)).value.toString();
+                return `File ${path} has no pending changes. Original content:\n\n${originalContent}`;
+            }
+            const existingElement = this.findExistingChangeElement(ctx.request.session.changeSet, fileUri);
+            if (existingElement && existingElement.targetState) {
+                return `File ${path} has pending changes. Proposed content:\n\n${existingElement.targetState}`;
+            } else {
+                const originalContent = (await this.fileService.read(fileUri)).value.toString();
+                return `File ${path} has no pending changes. Original content:\n\n${originalContent}`;
+            }
+        } catch (error) {
+            console.debug('Error getting proposed file state:', (error as Error).message);
+            return JSON.stringify({ error: (error as Error).message });
+        }
+    }
+}
+
+// ── ReplaceContentInFileFunctionHelperV2 ────────────────────────────────
+
+@injectable()
+export class ReplaceContentInFileFunctionHelperV2 extends ReplaceContentInFileFunctionHelper {
+    constructor() {
+        super();
+        this.setReplacer(new ContentReplacerV2Impl());
+    }
+}
+
+// ── SuggestFileReplacements (V2) ────────────────────────────────────────
+
+@injectable()
+export class SuggestFileReplacements implements ToolProvider {
+    static ID = SUGGEST_FILE_REPLACEMENTS_ID;
+
+    @inject(ReplaceContentInFileFunctionHelperV2)
+    protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelperV2;
+
+    getTool(): ToolRequest {
+        const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(true);
+        return {
+            id: SuggestFileReplacements.ID,
+            name: SuggestFileReplacements.ID,
+            displayName: 'Edit File',
+            description: metadata.description,
+            parameters: metadata.parameters,
+            handler: async (args: string, ctx?: ToolInvocationContext) => {
+                assertChatContext(ctx);
+                if (ctx.cancellationToken?.isCancellationRequested) {
+                    return JSON.stringify({ error: 'Operation cancelled by user' });
+                }
+                return this.replaceContentInFileFunctionHelper.createChangesetFromToolCall(args, ctx);
+            },
+            getArgumentsShortLabel: (args: string) => createPathShortLabel(args, true),
+        };
+    }
+}
+
+// ── ClearFileChanges ────────────────────────────────────────────────────
+
+@injectable()
+export class ClearFileChanges implements ToolProvider {
+    static ID = CLEAR_FILE_CHANGES_ID;
+
+    @inject(ReplaceContentInFileFunctionHelper)
+    protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
+
+    getTool(): ToolRequest {
+        return {
+            id: ClearFileChanges.ID,
+            name: ClearFileChanges.ID,
+            displayName: 'Clear File Changes',
+            description:
+                'Clears all pending (not yet applied) changes for a specific file, allowing you to start fresh with new modifications. ' +
+                'Use this when previous replacement attempts failed and you want to try a different approach. ' +
+                'Does not affect already-applied changes or the actual file on disk.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts").',
+                    },
+                },
+                required: ['path'],
+            },
+            handler: async (args: string, ctx?: ToolInvocationContext) => {
+                assertChatContext(ctx);
+                if (ctx.cancellationToken?.isCancellationRequested) {
+                    return JSON.stringify({ error: 'Operation cancelled by user' });
+                }
+                const { path } = JSON.parse(args);
+                return this.replaceContentInFileFunctionHelper.clearFileChanges(path, ctx);
+            },
+            getArgumentsShortLabel: (args: string) => createPathShortLabel(args, false),
+        };
+    }
+}
+
+// ── GetProposedFileState ────────────────────────────────────────────────
+
+@injectable()
+export class GetProposedFileState implements ToolProvider {
+    static ID = GET_PROPOSED_CHANGES_ID;
+
+    @inject(ReplaceContentInFileFunctionHelper)
+    protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
+
+    getTool(): ToolRequest {
+        return {
+            id: GET_PROPOSED_CHANGES_ID,
+            name: GET_PROPOSED_CHANGES_ID,
+            displayName: 'Get Proposed File State',
+            description:
+                'Returns the current proposed state of a file, including all pending changes that have been proposed ' +
+                'but not yet applied. Use this to see what the file will look like after your changes are applied. ' +
+                'This is useful when making incremental changes to verify the accumulated state is correct. ' +
+                'If no pending changes exist for the file, returns the original file content.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts").',
+                    },
+                },
+                required: ['path'],
+            },
+            handler: async (args: string, ctx?: ToolInvocationContext) => {
+                assertChatContext(ctx);
+                if (ctx.cancellationToken?.isCancellationRequested) {
+                    return JSON.stringify({ error: 'Operation cancelled by user' });
+                }
+                const { path } = JSON.parse(args);
+                return this.replaceContentInFileFunctionHelper.getProposedFileState(path, ctx);
+            },
+            getArgumentsShortLabel: (args: string) => createPathShortLabel(args, false),
+        };
+    }
+}

--- a/packages/cooklang-ai/src/browser/file-tools/function-ids.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/function-ids.ts
@@ -1,0 +1,27 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// Workspace function IDs
+export const FILE_CONTENT_FUNCTION_ID = 'getFileContent';
+export const GET_WORKSPACE_FILE_LIST_FUNCTION_ID = 'getWorkspaceFileList';
+export const GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID = 'getWorkspaceDirectoryStructure';
+export const FIND_FILES_BY_PATTERN_FUNCTION_ID = 'findFilesByPattern';
+
+// File changeset function IDs
+export const SUGGEST_FILE_CONTENT_ID = 'suggestFileContent';
+export const SUGGEST_FILE_REPLACEMENTS_ID = 'suggestFileReplacements';
+export const CLEAR_FILE_CHANGES_ID = 'clearFileChanges';
+export const GET_PROPOSED_CHANGES_ID = 'getProposedFileState';

--- a/packages/cooklang-ai/src/browser/file-tools/workspace-function-scope.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/workspace-function-scope.ts
@@ -1,0 +1,115 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceService, URI } from '@theia/core';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileStat } from '@theia/filesystem/lib/common/files';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import ignore, { Ignore } from 'ignore';
+import { Minimatch } from 'minimatch';
+import { CONSIDER_GITIGNORE_PREF, USER_EXCLUDE_PATTERN_PREF } from './workspace-preferences';
+
+@injectable()
+export class WorkspaceFunctionScope {
+
+    protected readonly GITIGNORE_FILE_NAME = '.gitignore';
+    protected gitignoreWatcherInitialized = false;
+    protected gitignoreMatcher: Ignore | undefined;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    async getWorkspaceRoot(): Promise<URI> {
+        const wsRoots = await this.workspaceService.roots;
+        if (wsRoots.length === 0) {
+            throw new Error('No workspace has been opened yet');
+        }
+        return wsRoots[0].resource;
+    }
+
+    ensureWithinWorkspace(targetUri: URI, workspaceRootUri: URI): void {
+        if (!targetUri.toString().startsWith(workspaceRootUri.toString())) {
+            throw new Error('Access outside of the workspace is not allowed');
+        }
+    }
+
+    async resolveRelativePath(relativePath: string): Promise<URI> {
+        const workspaceRoot = await this.getWorkspaceRoot();
+        return workspaceRoot.resolve(relativePath);
+    }
+
+    async shouldExclude(stat: FileStat): Promise<boolean> {
+        const shouldConsiderGitIgnore = this.preferences.get<boolean>(CONSIDER_GITIGNORE_PREF, false);
+        const userExcludePatterns = this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, []);
+        if (this.isUserExcluded(stat.resource.path.base, userExcludePatterns)) {
+            return true;
+        }
+        const workspaceRoot = await this.getWorkspaceRoot();
+        if (shouldConsiderGitIgnore && (await this.isGitIgnored(stat, workspaceRoot))) {
+            return true;
+        }
+        return false;
+    }
+
+    isUserExcluded(fileName: string, userExcludePatterns: string[]): boolean {
+        return userExcludePatterns.some(pattern => new Minimatch(pattern, { dot: true }).match(fileName));
+    }
+
+    protected async initializeGitignoreWatcher(workspaceRoot: URI): Promise<void> {
+        if (this.gitignoreWatcherInitialized) {
+            return;
+        }
+        const gitignoreUri = workspaceRoot.resolve(this.GITIGNORE_FILE_NAME);
+        this.fileService.watch(gitignoreUri);
+        this.fileService.onDidFilesChange(async event => {
+            if (event.contains(gitignoreUri)) {
+                this.gitignoreMatcher = undefined;
+            }
+        });
+        this.gitignoreWatcherInitialized = true;
+    }
+
+    protected async isGitIgnored(stat: FileStat, workspaceRoot: URI): Promise<boolean> {
+        await this.initializeGitignoreWatcher(workspaceRoot);
+        const gitignoreUri = workspaceRoot.resolve(this.GITIGNORE_FILE_NAME);
+        try {
+            const fileStat = await this.fileService.resolve(gitignoreUri);
+            if (fileStat) {
+                if (!this.gitignoreMatcher) {
+                    const gitignoreContent = await this.fileService.read(gitignoreUri);
+                    this.gitignoreMatcher = ignore().add(gitignoreContent.value);
+                }
+                const relativePath = workspaceRoot.relative(stat.resource);
+                if (relativePath) {
+                    const relativePathStr = relativePath.toString() + (stat.isDirectory ? '/' : '');
+                    if (this.gitignoreMatcher.ignores(relativePathStr)) {
+                        return true;
+                    }
+                }
+            }
+        } catch {
+            // If .gitignore does not exist or cannot be read, continue without error
+        }
+        return false;
+    }
+}

--- a/packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts
@@ -1,0 +1,620 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CancellationToken, PreferenceService, URI } from '@theia/core';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { Minimatch } from 'minimatch';
+import { WorkspaceFunctionScope } from './workspace-function-scope';
+import {
+    FILE_CONTENT_FUNCTION_ID,
+    GET_WORKSPACE_FILE_LIST_FUNCTION_ID,
+    GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID,
+    FIND_FILES_BY_PATTERN_FUNCTION_ID,
+} from './function-ids';
+import { CONSIDER_GITIGNORE_PREF, FILE_CONTENT_MAX_SIZE_KB_PREF, USER_EXCLUDE_PATTERN_PREF } from './workspace-preferences';
+
+// ── GetWorkspaceDirectoryStructure ──────────────────────────────────────
+
+@injectable()
+export class GetWorkspaceDirectoryStructure implements ToolProvider {
+    static ID = GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
+    getTool(): ToolRequest {
+        return {
+            id: GetWorkspaceDirectoryStructure.ID,
+            name: GetWorkspaceDirectoryStructure.ID,
+            displayName: 'Get Directory Structure',
+            description:
+                'Retrieves the complete directory tree structure of the workspace as a nested JSON object. ' +
+                'Lists only directories (no files), excluding common non-essential directories (node_modules, hidden files, etc.). ' +
+                'Useful for getting a high-level overview of project organization. ' +
+                'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
+                'For finding specific files, use findFilesByPattern.',
+            parameters: {
+                type: 'object',
+                properties: {},
+            },
+            handler: (_, ctx) => this.getDirectoryStructure(ctx?.cancellationToken),
+        };
+    }
+
+    protected async getDirectoryStructure(cancellationToken?: CancellationToken): Promise<Record<string, unknown> | string> {
+        if (cancellationToken?.isCancellationRequested) {
+            return { error: 'Operation cancelled by user' };
+        }
+        let workspaceRoot: URI;
+        try {
+            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+        } catch (error) {
+            return { error: (error as Error).message };
+        }
+        return this.buildDirectoryStructure(workspaceRoot, cancellationToken);
+    }
+
+    protected async buildDirectoryStructure(uri: URI, cancellationToken?: CancellationToken): Promise<Record<string, unknown>> {
+        if (cancellationToken?.isCancellationRequested) {
+            return { error: 'Operation cancelled by user' };
+        }
+        const stat = await this.fileService.resolve(uri);
+        const result: Record<string, unknown> = {};
+        if (stat && stat.isDirectory && stat.children) {
+            for (const child of stat.children) {
+                if (cancellationToken?.isCancellationRequested) {
+                    return { error: 'Operation cancelled by user' };
+                }
+                if (!child.isDirectory || (await this.workspaceScope.shouldExclude(child))) {
+                    continue;
+                }
+                const dirName = child.resource.path.base;
+                result[dirName] = await this.buildDirectoryStructure(child.resource, cancellationToken);
+            }
+        }
+        return result;
+    }
+}
+
+// ── FileContentFunction ─────────────────────────────────────────────────
+
+@injectable()
+export class FileContentFunction implements ToolProvider {
+    static ID = FILE_CONTENT_FUNCTION_ID;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
+    @inject(MonacoWorkspace)
+    protected readonly monacoWorkspace: MonacoWorkspace;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    getTool(): ToolRequest {
+        return {
+            id: FileContentFunction.ID,
+            name: FileContentFunction.ID,
+            displayName: 'Read File',
+            description:
+                'Returns the content of a specified file within the workspace as a raw string. ' +
+                'The file path must be provided relative to the workspace root. Only files within ' +
+                'workspace boundaries are accessible; attempting to access files outside the workspace will return an error. ' +
+                'If the file is currently open in an editor with unsaved changes, returns the editor\'s current content (not the saved file on disk). ' +
+                'Binary files may not be readable and will return an error. ' +
+                'Use this tool to read file contents before making any edits with replacement functions. ' +
+                'Do NOT use this for files you haven\'t located yet - use findFilesByPattern first. ' +
+                'Files exceeding the configured size limit will return an error. ' +
+                'It is recommended to read the whole file by not providing offset or limit parameters, ' +
+                'unless you expect it to be very large. ' +
+                'If the size limit is hit, do NOT attempt to read the full file in chunks using offset and limit \u2014 ' +
+                'this wastes context window.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    file: {
+                        type: 'string',
+                        description:
+                            'The relative path to the target file within the workspace (e.g., "src/index.ts", "package.json"). ' +
+                            'Must be relative to the workspace root. Absolute paths and paths outside the workspace will result in an error.',
+                    },
+                    offset: {
+                        type: 'number',
+                        description: 'Zero-based line offset to start reading from (default: 0). ' +
+                            'Use together with limit to page through large files.',
+                    },
+                    limit: {
+                        type: 'number',
+                        description: 'Maximum number of lines to return. Defaults to the rest of the file.',
+                    },
+                },
+                required: ['file'],
+            },
+            handler: (argString, ctx) => {
+                const { file, offset, limit } = this.parseArg(argString);
+                return this.getFileContent(file, ctx?.cancellationToken, offset, limit);
+            },
+            providerName: undefined,
+            getArgumentsShortLabel: (args: string) => {
+                try {
+                    const parsed = JSON.parse(args);
+                    if (parsed && typeof parsed === 'object' && 'file' in parsed) {
+                        const hasMore = 'offset' in parsed || 'limit' in parsed;
+                        return { label: String(parsed.file), hasMore };
+                    }
+                } catch {
+                    // ignore parse errors
+                }
+                return undefined;
+            },
+        };
+    }
+
+    protected parseArg(argString: string): { file: string; offset?: number; limit?: number } {
+        const result = JSON.parse(argString);
+        return { file: result.file, offset: result.offset, limit: result.limit };
+    }
+
+    async getFileContent(file: string, cancellationToken?: CancellationToken, offset?: number, limit?: number): Promise<string> {
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+        if (offset !== undefined && (!Number.isInteger(offset) || offset < 0)) {
+            return JSON.stringify({ error: 'offset must be a non-negative integer.' });
+        }
+        if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
+            return JSON.stringify({ error: 'limit must be a positive integer.' });
+        }
+        let targetUri: URI;
+        try {
+            const workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+            targetUri = workspaceRoot.resolve(file);
+            this.workspaceScope.ensureWithinWorkspace(targetUri, workspaceRoot);
+        } catch (error) {
+            return JSON.stringify({ error: (error as Error).message });
+        }
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+        const openEditorValue = this.monacoWorkspace.getTextDocument(targetUri.toString())?.getText();
+        const maxSizeKB = this.preferences.get<number>(FILE_CONTENT_MAX_SIZE_KB_PREF, 256);
+        const isEditorOpen = openEditorValue !== undefined;
+        const isPaginated = offset !== undefined || limit !== undefined;
+
+        if (isEditorOpen) {
+            return this.handleEditorContent(openEditorValue, maxSizeKB, offset, limit);
+        } else if (isPaginated) {
+            return this.readStreamedSlice(targetUri, maxSizeKB, offset, limit);
+        } else {
+            return this.handleFullDiskRead(targetUri, maxSizeKB);
+        }
+    }
+
+    protected handleEditorContent(content: string, maxSizeKB: number, offset?: number, limit?: number): string {
+        if (offset === undefined && limit === undefined) {
+            const sizeKB = this.sizeInKB(content);
+            if (sizeKB > maxSizeKB) {
+                return this.buildFileSizeLimitError(sizeKB, maxSizeKB);
+            }
+            return content;
+        }
+        const lines = content.split('\n');
+        const startOffset = offset ?? 0;
+        const sliced = limit !== undefined ? lines.slice(startOffset, startOffset + limit) : lines.slice(startOffset);
+        const result = sliced.join('\n');
+        const resultSizeKB = this.sizeInKB(result);
+        if (resultSizeKB > maxSizeKB) {
+            return this.buildSliceSizeLimitError(resultSizeKB, maxSizeKB);
+        }
+        const startLine = startOffset + 1;
+        const endLine = startOffset + sliced.length;
+        const header = `[Lines ${startLine}\u2013${endLine} of ${lines.length} total. Use offset and limit to read other ranges.]`;
+        return `${header}\n${result}`;
+    }
+
+    protected async handleFullDiskRead(targetUri: URI, maxSizeKB: number): Promise<string> {
+        try {
+            const stat = await this.fileService.resolve(targetUri);
+            if (stat.size !== undefined) {
+                const statSizeKB = Math.round(stat.size / 1024);
+                if (statSizeKB > maxSizeKB) {
+                    return this.buildFileSizeLimitError(statSizeKB, maxSizeKB);
+                }
+            } else {
+                return this.readStreamedSlice(targetUri, maxSizeKB);
+            }
+            const rawContent = (await this.fileService.read(targetUri)).value;
+            const sizeKB = this.sizeInKB(rawContent);
+            if (sizeKB > maxSizeKB) {
+                return this.buildFileSizeLimitError(sizeKB, maxSizeKB);
+            }
+            return rawContent;
+        } catch (error) {
+            if (error instanceof FileOperationError) {
+                if (error.fileOperationResult === FileOperationResult.FILE_TOO_LARGE ||
+                    error.fileOperationResult === FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT) {
+                    return this.buildFileSizeLimitError(undefined, maxSizeKB);
+                }
+            }
+            return JSON.stringify({ error: 'File not found' });
+        }
+    }
+
+    protected async readStreamedSlice(targetUri: URI, maxSizeKB: number, startLine?: number, limit?: number): Promise<string> {
+        const isPaginated = startLine !== undefined || limit !== undefined;
+        const effectiveStartLine = startLine ?? 0;
+        let streamValue;
+        try {
+            streamValue = (await this.fileService.readStream(targetUri, { limits: { size: Number.MAX_SAFE_INTEGER } })).value;
+        } catch (e) {
+            if (e instanceof FileOperationError &&
+                (e.fileOperationResult === FileOperationResult.FILE_TOO_LARGE ||
+                    e.fileOperationResult === FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT)) {
+                return JSON.stringify({
+                    error: 'File exceeds the configured ' + maxSizeKB + 'KB size limit. ' +
+                        'Use the \'offset\' (0-based) and \'limit\' parameters to read specific line ranges.',
+                    maxSizeKB
+                });
+            }
+            return JSON.stringify({ error: 'File not found' });
+        }
+        return new Promise<string>(resolve => {
+            let pending = '';
+            let lineIndex = 0;
+            const sliceLines: string[] = [];
+            streamValue.on('data', (chunk: string) => {
+                const parts = (pending + chunk).split('\n');
+                pending = parts.pop()!;
+                for (const line of parts) {
+                    if (lineIndex >= effectiveStartLine && (limit === undefined || lineIndex < effectiveStartLine + limit)) {
+                        sliceLines.push(line);
+                    }
+                    lineIndex++;
+                }
+            });
+            streamValue.on('end', () => {
+                if (pending.length > 0) {
+                    if (lineIndex >= effectiveStartLine && (limit === undefined || lineIndex < effectiveStartLine + limit)) {
+                        sliceLines.push(pending);
+                    }
+                    lineIndex++;
+                }
+                const result = sliceLines.join('\n');
+                const resultSizeKB = this.sizeInKB(result);
+                if (resultSizeKB > maxSizeKB) {
+                    const sizeError = isPaginated
+                        ? this.buildSliceSizeLimitError(resultSizeKB, maxSizeKB)
+                        : this.buildFileSizeLimitError(resultSizeKB, maxSizeKB);
+                    resolve(sizeError);
+                    return;
+                }
+                if (isPaginated) {
+                    const header = `[Lines ${effectiveStartLine + 1}\u2013${effectiveStartLine + sliceLines.length} of ${lineIndex} total. ` +
+                        'Use offset and limit to read other ranges.]';
+                    resolve(`${header}\n${result}`);
+                } else {
+                    resolve(result);
+                }
+            });
+            streamValue.on('error', () => resolve(JSON.stringify({ error: 'File not found' })));
+        });
+    }
+
+    protected sizeInKB(content: string): number {
+        return Math.round(Buffer.byteLength(content, 'utf8') / 1024);
+    }
+
+    protected buildFileSizeLimitError(sizeKB: number | undefined, maxSizeKB: number): string {
+        const sizeInfo = sizeKB !== undefined ? ` (${sizeKB}KB)` : '';
+        const result: Record<string, unknown> = {
+            error: `File exceeds the configured ${maxSizeKB}KB size limit${sizeInfo}. ` +
+                'Use the \'offset\' (0-based) and \'limit\' parameters to read specific line ranges.',
+            maxSizeKB
+        };
+        if (sizeKB !== undefined) {
+            result.sizeKB = sizeKB;
+        }
+        return JSON.stringify(result);
+    }
+
+    protected buildSliceSizeLimitError(resultSizeKB: number, maxSizeKB: number): string {
+        return JSON.stringify({
+            error: 'Requested range exceeds the configured ' + maxSizeKB + 'KB size limit (' + resultSizeKB + 'KB). ' +
+                'Use a smaller limit to read fewer lines at a time.',
+            resultSizeKB,
+            maxSizeKB
+        });
+    }
+}
+
+// ── GetWorkspaceFileList ────────────────────────────────────────────────
+
+@injectable()
+export class GetWorkspaceFileList implements ToolProvider {
+    static ID = GET_WORKSPACE_FILE_LIST_FUNCTION_ID;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
+    getTool(): ToolRequest {
+        return {
+            id: GetWorkspaceFileList.ID,
+            name: GetWorkspaceFileList.ID,
+            displayName: 'List Files',
+            parameters: {
+                type: 'object',
+                properties: {
+                    path: {
+                        type: 'string',
+                        description:
+                            'Relative path to a directory within the workspace (e.g., "src", "src/components"). ' +
+                            'Use "" or "." to list the workspace root. Paths outside the workspace will result in an error.',
+                    },
+                },
+                required: ['path'],
+            },
+            description:
+                'Lists files and directories within a specified workspace directory. ' +
+                'Returns an array of names where directories are suffixed with "/" (e.g., ["src/", "package.json", "README.md"]). ' +
+                'Use this to explore directory structure step by step. ' +
+                'For finding specific files by pattern, use findFilesByPattern instead.',
+            handler: (argString, ctx) => {
+                const args = JSON.parse(argString);
+                return this.getProjectFileList(args.path, ctx?.cancellationToken);
+            },
+        };
+    }
+
+    async getProjectFileList(path?: string, cancellationToken?: CancellationToken): Promise<string | string[]> {
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+        let workspaceRoot: URI;
+        try {
+            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+        } catch (error) {
+            return JSON.stringify({ error: (error as Error).message });
+        }
+        const targetUri = path ? workspaceRoot.resolve(path) : workspaceRoot;
+        this.workspaceScope.ensureWithinWorkspace(targetUri, workspaceRoot);
+        try {
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const stat = await this.fileService.resolve(targetUri);
+            if (!stat || !stat.isDirectory) {
+                return JSON.stringify({ error: 'Directory not found' });
+            }
+            return await this.listFilesDirectly(targetUri, cancellationToken);
+        } catch {
+            return JSON.stringify({ error: 'Directory not found' });
+        }
+    }
+
+    protected async listFilesDirectly(uri: URI, cancellationToken?: CancellationToken): Promise<string | string[]> {
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+        const stat = await this.fileService.resolve(uri);
+        const result: string[] = [];
+        if (stat && stat.isDirectory) {
+            if (await this.workspaceScope.shouldExclude(stat)) {
+                return result;
+            }
+            const children = await this.fileService.resolve(uri);
+            if (children.children) {
+                for (const child of children.children) {
+                    if (cancellationToken?.isCancellationRequested) {
+                        return JSON.stringify({ error: 'Operation cancelled by user' });
+                    }
+                    if (await this.workspaceScope.shouldExclude(child)) {
+                        continue;
+                    }
+                    const itemName = child.resource.path.base;
+                    result.push(child.isDirectory ? `${itemName}/` : itemName);
+                }
+            }
+        }
+        return result;
+    }
+}
+
+// ── FindFilesByPattern ──────────────────────────────────────────────────
+
+@injectable()
+export class FindFilesByPattern implements ToolProvider {
+    static ID = FIND_FILES_BY_PATTERN_FUNCTION_ID;
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    getTool(): ToolRequest {
+        return {
+            id: FindFilesByPattern.ID,
+            name: FindFilesByPattern.ID,
+            displayName: 'Find Files',
+            description:
+                'Find files in the workspace that match a given glob pattern. ' +
+                'This function allows efficient discovery of files using patterns like \'**/*.ts\' for all TypeScript files or ' +
+                '\'src/**/*.js\' for JavaScript files in the src directory. The function respects gitignore patterns and user exclusions, ' +
+                'returns relative paths from the workspace root, and limits results to 200 files maximum. ' +
+                'Performance note: This traverses directories recursively which may be slow in large workspaces. ' +
+                'For better performance, use specific subdirectory patterns (e.g., \'src/**/*.ts\' instead of \'**/*.ts\'). ' +
+                'Use this to find files by name/extension.',
+            parameters: {
+                type: 'object',
+                properties: {
+                    pattern: {
+                        type: 'string',
+                        description:
+                            'Glob pattern to match files against. ' +
+                            'Examples: \'**/*.ts\' (all TypeScript files), \'src/**/*.js\' (JS files in src), ' +
+                            '\'**/*.{js,ts}\' (JS or TS files), \'**/test/**/*.spec.ts\' (test files). ' +
+                            'Use specific subdirectory prefixes for better performance.',
+                    },
+                    exclude: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            'Optional glob patterns to exclude. ' +
+                            'Examples: [\'**/*.spec.ts\', \'**/node_modules/**\']. ' +
+                            'Common exclusions (node_modules, .git) are applied automatically via gitignore.',
+                    },
+                },
+                required: ['pattern'],
+            },
+            handler: (argString, ctx) => {
+                const args = JSON.parse(argString);
+                return this.findFiles(args.pattern, args.exclude, ctx?.cancellationToken);
+            },
+            providerName: undefined,
+            getArgumentsShortLabel: (args: string) => {
+                try {
+                    const parsed = JSON.parse(args);
+                    if (parsed && typeof parsed === 'object' && 'pattern' in parsed) {
+                        const keys = Object.keys(parsed);
+                        return { label: String(parsed.pattern), hasMore: keys.length > 1 };
+                    }
+                } catch {
+                    // ignore parse errors
+                }
+                return undefined;
+            },
+        };
+    }
+
+    protected async findFiles(pattern: string, excludePatterns?: string[], cancellationToken?: CancellationToken): Promise<string> {
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+        let workspaceRoot: URI;
+        try {
+            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+        } catch (error) {
+            return JSON.stringify({ error: (error as Error).message });
+        }
+        try {
+            const ignorePatterns = await this.buildIgnorePatterns(workspaceRoot);
+            const allExcludes = [...ignorePatterns];
+            if (excludePatterns && excludePatterns.length > 0) {
+                allExcludes.push(...excludePatterns);
+            }
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const patternMatcher = new Minimatch(pattern, { dot: false });
+            const excludeMatchers = allExcludes.map(ep => new Minimatch(ep, { dot: true }));
+            const files: string[] = [];
+            const maxResults = 200;
+            await this.traverseDirectory(workspaceRoot, workspaceRoot, patternMatcher, excludeMatchers, files, maxResults, cancellationToken);
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const result: Record<string, unknown> = {
+                files: files.slice(0, maxResults),
+            };
+            if (files.length > maxResults) {
+                result.totalFound = files.length;
+                result.truncated = true;
+            }
+            return JSON.stringify(result);
+        } catch (error) {
+            return JSON.stringify({ error: `Failed to find files: ${(error as Error).message}` });
+        }
+    }
+
+    protected async buildIgnorePatterns(workspaceRoot: URI): Promise<string[]> {
+        const patterns: string[] = [];
+        const userExcludePatterns = this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, []);
+        patterns.push(...userExcludePatterns);
+        const shouldConsiderGitIgnore = this.preferences.get<boolean>(CONSIDER_GITIGNORE_PREF, false);
+        if (shouldConsiderGitIgnore) {
+            try {
+                const gitignoreUri = workspaceRoot.resolve('.gitignore');
+                const gitignoreContent = await this.fileService.read(gitignoreUri);
+                const gitignoreLines = gitignoreContent.value
+                    .split('\n')
+                    .map(line => line.trim())
+                    .filter(line => line && !line.startsWith('#'));
+                patterns.push(...gitignoreLines);
+            } catch {
+                // Gitignore file doesn't exist or can't be read
+            }
+        }
+        return patterns;
+    }
+
+    protected async traverseDirectory(
+        currentUri: URI,
+        workspaceRoot: URI,
+        patternMatcher: Minimatch,
+        excludeMatchers: Minimatch[],
+        results: string[],
+        maxResults: number,
+        cancellationToken?: CancellationToken,
+    ): Promise<void> {
+        if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
+            return;
+        }
+        try {
+            const stat = await this.fileService.resolve(currentUri);
+            if (!stat || !stat.isDirectory || !stat.children) {
+                return;
+            }
+            for (const child of stat.children) {
+                if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
+                    break;
+                }
+                const relativePath = workspaceRoot.relative(child.resource)?.toString();
+                if (!relativePath) {
+                    continue;
+                }
+                const shouldExclude =
+                    excludeMatchers.some(matcher => matcher.match(relativePath)) ||
+                    (await this.workspaceScope.shouldExclude(child));
+                if (shouldExclude) {
+                    continue;
+                }
+                if (child.isDirectory) {
+                    await this.traverseDirectory(child.resource, workspaceRoot, patternMatcher, excludeMatchers, results, maxResults, cancellationToken);
+                } else if (patternMatcher.match(relativePath)) {
+                    results.push(relativePath);
+                }
+            }
+        } catch {
+            // If we can't access a directory, skip it
+        }
+    }
+}

--- a/packages/cooklang-ai/src/browser/file-tools/workspace-preferences.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/workspace-preferences.ts
@@ -1,0 +1,60 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
+
+export const CONSIDER_GITIGNORE_PREF = 'ai-features.workspaceFunctions.considerGitIgnore';
+export const USER_EXCLUDE_PATTERN_PREF = 'ai-features.workspaceFunctions.userExcludes';
+export const FILE_CONTENT_MAX_SIZE_KB_PREF = 'ai-features.workspaceFunctions.fileContentMaxSizeKB';
+
+export const WorkspacePreferencesSchema: PreferenceSchema = {
+    properties: {
+        [CONSIDER_GITIGNORE_PREF]: {
+            type: 'boolean',
+            title: nls.localize('theia/ai/workspace/considerGitignore/title', 'Consider .gitignore'),
+            description: nls.localize(
+                'theia/ai/workspace/considerGitignore/description',
+                'If enabled, excludes files/folders specified in a global .gitignore file (expected location is the workspace root).'
+            ),
+            default: true
+        },
+        [USER_EXCLUDE_PATTERN_PREF]: {
+            type: 'array',
+            title: nls.localize('theia/ai/workspace/excludedPattern/title', 'Excluded File Patterns'),
+            description: nls.localize(
+                'theia/ai/workspace/excludedPattern/description',
+                'List of patterns (glob or regex) for files/folders to exclude.'
+            ),
+            default: ['node_modules', 'lib'],
+            items: {
+                type: 'string'
+            }
+        },
+        [FILE_CONTENT_MAX_SIZE_KB_PREF]: {
+            type: 'number',
+            title: nls.localize('theia/ai/workspace/fileContentMaxSizeKB/title', 'File Content Max Size (KB)'),
+            description: nls.localize(
+                'theia/ai/workspace/fileContentMaxSizeKB/description',
+                'Maximum size in kilobytes of the content returned by the getFileContent tool. ' +
+                'When reading a full file (no offset/limit), files exceeding this limit return an error. ' +
+                'When using offset and limit, only the requested range is checked against this limit.'
+            ),
+            default: 256,
+            minimum: 1
+        }
+    }
+};

--- a/packages/cooklang-ai/tsconfig.json
+++ b/packages/cooklang-ai/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../cooklang-account" },
     { "path": "../core" },
     { "path": "../filesystem" },
+    { "path": "../monaco" },
     { "path": "../workspace" }
   ]
 }

--- a/packages/cooklang/src/browser/menu-preview-contribution.ts
+++ b/packages/cooklang/src/browser/menu-preview-contribution.ts
@@ -66,7 +66,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
     readonly label = 'Cooklang: Menu Preview';
 
     canHandle(uri: URI): number {
-        if (uri.path.ext === '.menu') {
+        if (uri.scheme === 'file' && uri.path.ext === '.menu') {
             return 200;
         }
         return 0;

--- a/packages/cooklang/src/browser/recipe-preview-contribution.ts
+++ b/packages/cooklang/src/browser/recipe-preview-contribution.ts
@@ -69,7 +69,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
     readonly label = 'Cooklang: Recipe Preview';
 
     canHandle(uri: URI): number {
-        if (uri.path.ext === '.cook' && this.preferences['cooklang.openInPreviewMode']) {
+        if (uri.scheme === 'file' && uri.path.ext === '.cook' && this.preferences['cooklang.openInPreviewMode']) {
             return 200;
         }
         return 0;


### PR DESCRIPTION
…isplayName

- Replace 4 simplistic file tools (list, read, write, edit) with production-grade equivalents reconstructed from @theia/ai-ide: GetWorkspaceFileList, FileContentFunction, SuggestFileContent, SuggestFileReplacements
- Add bonus tools: GetWorkspaceDirectoryStructure, FindFilesByPattern, ClearFileChanges, GetProposedFileState
- Use suggest (user review) instead of write (auto-apply) for file changes
- Add displayName field to ToolRequest for human-readable labels in chat UI
- Rename server tool IDs from snake_case to camelCase for consistency
- Fix preview contributions to skip non-file URIs (changeset in-memory URIs)