### PR TITLE
feat(shopping-list): migrate to .shopping-list + .shopping-checked format

### DIFF
--- a/docs/superpowers/plans/2026-04-10-shopping-list-format-migration.md
+++ b/docs/superpowers/plans/2026-04-10-shopping-list-format-migration.md
@@ -1,0 +1,1946 @@
+# Shopping List Format Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the legacy `.shopping_list.txt` shopping list with the new cooklang `.shopping-list` format and add persistent checked-ingredient state via `.shopping-checked`, matching [cookcli PR #318](https://github.com/cooklang/cookcli/pull/318) feature set.
+
+**Architecture:** Thin stateless Rust NAPI helpers (`parse_shopping_list`, `write_shopping_list`, `parse_checked`, `write_check_entry`, `checked_set`, `compact_checked`) exposed via the existing Theia RPC service. The TypeScript `ShoppingListService` owns all file I/O via Theia `FileService` and orchestrates the helpers.
+
+**Tech Stack:** Rust (NAPI-RS, `cooklang` 0.18.5 with `shopping_list` feature), TypeScript, Theia `FileService`, InversifyJS, React.
+
+**Reference:** `docs/superpowers/specs/2026-04-10-shopping-list-format-migration-design.md`
+
+**Scope notes:**
+- No migration from `.shopping_list.txt` — existing users start fresh.
+- No file locking (single-user editor).
+- Testing: Rust via `cargo test`; TypeScript via Mocha + Chai (pattern already used in `packages/ai-chat-ui/src/browser/**/*.spec.ts`).
+
+---
+
+## File map
+
+**Created:**
+- `packages/cooklang-native/src/shopping_list.rs` — pure Rust helpers + unit tests (new module)
+- `packages/cooklang/src/browser/shopping-list-service.spec.ts` — TS unit tests
+
+**Modified:**
+- `packages/cooklang-native/Cargo.toml` — bump cooklang crate
+- `packages/cooklang-native/src/lib.rs` — new NAPI wrappers, wire module, audit `generate_shopping_list` for 0.18 API
+- `packages/cooklang-native/index.d.ts`, `index.js` — regenerated bindings
+- `packages/cooklang/src/common/shopping-list-types.ts` — replace types
+- `packages/cooklang/src/common/cooklang-language-service.ts` — add 6 RPC methods
+- `packages/cooklang/src/node/cooklang-language-service-impl.ts` — add 6 RPC implementations
+- `packages/cooklang/src/browser/shopping-list-service.ts` — rewrite
+- `packages/cooklang/src/browser/shopping-list-widget.tsx` — hook async check/uncheck
+- `packages/cooklang/src/browser/shopping-list-components.tsx` — menu row rendering, new prop shape
+- `packages/cooklang/src/browser/shopping-list-contribution.ts` — new `addMenuToShoppingList` command
+
+---
+
+## Task 1: Upgrade `cooklang` crate to 0.18.5 and verify existing code still compiles
+
+**Files:**
+- Modify: `packages/cooklang-native/Cargo.toml`
+- Modify (as needed): `packages/cooklang-native/src/lib.rs` (existing `generate_shopping_list` for API changes)
+
+- [ ] **Step 1: Update Cargo.toml**
+
+Change line `cooklang = { version = "0.17", features = ["pantry"] }` to:
+
+```toml
+cooklang = { version = "0.18.5", features = ["aisle", "pantry", "shopping_list"] }
+```
+
+- [ ] **Step 2: Attempt to compile**
+
+```
+cd packages/cooklang-native && cargo build --release 2>&1 | tee /tmp/cooklang-build.log
+```
+
+Expected: may fail with API changes in 0.17→0.18.5. Common breakages:
+- `CooklangParser::new(Extensions, Converter)` signature
+- `IngredientList::add_recipe(&recipe, converter, bool)` — may have new `include_sub_references` arg
+- `aisle::parse_lenient` / `pantry::parse_lenient` return types
+- `recipe.scale(factor, converter)` signature
+
+- [ ] **Step 3: Fix any signature breaks in `generate_shopping_list`**
+
+Read error messages and update call sites in `packages/cooklang-native/src/lib.rs` lines 222-300. Do the MINIMUM change to restore the original behavior. If a new arg is required (e.g. "include sub-references"), pass `true` or `None` (permissive default) to preserve current behavior.
+
+- [ ] **Step 4: Check cooklang-language-server sibling compatibility**
+
+```
+grep -n "cooklang" ../../../cooklang-language-server/Cargo.toml
+```
+
+If that crate pins `cooklang = "0.17"`, bump it to `0.18.5` in the sibling repo (same features it previously used). Rebuild:
+
+```
+cd packages/cooklang-native && cargo build --release
+```
+
+If a breaking API appears in `cooklang-language-server` itself, report it and pause — that's an upstream decision the user must make.
+
+- [ ] **Step 5: Verify build succeeds**
+
+Run: `cd packages/cooklang-native && cargo build --release`
+Expected: clean build, `target/release/libcooklang_native.*` produced.
+
+- [ ] **Step 6: Run existing tests (if any) and manual smoke test via editor**
+
+Run: `cd packages/cooklang-native && cargo test`
+Expected: PASS (or no tests).
+
+Then rebuild NAPI bindings and the electron app; open an existing `.cook` file in the editor — syntax highlighting + hover still works.
+
+```
+cd packages/cooklang-native && npm run build
+cd ../../examples/electron && npm run bundle
+```
+
+- [ ] **Step 7: Commit**
+
+```
+git add packages/cooklang-native/Cargo.toml packages/cooklang-native/Cargo.lock packages/cooklang-native/src/lib.rs
+git commit -m "chore: bump cooklang crate to 0.18.5 and enable shopping_list feature"
+```
+
+---
+
+## Task 2: Add Rust helpers for `.shopping-list` parse/write with unit tests
+
+**Files:**
+- Create: `packages/cooklang-native/src/shopping_list.rs`
+- Modify: `packages/cooklang-native/src/lib.rs` (add `mod shopping_list;`)
+
+- [ ] **Step 1: Create the module with a failing test**
+
+Create `packages/cooklang-native/src/shopping_list.rs`:
+
+```rust
+//! Pure helpers around cooklang::shopping_list. No NAPI, no filesystem.
+
+use cooklang::shopping_list::{self, ShoppingList};
+
+/// Parse `.shopping-list` text → `ShoppingList`.
+pub fn parse_list(text: &str) -> Result<ShoppingList, String> {
+    shopping_list::parse(text).map_err(|e| e.to_string())
+}
+
+/// Serialize `ShoppingList` → `.shopping-list` text.
+pub fn write_list(list: &ShoppingList) -> Result<String, String> {
+    let mut buf = Vec::new();
+    shopping_list::write(list, &mut buf).map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_single_recipe() {
+        let text = "pasta\n";
+        let list = parse_list(text).expect("parse");
+        assert_eq!(list.items.len(), 1);
+        let out = write_list(&list).expect("write");
+        assert_eq!(out.trim(), "pasta");
+    }
+
+    #[test]
+    fn round_trips_recipe_with_multiplier() {
+        let text = "pasta *2\n";
+        let list = parse_list(text).expect("parse");
+        let out = write_list(&list).expect("write");
+        // Multiplier should round-trip
+        assert!(out.contains("pasta"));
+        assert!(out.contains("2"));
+    }
+
+    #[test]
+    fn round_trips_nested_children() {
+        // Menu-style entry with nested children (exact syntax per cooklang-rs 0.18.5)
+        let text = "menu/weekday\n  pasta\n  salad\n";
+        let list = parse_list(text).expect("parse");
+        assert_eq!(list.items.len(), 1);
+        // Reparse what we wrote and confirm structure preserved
+        let out = write_list(&list).expect("write");
+        let reparsed = parse_list(&out).expect("reparse");
+        assert_eq!(reparsed.items.len(), 1);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_list() {
+        let list = parse_list("").expect("parse");
+        assert!(list.items.is_empty());
+    }
+}
+```
+
+> Note: the exact multiplier / nested-child syntax in `.shopping-list` files is defined by cooklang-rs 0.18.5. If the "pasta *2" or indent-based nested syntax differs, adjust the test inputs to match what `write` emits — run the `write` side first on a hand-constructed `ShoppingList` to see the canonical format, then use that as the parse test input.
+
+- [ ] **Step 2: Wire the module**
+
+Modify `packages/cooklang-native/src/lib.rs` — add near top (after other `use` statements):
+
+```rust
+mod shopping_list;
+```
+
+- [ ] **Step 3: Run the tests and verify they fail meaningfully first**
+
+Run: `cd packages/cooklang-native && cargo test --lib shopping_list::tests`
+
+If any test's assertion about exact text output is off because the writer uses different syntax, adjust the test to match. The goal is behavioral correctness (round-trip preserves structure), not string-exact matches beyond what the format guarantees.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/cooklang-native && cargo test --lib shopping_list`
+Expected: 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/cooklang-native/src/shopping_list.rs packages/cooklang-native/src/lib.rs
+git commit -m "feat(cooklang-native): add parse_list/write_list helpers for .shopping-list"
+```
+
+---
+
+## Task 3: Add Rust helpers for `.shopping-checked` parse/write/append with unit tests
+
+**Files:**
+- Modify: `packages/cooklang-native/src/shopping_list.rs`
+
+- [ ] **Step 1: Extend the module with failing tests**
+
+Append to `packages/cooklang-native/src/shopping_list.rs`:
+
+```rust
+use cooklang::shopping_list::CheckEntry;
+use std::collections::HashSet;
+
+/// Parse `.shopping-checked` text → list of log entries.
+pub fn parse_checked_log(text: &str) -> Vec<CheckEntry> {
+    shopping_list::parse_checked(text)
+}
+
+/// Serialize a single check entry to the line form used in `.shopping-checked`.
+pub fn write_checked_entry(entry: &CheckEntry) -> Result<String, String> {
+    let mut buf = Vec::new();
+    shopping_list::write_check_entry(entry, &mut buf).map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+/// Derive the set of currently-checked ingredient names (lowercased) from a log.
+pub fn checked_set_from_log(entries: &[CheckEntry]) -> HashSet<String> {
+    shopping_list::checked_set(entries)
+}
+
+#[cfg(test)]
+mod checked_tests {
+    use super::*;
+
+    #[test]
+    fn last_write_wins_for_same_ingredient() {
+        let log_text = "+ flour\n- flour\n+ flour\n";
+        let entries = parse_checked_log(log_text);
+        let set = checked_set_from_log(&entries);
+        assert!(set.contains("flour"));
+
+        let log_text = "+ flour\n- flour\n";
+        let entries = parse_checked_log(log_text);
+        let set = checked_set_from_log(&entries);
+        assert!(!set.contains("flour"));
+    }
+
+    #[test]
+    fn entry_write_produces_parseable_line() {
+        let entry = CheckEntry::Checked("flour".into());
+        let line = write_checked_entry(&entry).unwrap();
+        // Should round-trip through parse_checked
+        let parsed = parse_checked_log(&line);
+        assert_eq!(parsed.len(), 1);
+        let set = checked_set_from_log(&parsed);
+        assert!(set.contains("flour"));
+    }
+
+    #[test]
+    fn checked_set_is_case_insensitive_lowercase() {
+        // cooklang-rs normalizes to lowercase per cookcli PR #318 comments
+        let entries = parse_checked_log("+ Flour\n");
+        let set = checked_set_from_log(&entries);
+        assert!(set.contains("flour"));
+    }
+
+    #[test]
+    fn empty_log_yields_empty_set() {
+        let entries = parse_checked_log("");
+        assert!(entries.is_empty());
+        assert!(checked_set_from_log(&entries).is_empty());
+    }
+}
+```
+
+> If `CheckEntry` variant names differ in cooklang-rs 0.18.5 (e.g. `Check` vs `Checked`), adjust accordingly. The docstring of `cooklang::shopping_list::CheckEntry` in the compiled crate is authoritative — run `cargo doc --open` if unsure.
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/cooklang-native && cargo test --lib shopping_list::checked_tests`
+Expected: 4 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/cooklang-native/src/shopping_list.rs
+git commit -m "feat(cooklang-native): add checked-log parse/write/set helpers"
+```
+
+---
+
+## Task 4: Add `compact_checked` helper with unit tests
+
+**Files:**
+- Modify: `packages/cooklang-native/src/shopping_list.rs`
+
+- [ ] **Step 1: Extend with failing tests**
+
+Append to `packages/cooklang-native/src/shopping_list.rs`:
+
+```rust
+/// Return a compacted log: entries whose name is in `current_ingredients`
+/// (case-insensitive) are kept, others are dropped.
+///
+/// Delegates to cooklang-rs's `compact_checked`.
+pub fn compact_checked_log<'a, I>(
+    entries: &[CheckEntry],
+    current_ingredients: I,
+) -> Vec<CheckEntry>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    shopping_list::compact_checked(entries, current_ingredients)
+}
+
+#[cfg(test)]
+mod compact_tests {
+    use super::*;
+
+    #[test]
+    fn drops_entries_for_missing_ingredients() {
+        let entries = parse_checked_log("+ flour\n+ sugar\n+ milk\n");
+        let compacted = compact_checked_log(&entries, ["flour", "sugar"]);
+        let set = checked_set_from_log(&compacted);
+        assert!(set.contains("flour"));
+        assert!(set.contains("sugar"));
+        assert!(!set.contains("milk"));
+    }
+
+    #[test]
+    fn keeps_all_when_all_ingredients_present() {
+        let entries = parse_checked_log("+ flour\n+ sugar\n");
+        let compacted = compact_checked_log(&entries, ["flour", "sugar"]);
+        assert_eq!(compacted.len(), 2);
+    }
+
+    #[test]
+    fn empty_ingredients_drops_everything() {
+        let entries = parse_checked_log("+ flour\n");
+        let compacted = compact_checked_log(&entries, Vec::<&str>::new());
+        assert!(compacted.is_empty());
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd packages/cooklang-native && cargo test --lib shopping_list`
+Expected: all 11 tests across the 3 `mod` blocks PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/cooklang-native/src/shopping_list.rs
+git commit -m "feat(cooklang-native): add compact_checked helper"
+```
+
+---
+
+## Task 5: Expose NAPI wrappers for all shopping-list helpers
+
+**Files:**
+- Modify: `packages/cooklang-native/src/lib.rs`
+- Regenerated: `packages/cooklang-native/index.d.ts`, `packages/cooklang-native/index.js`
+
+- [ ] **Step 1: Add NAPI functions at the end of `lib.rs`**
+
+Append to `packages/cooklang-native/src/lib.rs`:
+
+```rust
+// ── Shopping list format (NAPI wrappers) ─────────────────────────────────────
+// Thin JSON-bridge wrappers around helpers in `shopping_list` module.
+// All functions are stateless; file I/O is performed by the TypeScript caller.
+
+#[napi(js_name = "parseShoppingList")]
+pub fn napi_parse_shopping_list(text: String) -> napi::Result<String> {
+    let list = shopping_list::parse_list(&text)
+        .map_err(|e| napi::Error::from_reason(format!("parse_shopping_list: {e}")))?;
+    serde_json::to_string(&list)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
+#[napi(js_name = "writeShoppingList")]
+pub fn napi_write_shopping_list(json: String) -> napi::Result<String> {
+    let list: cooklang::shopping_list::ShoppingList = serde_json::from_str(&json)
+        .map_err(|e| napi::Error::from_reason(format!("writeShoppingList parse json: {e}")))?;
+    shopping_list::write_list(&list)
+        .map_err(|e| napi::Error::from_reason(format!("writeShoppingList: {e}")))
+}
+
+#[napi(js_name = "parseChecked")]
+pub fn napi_parse_checked(text: String) -> napi::Result<String> {
+    let entries = shopping_list::parse_checked_log(&text);
+    serde_json::to_string(&entries)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
+#[napi(js_name = "writeCheckEntry")]
+pub fn napi_write_check_entry(entry_json: String) -> napi::Result<String> {
+    let entry: cooklang::shopping_list::CheckEntry = serde_json::from_str(&entry_json)
+        .map_err(|e| napi::Error::from_reason(format!("writeCheckEntry parse json: {e}")))?;
+    shopping_list::write_checked_entry(&entry)
+        .map_err(|e| napi::Error::from_reason(format!("writeCheckEntry: {e}")))
+}
+
+#[napi(js_name = "checkedSet")]
+pub fn napi_checked_set(entries_json: String) -> napi::Result<Vec<String>> {
+    let entries: Vec<cooklang::shopping_list::CheckEntry> = serde_json::from_str(&entries_json)
+        .map_err(|e| napi::Error::from_reason(format!("checkedSet parse json: {e}")))?;
+    let set = shopping_list::checked_set_from_log(&entries);
+    Ok(set.into_iter().collect())
+}
+
+#[napi(js_name = "compactChecked")]
+pub fn napi_compact_checked(
+    entries_json: String,
+    current_ingredients: Vec<String>,
+) -> napi::Result<String> {
+    let entries: Vec<cooklang::shopping_list::CheckEntry> = serde_json::from_str(&entries_json)
+        .map_err(|e| napi::Error::from_reason(format!("compactChecked parse json: {e}")))?;
+    let refs: Vec<&str> = current_ingredients.iter().map(|s| s.as_str()).collect();
+    let compacted = shopping_list::compact_checked_log(&entries, refs);
+    serde_json::to_string(&compacted)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+```
+
+> Confirm that `cooklang::shopping_list::{ShoppingList, CheckEntry}` implement `Serialize` + `Deserialize`. If they do not (the upstream crate may only expose the parser / writer, not serde), fall back to: define our own DTO types in `shopping_list.rs` that mirror the public fields and a `From<ShoppingList>` / `Into<ShoppingList>` pair, serialize those instead. The TS side sees the DTO shape either way.
+
+- [ ] **Step 2: Build NAPI bindings**
+
+```
+cd packages/cooklang-native && npm run build
+```
+
+Expected: regenerates `index.d.ts` and `index.js` with new exported functions. Verify by:
+
+```
+grep -n "parseShoppingList\|writeShoppingList\|parseChecked\|writeCheckEntry\|checkedSet\|compactChecked" packages/cooklang-native/index.d.ts
+```
+
+Expected: 6 matches.
+
+- [ ] **Step 3: Quick node-level smoke test**
+
+Run:
+
+```
+cd packages/cooklang-native && node -e "const n = require('./'); console.log(n.parseShoppingList('pasta\n'))"
+```
+
+Expected: prints JSON like `{"items":[{"type":"recipe","path":"pasta","multiplier":null,"children":[]}]}` (exact field names per serde output — may differ).
+
+**Note the exact shape output here — it determines the TypeScript interface in Task 7.**
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/cooklang-native/src/lib.rs packages/cooklang-native/index.d.ts packages/cooklang-native/index.js packages/cooklang-native/cooklang-native.*.node
+git commit -m "feat(cooklang-native): expose shopping-list NAPI wrappers"
+```
+
+---
+
+## Task 6: Add RPC methods on `CooklangLanguageService`
+
+**Files:**
+- Modify: `packages/cooklang/src/common/cooklang-language-service.ts`
+- Modify: `packages/cooklang/src/node/cooklang-language-service-impl.ts`
+
+- [ ] **Step 1: Add 6 RPC method signatures to the interface**
+
+Modify `packages/cooklang/src/common/cooklang-language-service.ts`. In the `CooklangLanguageService` interface, after the existing `generateShoppingList` line, add:
+
+```ts
+    // Shopping list format (new in 2026-04)
+    parseShoppingList(text: string): Promise<string>;
+    writeShoppingList(json: string): Promise<string>;
+    parseChecked(text: string): Promise<string>;
+    writeCheckEntry(entryJson: string): Promise<string>;
+    checkedSet(entriesJson: string): Promise<string[]>;
+    compactChecked(entriesJson: string, currentIngredients: string[]): Promise<string>;
+```
+
+- [ ] **Step 2: Add implementations in the backend**
+
+Modify `packages/cooklang/src/node/cooklang-language-service-impl.ts`. After the existing `generateShoppingList` method in the class body, add:
+
+```ts
+    async parseShoppingList(text: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.parseShoppingList(text);
+    }
+
+    async writeShoppingList(json: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.writeShoppingList(json);
+    }
+
+    async parseChecked(text: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.parseChecked(text);
+    }
+
+    async writeCheckEntry(entryJson: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.writeCheckEntry(entryJson);
+    }
+
+    async checkedSet(entriesJson: string): Promise<string[]> {
+        const native = require('@theia/cooklang-native');
+        return native.checkedSet(entriesJson);
+    }
+
+    async compactChecked(entriesJson: string, currentIngredients: string[]): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.compactChecked(entriesJson, currentIngredients);
+    }
+```
+
+Unlike the existing `generateShoppingList` method which swallows errors into a default value, **these throw** on native errors — the `ShoppingListService` needs to know when a write fails.
+
+- [ ] **Step 3: Compile the package**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/cooklang/src/common/cooklang-language-service.ts packages/cooklang/src/node/cooklang-language-service-impl.ts
+git commit -m "feat(cooklang): expose shopping-list RPC methods"
+```
+
+---
+
+## Task 7: Replace TypeScript shopping-list types
+
+**Files:**
+- Modify: `packages/cooklang/src/common/shopping-list-types.ts`
+
+- [ ] **Step 1: Read the current file**
+
+```
+cat packages/cooklang/src/common/shopping-list-types.ts
+```
+
+- [ ] **Step 2: Replace the file contents**
+
+Overwrite `packages/cooklang/src/common/shopping-list-types.ts` with:
+
+```ts
+// Copyright (C) 2026 Cooklang contributors
+// SPDX-License-Identifier: MIT
+
+/**
+ * Persisted shopping list format — mirrors the JSON produced by the Rust
+ * `parseShoppingList` NAPI wrapper. This matches `cooklang::shopping_list::ShoppingList`.
+ */
+export interface ShoppingListFile {
+    items: ShoppingListRecipeItem[];
+}
+
+/**
+ * A recipe entry. A bare entry (empty `children`) represents a single recipe.
+ * An entry with children represents either a menu (children are recipes) or a
+ * recipe with selected sub-references (children are sub-recipe paths).
+ *
+ * `multiplier` is `undefined` when the `.shopping-list` serializes without an
+ * explicit multiplier (equivalent to 1).
+ */
+export interface ShoppingListRecipeItem {
+    type: 'recipe';
+    path: string;
+    multiplier?: number;
+    children: ShoppingListRecipeItem[];
+}
+
+/** Single entry in the `.shopping-checked` log. */
+export type CheckEntry =
+    | { type: 'checked'; name: string }
+    | { type: 'unchecked'; name: string };
+
+/** Aggregated shopping-list result returned by `generateShoppingList`. Unchanged. */
+export interface ShoppingListResult {
+    categories: ShoppingListCategory[];
+    other: ShoppingListCategory;
+    pantryItems: string[];
+}
+
+export interface ShoppingListCategory {
+    name: string;
+    items: ShoppingListItem[];
+}
+
+export interface ShoppingListItem {
+    name: string;
+    quantities: string;
+}
+```
+
+> If the serde JSON discovered in Task 5 Step 3 uses different field names (e.g. `multiplier` serialized as `mult`, or tag field named `kind` instead of `type`), update this interface to match. The Rust shape is authoritative.
+
+- [ ] **Step 3: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile errors in `shopping-list-service.ts`, `shopping-list-components.tsx`, `shopping-list-contribution.ts` because the old `ShoppingListRecipe` type is gone. That's fine — subsequent tasks fix those files.
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/cooklang/src/common/shopping-list-types.ts
+git commit -m "feat(cooklang): replace shopping-list types with new format"
+```
+
+---
+
+## Task 8: Rewrite `ShoppingListService` — load/save core
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.ts`
+
+- [ ] **Step 1: Replace the service with the new core**
+
+Overwrite `packages/cooklang/src/browser/shopping-list-service.ts` with:
+
+```ts
+// Copyright (C) 2026 Cooklang contributors
+// SPDX-License-Identifier: MIT
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import URI from '@theia/core/lib/common/uri';
+import { CooklangLanguageService } from '../common/cooklang-language-service';
+import {
+    ShoppingListFile,
+    ShoppingListRecipeItem,
+    CheckEntry,
+    ShoppingListResult,
+} from '../common/shopping-list-types';
+
+const LIST_FILE = '.shopping-list';
+const CHECKED_FILE = '.shopping-checked';
+
+/**
+ * Manages the shopping list using the new cooklang `.shopping-list` format
+ * plus a `.shopping-checked` append-only log.
+ *
+ * All format parse/serialize is delegated to the Rust NAPI backend via
+ * CooklangLanguageService RPC. File I/O uses Theia FileService so remote /
+ * virtual workspaces work transparently.
+ */
+@injectable()
+export class ShoppingListService implements Disposable {
+
+    @inject(CooklangLanguageService)
+    protected readonly languageService: CooklangLanguageService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected list: ShoppingListFile = { items: [] };
+    protected checkedLog: CheckEntry[] = [];
+    protected checkedSet = new Set<string>();
+    protected result: ShoppingListResult | undefined;
+    protected regenerationSeq = 0;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.onDidChangeEmitter);
+        this.workspaceService.roots.then(() => this.loadFromDisk());
+    }
+
+    // -- Public getters --
+
+    getItems(): readonly ShoppingListRecipeItem[] {
+        return this.list.items;
+    }
+
+    getResult(): ShoppingListResult | undefined {
+        return this.result;
+    }
+
+    isChecked(ingredientName: string): boolean {
+        // cooklang-rs normalizes to lowercase for the checked set
+        return this.checkedSet.has(ingredientName.toLowerCase());
+    }
+
+    getWorkspaceRootUri(): URI | undefined {
+        const roots = this.workspaceService.tryGetRoots();
+        return roots.length > 0 ? new URI(roots[0].resource.toString()) : undefined;
+    }
+
+    // -- Load / save --
+
+    protected async loadFromDisk(): Promise<void> {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+
+        // Load recipe list
+        try {
+            const content = await this.fileService.read(root.resolve(LIST_FILE));
+            const json = await this.languageService.parseShoppingList(content.value);
+            this.list = JSON.parse(json);
+        } catch {
+            this.list = { items: [] };
+        }
+
+        // Load checked log
+        try {
+            const content = await this.fileService.read(root.resolve(CHECKED_FILE));
+            const json = await this.languageService.parseChecked(content.value);
+            this.checkedLog = JSON.parse(json);
+            const set = await this.languageService.checkedSet(json);
+            this.checkedSet = new Set(set.map(s => s.toLowerCase()));
+        } catch {
+            this.checkedLog = [];
+            this.checkedSet = new Set();
+        }
+
+        if (this.list.items.length > 0) {
+            await this.regenerate();
+        } else {
+            this.onDidChangeEmitter.fire();
+        }
+    }
+
+    protected async saveList(): Promise<void> {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+        const text = await this.languageService.writeShoppingList(JSON.stringify(this.list));
+        await this.fileService.write(root.resolve(LIST_FILE), text);
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    // Stubs — implemented in subsequent tasks.
+    async regenerate(): Promise<void> { /* Task 9 */ }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: still broken — `shopping-list-widget.tsx` and `-contribution.ts` reference removed methods (`getRecipes`, `toggleChecked`, `addRecipe(path, name, scale)`, etc.). Leave those broken for now; Task 9–12 fix them.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-service.ts
+git commit -m "refactor(cooklang): ShoppingListService load/save core for new format"
+```
+
+---
+
+## Task 9: `ShoppingListService` — regenerate, add/remove/scale/clear
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.ts`
+
+- [ ] **Step 1: Add helper to flatten the list into RecipeInput[]**
+
+Inside the `ShoppingListService` class in `packages/cooklang/src/browser/shopping-list-service.ts`, replace the `regenerate` stub and add the new methods:
+
+```ts
+    /**
+     * Flattens nested items into a list of `{ path, scale }` pairs that the
+     * existing `generateShoppingList` RPC expects.
+     *
+     * Flattening rules:
+     * - A top-level item with no children contributes itself.
+     * - A top-level item with children contributes: itself (for its own
+     *   ingredients) AND each child (for expanded references / nested recipes).
+     * - Multipliers multiply down: a child under a menu scaled *2 is effectively *2.
+     */
+    protected flattenForGeneration(): Array<{ path: string; scale: number }> {
+        const out: Array<{ path: string; scale: number }> = [];
+        const walk = (item: ShoppingListRecipeItem, parentScale: number): void => {
+            const scale = (item.multiplier ?? 1) * parentScale;
+            out.push({ path: item.path, scale });
+            for (const child of item.children) {
+                walk(child, scale);
+            }
+        };
+        for (const item of this.list.items) {
+            walk(item, 1);
+        }
+        return out;
+    }
+
+    async regenerate(): Promise<void> {
+        const seq = ++this.regenerationSeq;
+
+        if (this.list.items.length === 0) {
+            this.result = undefined;
+            this.onDidChangeEmitter.fire();
+            return;
+        }
+
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+
+        const flat = this.flattenForGeneration();
+        const recipeInputs: Array<{ content: string; scale: number }> = [];
+        for (const { path, scale } of flat) {
+            try {
+                const content = await this.fileService.read(root.resolve(path));
+                recipeInputs.push({ content: content.value, scale });
+            } catch (e) {
+                console.warn(`[shopping-list] Failed to read recipe ${path}:`, e);
+            }
+        }
+        if (seq !== this.regenerationSeq) { return; }
+
+        const aisleConf = await this.readConfigFile(root, 'config/aisle.conf');
+        const pantryConf = await this.readConfigFile(root, 'config/pantry.conf');
+        if (seq !== this.regenerationSeq) { return; }
+
+        try {
+            const json = await this.languageService.generateShoppingList(
+                JSON.stringify(recipeInputs),
+                aisleConf,
+                pantryConf,
+            );
+            if (seq !== this.regenerationSeq) { return; }
+            this.result = JSON.parse(json);
+        } catch (e) {
+            console.error('[shopping-list] Failed to generate shopping list:', e);
+            this.result = undefined;
+        }
+        this.onDidChangeEmitter.fire();
+    }
+
+    async addRecipe(path: string, scale = 1, includedRefs?: string[]): Promise<void> {
+        const children: ShoppingListRecipeItem[] = includedRefs
+            ? includedRefs.map(p => ({
+                  type: 'recipe',
+                  path: p.replace(/^\.\//, ''),
+                  multiplier: undefined,
+                  children: [],
+              }))
+            : [];
+        this.list.items.push({
+            type: 'recipe',
+            path,
+            multiplier: scale === 1 ? undefined : scale,
+            children,
+        });
+        await this.saveList();
+        await this.regenerate();
+    }
+
+    async removeRecipe(index: number): Promise<void> {
+        if (index < 0 || index >= this.list.items.length) {
+            return;
+        }
+        this.list.items.splice(index, 1);
+        await this.saveList();
+        await this.regenerate();
+        // Compact the checked log against the now-current ingredient set.
+        await this.compactCheckedLog();
+    }
+
+    async updateScale(index: number, scale: number): Promise<void> {
+        if (index < 0 || index >= this.list.items.length) {
+            return;
+        }
+        this.list.items[index].multiplier = scale === 1 ? undefined : scale;
+        await this.saveList();
+        await this.regenerate();
+    }
+
+    async clearAll(): Promise<void> {
+        this.list = { items: [] };
+        this.checkedLog = [];
+        this.checkedSet.clear();
+        this.result = undefined;
+        const root = this.getWorkspaceRootUri();
+        if (root) {
+            try { await this.fileService.delete(root.resolve(LIST_FILE)); } catch { /* already gone */ }
+            try { await this.fileService.delete(root.resolve(CHECKED_FILE)); } catch { /* already gone */ }
+        }
+        this.onDidChangeEmitter.fire();
+    }
+
+    protected async readConfigFile(root: URI, relativePath: string): Promise<string | null> {
+        try {
+            const content = await this.fileService.read(root.resolve(relativePath));
+            return content.value;
+        } catch {
+            return null;
+        }
+    }
+
+    // Stubs — implemented in Task 10 and 11.
+    async checkItem(_name: string): Promise<void> { /* Task 10 */ }
+    async uncheckItem(_name: string): Promise<void> { /* Task 10 */ }
+    async addMenu(
+        _menuPath: string,
+        _menuScale: number,
+        _recipes: Array<{ path: string; scale: number; includedRefs?: string[] }>,
+    ): Promise<void> { /* Task 11 */ }
+    protected async compactCheckedLog(): Promise<void> { /* Task 10 */ }
+```
+
+- [ ] **Step 2: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: still compile errors in widget/components/contribution (they call old API). Leave for Task 12–13.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-service.ts
+git commit -m "feat(cooklang): ShoppingListService regenerate + CRUD methods"
+```
+
+---
+
+## Task 10: `ShoppingListService` — check/uncheck/compact
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.ts`
+
+- [ ] **Step 1: Replace the stubs for check/uncheck/compact**
+
+In `packages/cooklang/src/browser/shopping-list-service.ts`, replace `checkItem`, `uncheckItem`, and `compactCheckedLog` stubs with:
+
+```ts
+    async checkItem(name: string): Promise<void> {
+        await this.appendCheckEntry({ type: 'checked', name });
+    }
+
+    async uncheckItem(name: string): Promise<void> {
+        await this.appendCheckEntry({ type: 'unchecked', name });
+    }
+
+    protected async appendCheckEntry(entry: CheckEntry): Promise<void> {
+        const root = this.getWorkspaceRootUri();
+        if (!root) { return; }
+
+        const line = await this.languageService.writeCheckEntry(JSON.stringify(entry));
+
+        // Read-modify-write. FileService has no native append; single-user
+        // event-loop serialization keeps this safe.
+        let existing = '';
+        try {
+            const content = await this.fileService.read(root.resolve(CHECKED_FILE));
+            existing = content.value;
+        } catch {
+            existing = '';
+        }
+        const next = existing + (existing.endsWith('\n') || existing.length === 0 ? '' : '\n') + line;
+        await this.fileService.write(root.resolve(CHECKED_FILE), next);
+
+        // Update in-memory state
+        this.checkedLog.push(entry);
+        const setArr = await this.languageService.checkedSet(JSON.stringify(this.checkedLog));
+        this.checkedSet = new Set(setArr.map(s => s.toLowerCase()));
+        this.onDidChangeEmitter.fire();
+    }
+
+    /**
+     * Rewrite `.shopping-checked` keeping only entries whose ingredient name
+     * is still present in the current aggregated result. If `this.result` is
+     * missing (regeneration failed), skip — matches cookcli policy.
+     */
+    protected async compactCheckedLog(): Promise<void> {
+        if (!this.result) { return; }
+        const root = this.getWorkspaceRootUri();
+        if (!root) { return; }
+
+        const names: string[] = [];
+        for (const c of this.result.categories) {
+            for (const it of c.items) { names.push(it.name); }
+        }
+        for (const it of this.result.other.items) { names.push(it.name); }
+
+        const compactedJson = await this.languageService.compactChecked(
+            JSON.stringify(this.checkedLog),
+            names,
+        );
+        const compacted: CheckEntry[] = JSON.parse(compactedJson);
+
+        // If nothing changed, skip the write.
+        if (compacted.length === this.checkedLog.length) { return; }
+        this.checkedLog = compacted;
+
+        // Serialize each entry back to a line, join, write.
+        const lines: string[] = [];
+        for (const entry of compacted) {
+            lines.push(await this.languageService.writeCheckEntry(JSON.stringify(entry)));
+        }
+        const text = lines.length > 0 ? lines.join('') : '';
+        if (text.length === 0) {
+            try { await this.fileService.delete(root.resolve(CHECKED_FILE)); } catch { /* already gone */ }
+        } else {
+            // writeCheckEntry already emits a trailing newline per entry; if it
+            // doesn't, ensure separation:
+            const needsNewlines = !lines.every(l => l.endsWith('\n'));
+            const joined = needsNewlines ? lines.join('\n') + '\n' : text;
+            await this.fileService.write(root.resolve(CHECKED_FILE), joined);
+        }
+
+        // Rebuild in-memory set
+        const setArr = await this.languageService.checkedSet(compactedJson);
+        this.checkedSet = new Set(setArr.map(s => s.toLowerCase()));
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: widget/components/contribution still broken — fixed in later tasks.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-service.ts
+git commit -m "feat(cooklang): persist checked state via append + compact"
+```
+
+---
+
+## Task 11: `ShoppingListService` — addMenu with nested children
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.ts`
+
+- [ ] **Step 1: Replace the `addMenu` stub**
+
+In `packages/cooklang/src/browser/shopping-list-service.ts`, replace the `addMenu` stub:
+
+```ts
+    /**
+     * Adds a menu as a single top-level item with nested recipe children.
+     * Each child recipe may itself have sub-recipe references as grandchildren.
+     */
+    async addMenu(
+        menuPath: string,
+        menuScale: number,
+        recipes: Array<{ path: string; scale: number; includedRefs?: string[] }>,
+    ): Promise<void> {
+        const children: ShoppingListRecipeItem[] = recipes.map(r => ({
+            type: 'recipe',
+            path: r.path,
+            multiplier: r.scale === 1 ? undefined : r.scale,
+            children: (r.includedRefs ?? []).map(p => ({
+                type: 'recipe',
+                path: p.replace(/^\.\//, ''),
+                multiplier: undefined,
+                children: [],
+            })),
+        }));
+        this.list.items.push({
+            type: 'recipe',
+            path: menuPath,
+            multiplier: menuScale === 1 ? undefined : menuScale,
+            children,
+        });
+        await this.saveList();
+        await this.regenerate();
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: errors only in `shopping-list-widget.tsx`, `shopping-list-components.tsx`, `shopping-list-contribution.ts`.
+
+- [ ] **Step 3: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-service.ts
+git commit -m "feat(cooklang): ShoppingListService.addMenu for menu bulk-add"
+```
+
+---
+
+## Task 12: Update widget + components for new service API
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-widget.tsx`
+- Modify: `packages/cooklang/src/browser/shopping-list-components.tsx`
+
+- [ ] **Step 1: Update the widget**
+
+Overwrite `packages/cooklang/src/browser/shopping-list-widget.tsx` render/handlers portion with:
+
+Replace the render method body:
+
+```tsx
+    protected render(): React.ReactNode {
+        const items = this.shoppingListService.getItems();
+        const result = this.shoppingListService.getResult();
+
+        const checkedItems = new Set<string>();
+        if (result) {
+            const allItems = [
+                ...result.categories.flatMap(c => c.items),
+                ...result.other.items,
+            ];
+            for (const item of allItems) {
+                if (this.shoppingListService.isChecked(item.name)) {
+                    checkedItems.add(item.name);
+                }
+            }
+        }
+
+        return (
+            <ShoppingListView
+                items={items}
+                result={result}
+                checkedItems={checkedItems}
+                onRemoveRecipe={this.handleRemoveRecipe}
+                onScaleChange={this.handleScaleChange}
+                onClearAll={this.handleClearAll}
+                onToggleItem={this.handleToggleItem}
+            />
+        );
+    }
+
+    protected handleRemoveRecipe = (index: number): void => {
+        void this.shoppingListService.removeRecipe(index);
+    };
+
+    protected handleScaleChange = (index: number, scale: number): void => {
+        void this.shoppingListService.updateScale(index, scale);
+    };
+
+    protected handleClearAll = (): void => {
+        void this.shoppingListService.clearAll();
+    };
+
+    protected handleToggleItem = (name: string): void => {
+        if (this.shoppingListService.isChecked(name)) {
+            void this.shoppingListService.uncheckItem(name);
+        } else {
+            void this.shoppingListService.checkItem(name);
+        }
+    };
+```
+
+- [ ] **Step 2: Update components for new item shape and menu row**
+
+Overwrite `packages/cooklang/src/browser/shopping-list-components.tsx` with:
+
+```tsx
+// Copyright (C) 2026 Cooklang contributors
+// SPDX-License-Identifier: MIT
+
+import * as React from '@theia/core/shared/react';
+import {
+    ShoppingListRecipeItem,
+    ShoppingListResult,
+    ShoppingListCategory,
+    ShoppingListItem,
+} from '../common/shopping-list-types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Derive a human-friendly display name from a recipe path. */
+function displayNameFromPath(path: string): string {
+    const base = path.split('/').pop() ?? path;
+    return base.replace(/\.(cook|menu)$/i, '');
+}
+
+// ---------------------------------------------------------------------------
+// RecipeListPanel
+// ---------------------------------------------------------------------------
+
+interface RecipeListPanelProps {
+    items: readonly ShoppingListRecipeItem[];
+    onRemove: (index: number) => void;
+    onScaleChange: (index: number, scale: number) => void;
+    onClearAll: () => void;
+}
+
+export const RecipeListPanel = ({
+    items,
+    onRemove,
+    onScaleChange,
+    onClearAll,
+}: RecipeListPanelProps): React.ReactElement => {
+    if (items.length === 0) {
+        return (
+            <div className='shopping-list-empty-recipes'>
+                No recipes selected. Add recipes from the preview or explorer.
+            </div>
+        );
+    }
+
+    return (
+        <div className='shopping-list-recipes'>
+            <div className='shopping-list-recipes-header'>
+                <span className='shopping-list-recipes-title'>Selected Recipes</span>
+                <button className='shopping-list-clear-btn' onClick={onClearAll}>
+                    Clear All
+                </button>
+            </div>
+            {items.map((item, idx) => {
+                const name = displayNameFromPath(item.path);
+                const isMenu = item.children.length > 0 && item.path.toLowerCase().endsWith('.menu');
+                const scale = item.multiplier ?? 1;
+                return (
+                    <div key={`${item.path}-${idx}`} className='shopping-list-recipe-row'>
+                        <div className='shopping-list-recipe-main'>
+                            <span className='shopping-list-recipe-name'>{name}</span>
+                            {isMenu && (
+                                <span className='shopping-list-recipe-sub'>
+                                    menu ({item.children.length} recipes)
+                                </span>
+                            )}
+                        </div>
+                        <input
+                            className='shopping-list-scale-input'
+                            type='number'
+                            min='0.5'
+                            max='100'
+                            step='0.5'
+                            defaultValue={scale}
+                            onBlur={e => {
+                                const val = parseFloat(e.target.value);
+                                if (!isNaN(val) && val > 0) {
+                                    onScaleChange(idx, val);
+                                }
+                            }}
+                            title='Scale factor'
+                        />
+                        <button
+                            className='shopping-list-remove-btn'
+                            onClick={() => onRemove(idx)}
+                            title='Remove from shopping list'
+                        >
+                            x
+                        </button>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// IngredientRow
+// ---------------------------------------------------------------------------
+
+interface IngredientRowProps {
+    item: ShoppingListItem;
+    checked: boolean;
+    onToggle: () => void;
+}
+
+const IngredientRow = ({ item, checked, onToggle }: IngredientRowProps): React.ReactElement => (
+    <div className={'shopping-list-ingredient' + (checked ? ' checked' : '')}>
+        <label className='shopping-list-ingredient-label'>
+            <input
+                type='checkbox'
+                checked={checked}
+                onChange={onToggle}
+            />
+            <span className='shopping-list-ingredient-name'>{item.name}</span>
+            {item.quantities && (
+                <span className='shopping-list-ingredient-qty'>{item.quantities}</span>
+            )}
+        </label>
+    </div>
+);
+
+// ---------------------------------------------------------------------------
+// CategorySection
+// ---------------------------------------------------------------------------
+
+interface CategorySectionProps {
+    category: ShoppingListCategory;
+    checkedItems: Set<string>;
+    onToggle: (name: string) => void;
+}
+
+export const CategorySection = ({
+    category,
+    checkedItems,
+    onToggle,
+}: CategorySectionProps): React.ReactElement | null => {
+    if (category.items.length === 0) { return null; }
+    return (
+        <div className='shopping-list-category'>
+            <h3 className='shopping-list-category-header'>{category.name}</h3>
+            {category.items.map(item => (
+                <IngredientRow
+                    key={item.name}
+                    item={item}
+                    checked={checkedItems.has(item.name)}
+                    onToggle={() => onToggle(item.name)}
+                />
+            ))}
+        </div>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// PantrySection (unchanged)
+// ---------------------------------------------------------------------------
+
+interface PantrySectionProps {
+    pantryItems: string[];
+}
+
+export const PantrySection = ({ pantryItems }: PantrySectionProps): React.ReactElement | null => {
+    const [expanded, setExpanded] = React.useState(false);
+    if (pantryItems.length === 0) { return null; }
+    return (
+        <div className='shopping-list-pantry'>
+            <button
+                className='shopping-list-pantry-toggle'
+                onClick={() => setExpanded(!expanded)}
+            >
+                {expanded ? '\u25BC' : '\u25B6'} In Pantry ({pantryItems.length})
+            </button>
+            {expanded && (
+                <ul className='shopping-list-pantry-list'>
+                    {pantryItems.map(name => (
+                        <li key={name} className='shopping-list-pantry-item'>{name}</li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// ShoppingListView (top-level)
+// ---------------------------------------------------------------------------
+
+export interface ShoppingListViewProps {
+    items: readonly ShoppingListRecipeItem[];
+    result: ShoppingListResult | undefined;
+    checkedItems: Set<string>;
+    onRemoveRecipe: (index: number) => void;
+    onScaleChange: (index: number, scale: number) => void;
+    onClearAll: () => void;
+    onToggleItem: (name: string) => void;
+}
+
+export const ShoppingListView = ({
+    items,
+    result,
+    checkedItems,
+    onRemoveRecipe,
+    onScaleChange,
+    onClearAll,
+    onToggleItem,
+}: ShoppingListViewProps): React.ReactElement => (
+    <div className='shopping-list-content'>
+        <RecipeListPanel
+            items={items}
+            onRemove={onRemoveRecipe}
+            onScaleChange={onScaleChange}
+            onClearAll={onClearAll}
+        />
+        {result && (
+            <>
+                {result.categories.map(category => (
+                    <CategorySection
+                        key={category.name}
+                        category={category}
+                        checkedItems={checkedItems}
+                        onToggle={onToggleItem}
+                    />
+                ))}
+                {result.other.items.length > 0 && (
+                    <CategorySection
+                        key='other'
+                        category={result.other}
+                        checkedItems={checkedItems}
+                        onToggle={onToggleItem}
+                    />
+                )}
+                <PantrySection pantryItems={result.pantryItems} />
+            </>
+        )}
+    </div>
+);
+```
+
+- [ ] **Step 3: Add menu sub-label CSS**
+
+Append to `packages/cooklang/src/browser/style/shopping-list.css`:
+
+```css
+.shopping-list-recipe-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.shopping-list-recipe-sub {
+    font-size: 0.85em;
+    color: var(--theia-descriptionForeground);
+}
+```
+
+- [ ] **Step 4: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: only `shopping-list-contribution.ts` still broken (calls `addRecipe(path, name, scale)` signature that no longer exists).
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-widget.tsx packages/cooklang/src/browser/shopping-list-components.tsx packages/cooklang/src/browser/style/shopping-list.css
+git commit -m "feat(cooklang): UI for new shopping list shape with menu rows"
+```
+
+---
+
+## Task 13: Update `addToShoppingList` command and add `addMenuToShoppingList`
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-contribution.ts`
+
+- [ ] **Step 1: Update addRecipe call site + add menu command**
+
+In `packages/cooklang/src/browser/shopping-list-contribution.ts`:
+
+1. Replace `addRecipe` method body — drop the `name` param (now derived from path):
+
+```ts
+    protected async addRecipe(args: unknown[] = []): Promise<void> {
+        const targetUri = this.resolveTargetUri(args);
+        if (!targetUri) { return; }
+
+        const scale = this.resolveScale(args);
+        const workspaceRoot = this.shoppingListService.getWorkspaceRootUri();
+        const relativePath = workspaceRoot
+            ? workspaceRoot.relative(targetUri)?.toString() ?? targetUri.path.base
+            : targetUri.path.base;
+
+        await this.shoppingListService.addRecipe(relativePath, scale);
+        await this.openView({ activate: true });
+    }
+```
+
+2. Add the new menu command in the `ShoppingListCommands` namespace:
+
+```ts
+    export const ADD_MENU_TO_LIST: Command = {
+        id: 'cooklang.addMenuToShoppingList',
+        label: 'Cooklang: Add Menu to Shopping List',
+        iconClass: 'theia-shopping-cart-icon',
+    };
+```
+
+3. In `registerCommands`, after the existing `ADD_TO_LIST` registration, add:
+
+```ts
+        commands.registerCommand(ShoppingListCommands.ADD_MENU_TO_LIST, {
+            execute: (...args: unknown[]) => this.addMenu(args),
+            isEnabled: (...args: unknown[]) => this.canAddMenu(args),
+            isVisible: (...args: unknown[]) => this.canAddMenu(args),
+        });
+```
+
+4. In `registerMenus`, after the existing ADD_TO_LIST menu action, add:
+
+```ts
+        menus.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
+            commandId: ShoppingListCommands.ADD_MENU_TO_LIST.id,
+            label: 'Add Menu to Shopping List',
+            when: 'resourceExtname == .menu',
+        });
+```
+
+5. In `registerToolbarItems`, after the existing entry, add:
+
+```ts
+        toolbar.registerItem({
+            id: ShoppingListCommands.ADD_MENU_TO_LIST.id + '.editor',
+            command: ShoppingListCommands.ADD_MENU_TO_LIST.id,
+            tooltip: 'Add Menu to Shopping List',
+            when: `resourceExtname == .menu`,
+        });
+```
+
+6. Add helper methods at the bottom of the class:
+
+```ts
+    protected resolveMenuUri(args: unknown[]): URI | undefined {
+        if (args.length > 0 && args[0] instanceof URI) {
+            const uri = args[0] as URI;
+            if (uri.path.ext === '.menu') { return uri; }
+        }
+        if (args.length > 0 && NavigatableWidget.is(args[0])) {
+            const uri = (args[0] as NavigatableWidget).getResourceUri();
+            if (uri && uri.path.ext === '.menu') { return uri; }
+        }
+        const selection = this.selectionService.selection;
+        const selectedUri = UriSelection.getUri(selection);
+        if (selectedUri && selectedUri.path.ext === '.menu') { return selectedUri; }
+        const currentWidget = this.shell?.currentWidget;
+        if (NavigatableWidget.is(currentWidget)) {
+            const uri = currentWidget.getResourceUri();
+            if (uri && uri.path.ext === '.menu') { return uri; }
+        }
+        return undefined;
+    }
+
+    protected canAddMenu(args: unknown[] = []): boolean {
+        return this.resolveMenuUri(args) !== undefined;
+    }
+
+    protected async addMenu(args: unknown[] = []): Promise<void> {
+        const menuUri = this.resolveMenuUri(args);
+        if (!menuUri) { return; }
+
+        const workspaceRoot = this.shoppingListService.getWorkspaceRootUri();
+        const relativePath = workspaceRoot
+            ? workspaceRoot.relative(menuUri)?.toString() ?? menuUri.path.base
+            : menuUri.path.base;
+
+        // Parse the menu to enumerate referenced recipes.
+        let menuContent: string;
+        try {
+            const root = this.shoppingListService.getWorkspaceRootUri();
+            if (!root) { return; }
+            const content = await this.fileService.read(root.resolve(relativePath));
+            menuContent = content.value;
+        } catch (e) {
+            console.error('[shopping-list] Failed to read menu file:', e);
+            return;
+        }
+
+        let parsed: { sections?: Array<{ lines?: Array<Array<{ kind?: string; name?: string; path?: string; scale?: number }>> }> };
+        try {
+            parsed = JSON.parse(await this.languageService.parseMenu(menuContent, 1));
+        } catch (e) {
+            console.error('[shopping-list] Failed to parse menu:', e);
+            return;
+        }
+
+        const recipes: Array<{ path: string; scale: number; includedRefs?: string[] }> = [];
+        for (const section of parsed.sections ?? []) {
+            for (const line of section.lines ?? []) {
+                for (const item of line) {
+                    // Shape of recipe-reference items: see `MenuRecipeReferenceItem` in
+                    // packages/cooklang/src/common/menu-types.ts. Heuristic: has `path` or
+                    // has a recipe-reference `kind`. Adjust by inspecting the actual
+                    // shape in node REPL during implementation.
+                    const refPath = item.path ?? item.name;
+                    if (!refPath) { continue; }
+                    if (item.kind && item.kind !== 'recipe-reference' && item.kind !== 'recipeReference') { continue; }
+                    recipes.push({
+                        path: refPath.replace(/^\.\//, ''),
+                        scale: typeof item.scale === 'number' && item.scale > 0 ? item.scale : 1,
+                    });
+                }
+            }
+        }
+
+        if (recipes.length === 0) {
+            console.warn('[shopping-list] Menu contained no recipe references:', relativePath);
+            return;
+        }
+
+        await this.shoppingListService.addMenu(relativePath, 1, recipes);
+        await this.openView({ activate: true });
+    }
+```
+
+7. Add `FileService` and `CooklangLanguageService` imports + property injections at the top of the class:
+
+```ts
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(CooklangLanguageService)
+    protected readonly languageService: CooklangLanguageService;
+```
+
+And the imports at the top of the file:
+
+```ts
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { CooklangLanguageService } from '../common/cooklang-language-service';
+```
+
+- [ ] **Step 2: Compile**
+
+```
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: clean compile across the whole package.
+
+- [ ] **Step 3: Full electron build**
+
+```
+cd examples/electron && npm run bundle
+```
+
+Expected: clean bundle.
+
+- [ ] **Step 4: Manual smoke test**
+
+Start the editor, open a workspace with at least one `.cook` and one `.menu` file.
+
+Test script:
+1. Right-click a `.cook` → "Add to Shopping List" → shopping list widget opens with ingredients grouped.
+2. Check a few items.
+3. Restart the editor. Verify checked state persists.
+4. Right-click a `.menu` → "Add Menu to Shopping List" → a single row appears labeled "menu (N recipes)".
+5. Change scale on the menu row → ingredients scale.
+6. Remove a recipe → stale checks are pruned from `.shopping-checked`.
+7. Clear All → both files are deleted.
+
+Verify on disk: `.shopping-list` contains readable text, `.shopping-checked` contains `+ name` / `- name` lines.
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-contribution.ts
+git commit -m "feat(cooklang): addMenuToShoppingList command for .menu files"
+```
+
+---
+
+## Task 14: TypeScript unit tests for `ShoppingListService`
+
+**Files:**
+- Create: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+- [ ] **Step 1: Check test harness prerequisites**
+
+Run: `cat packages/cooklang/package.json | grep -A2 scripts`
+
+Verify `"test": "theiaext test"`. If the `test` script is absent, add `"test": "theiaext test"` to `scripts`. (The pattern is the same as every other Theia package.)
+
+- [ ] **Step 2: Write the spec file**
+
+Create `packages/cooklang/src/browser/shopping-list-service.spec.ts`:
+
+```ts
+// Copyright (C) 2026 Cooklang contributors
+// SPDX-License-Identifier: MIT
+
+import { expect } from 'chai';
+import { ShoppingListService } from './shopping-list-service';
+import { ShoppingListRecipeItem, CheckEntry } from '../common/shopping-list-types';
+
+/** Minimal in-memory FileService stub — only the methods we call. */
+class FakeFileService {
+    files = new Map<string, string>();
+    async read(uri: { toString(): string }): Promise<{ value: string }> {
+        const key = uri.toString();
+        if (!this.files.has(key)) { throw new Error('ENOENT'); }
+        return { value: this.files.get(key)! };
+    }
+    async write(uri: { toString(): string }, content: string): Promise<void> {
+        this.files.set(uri.toString(), content);
+    }
+    async delete(uri: { toString(): string }): Promise<void> {
+        this.files.delete(uri.toString());
+    }
+}
+
+/** FakeWorkspaceService with a single root. */
+class FakeWorkspaceService {
+    roots = Promise.resolve([{ resource: { toString: () => 'file:///ws' } }]);
+    tryGetRoots(): Array<{ resource: { toString: () => string } }> {
+        return [{ resource: { toString: () => 'file:///ws' } }];
+    }
+}
+
+/** FakeCooklangLanguageService — only the methods the service calls. */
+class FakeLanguageService {
+    // Mirrors cooklang-rs' serde JSON output shape.
+    async parseShoppingList(text: string): Promise<string> {
+        // Tests can override by pre-stuffing state; for now, do a trivial parse:
+        // one recipe per non-empty line.
+        const items = text.split('\n').filter(l => l.trim().length > 0).map(l => ({
+            type: 'recipe', path: l.trim(), multiplier: undefined, children: [],
+        }));
+        return JSON.stringify({ items });
+    }
+    async writeShoppingList(json: string): Promise<string> {
+        const list: { items: Array<{ path: string }> } = JSON.parse(json);
+        return list.items.map(i => i.path).join('\n') + (list.items.length > 0 ? '\n' : '');
+    }
+    async parseChecked(text: string): Promise<string> {
+        const entries: CheckEntry[] = [];
+        for (const line of text.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('+ ')) { entries.push({ type: 'checked', name: trimmed.slice(2) }); }
+            else if (trimmed.startsWith('- ')) { entries.push({ type: 'unchecked', name: trimmed.slice(2) }); }
+        }
+        return JSON.stringify(entries);
+    }
+    async writeCheckEntry(entryJson: string): Promise<string> {
+        const entry: CheckEntry = JSON.parse(entryJson);
+        return (entry.type === 'checked' ? '+ ' : '- ') + entry.name + '\n';
+    }
+    async checkedSet(entriesJson: string): Promise<string[]> {
+        const entries: CheckEntry[] = JSON.parse(entriesJson);
+        const set = new Set<string>();
+        for (const e of entries) {
+            if (e.type === 'checked') { set.add(e.name.toLowerCase()); }
+            else { set.delete(e.name.toLowerCase()); }
+        }
+        return [...set];
+    }
+    async compactChecked(entriesJson: string, names: string[]): Promise<string> {
+        const entries: CheckEntry[] = JSON.parse(entriesJson);
+        const lc = new Set(names.map(n => n.toLowerCase()));
+        return JSON.stringify(entries.filter(e => lc.has(e.name.toLowerCase())));
+    }
+    // Unused in tests but part of the interface — recipes are not physically read.
+    async generateShoppingList(_recipes: string, _a: string | null, _p: string | null): Promise<string> {
+        return JSON.stringify({
+            categories: [],
+            other: { name: 'other', items: [{ name: 'flour', quantities: '' }] },
+            pantryItems: [],
+        });
+    }
+    async parse(_c: string): Promise<string> { return '{}'; }
+    async parseMenu(_c: string, _s: number): Promise<string> { return '{}'; }
+}
+
+/**
+ * Construct a ShoppingListService with injected fakes. We bypass Inversify and
+ * set protected fields directly — simpler than wiring a test container.
+ */
+function makeService(): { svc: ShoppingListService; fs: FakeFileService; ls: FakeLanguageService } {
+    const fs = new FakeFileService();
+    const ls = new FakeLanguageService();
+    const ws = new FakeWorkspaceService();
+    const svc = new ShoppingListService();
+    (svc as any).fileService = fs;
+    (svc as any).languageService = ls;
+    (svc as any).workspaceService = ws;
+    (svc as any).toDispose = { push: (): void => {} };
+    return { svc, fs, ls };
+}
+
+describe('ShoppingListService', () => {
+    it('addRecipe appends to list and persists', async () => {
+        const { svc, fs } = makeService();
+        await svc.addRecipe('pasta.cook', 1);
+        expect(svc.getItems().length).to.equal(1);
+        expect(fs.files.get('file:///ws/.shopping-list')).to.contain('pasta.cook');
+    });
+
+    it('addMenu creates a nested structure', async () => {
+        const { svc } = makeService();
+        await svc.addMenu('weekday.menu', 1, [
+            { path: 'pasta.cook', scale: 1 },
+            { path: 'salad.cook', scale: 2 },
+        ]);
+        const items = svc.getItems() as readonly ShoppingListRecipeItem[];
+        expect(items.length).to.equal(1);
+        expect(items[0].children.length).to.equal(2);
+        expect(items[0].children[1].multiplier).to.equal(2);
+    });
+
+    it('checkItem appends to .shopping-checked and updates the set', async () => {
+        const { svc, fs } = makeService();
+        await svc.checkItem('Flour');
+        expect(svc.isChecked('flour')).to.equal(true);
+        expect(fs.files.get('file:///ws/.shopping-checked')).to.contain('+ Flour');
+    });
+
+    it('uncheckItem reverses a prior check', async () => {
+        const { svc } = makeService();
+        await svc.checkItem('flour');
+        await svc.uncheckItem('flour');
+        expect(svc.isChecked('flour')).to.equal(false);
+    });
+
+    it('clearAll deletes both files', async () => {
+        const { svc, fs } = makeService();
+        await svc.addRecipe('pasta.cook', 1);
+        await svc.checkItem('flour');
+        await svc.clearAll();
+        expect(fs.files.has('file:///ws/.shopping-list')).to.equal(false);
+        expect(fs.files.has('file:///ws/.shopping-checked')).to.equal(false);
+        expect(svc.getItems().length).to.equal(0);
+    });
+
+    it('removeRecipe compacts stale checks', async () => {
+        const { svc, fs, ls } = makeService();
+        // Make the fake generateShoppingList return "milk" while pasta is in the list,
+        // but return nothing once the list is empty.
+        let callCount = 0;
+        ls.generateShoppingList = async () => {
+            callCount++;
+            return JSON.stringify({
+                categories: [],
+                other: {
+                    name: 'other',
+                    items: callCount === 1
+                        ? [{ name: 'flour', quantities: '' }, { name: 'milk', quantities: '' }]
+                        : [{ name: 'flour', quantities: '' }],
+                },
+                pantryItems: [],
+            });
+        };
+
+        await svc.addRecipe('pasta.cook', 1);
+        await svc.checkItem('milk');
+        expect(svc.isChecked('milk')).to.equal(true);
+
+        await svc.removeRecipe(0);
+        // milk is no longer in the ingredient list → compact should drop it.
+        // The compacted file no longer contains "milk".
+        const checkedContent = fs.files.get('file:///ws/.shopping-checked') ?? '';
+        expect(checkedContent.includes('milk')).to.equal(false);
+    });
+});
+```
+
+- [ ] **Step 3: Run the tests**
+
+```
+npx lerna run test --scope @theia/cooklang
+```
+
+Expected: 6 tests PASS.
+
+> If the Theia test runner does not discover `.spec.ts` files under `src/browser`, inspect `packages/cooklang/.mocharc.js` (or equivalent). Packages in this repo use the `theiaext` tool which should auto-discover; if not, check pattern in `packages/ai-chat-ui` for reference.
+
+- [ ] **Step 4: Commit**
+
+```
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): unit tests for ShoppingListService behavior"
+```
+
+---
+
+## Task 15: Final cleanup + smoke test + gitignore
+
+**Files:**
+- Modify: `.gitignore` (workspace root)
+- Verify: no references to `.shopping_list.txt` remain
+
+- [ ] **Step 1: Grep for stale references**
+
+Run: `grep -rn "shopping_list\\.txt\\|ShoppingListRecipe\\b\\|toggleChecked" packages/cooklang/src/ packages/cooklang/data/`
+
+Expected: no matches. If any remain, remove / update them.
+
+- [ ] **Step 2: Add the new files to `.gitignore`**
+
+If `.gitignore` exists at workspace root, add:
+
+```
+.shopping-list
+.shopping-checked
+```
+
+(Only if the repo was previously ignoring `.shopping_list.txt`; otherwise the user's workspace `.gitignore` is their responsibility — flag but don't modify user workspace files.)
+
+- [ ] **Step 3: Full end-to-end smoke test**
+
+Start the editor on a fresh workspace. Run each of the following in sequence and verify behavior:
+
+1. Add `.cook` recipe → widget shows items.
+2. Check an ingredient → `.shopping-checked` has `+ name`.
+3. Uncheck → `.shopping-checked` has `+ name\n- name\n`.
+4. Restart editor → checked state restored.
+5. Add `.menu` → single row "menu (N recipes)", ingredients aggregate all referenced recipes.
+6. Scale the menu row → ingredients scale proportionally.
+7. Remove menu → ingredients from all referenced recipes disappear, stale checks pruned.
+8. Clear All → both files deleted.
+
+- [ ] **Step 4: Commit any .gitignore change**
+
+```
+git add .gitignore
+git commit -m "chore: gitignore new shopping-list format files"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Self-review checklist
+
+- [x] **Spec coverage:** All sections in the spec map to tasks — Rust surface (Tasks 2–5), RPC (Task 6), TS types (Task 7), service (Tasks 8–11), UI (Tasks 12–13), tests (Tasks 2–4, 14), crate upgrade (Task 1).
+- [x] **No placeholders:** Each code step shows the actual code.
+- [x] **Type consistency:** `ShoppingListRecipeItem` used consistently across types, service, components. `addRecipe(path, scale, includedRefs?)` signature in service matches call site in contribution. `addMenu(menuPath, menuScale, recipes)` matches call site.
+- [x] **Known uncertainties called out inline:** Serde field names in Task 5 Step 3 determine Task 7 interface. Menu JSON shape in Task 13 depends on `MenuRecipeReferenceItem`. Both have inspection steps with fallback guidance.
+
+## Known risks
+
+- **Serde shape discovery (Task 5):** The exact JSON that `cooklang::shopping_list::ShoppingList` produces (field names, optional tagging) isn't known without running the NAPI. Task 5 Step 3 captures it, Task 7 uses it. If the shape diverges from the plan's draft interface, update Task 7's types accordingly — the rest of the code treats the shape as opaque JSON transit.
+- **`cooklang-language-server` sibling bump** may cascade. Task 1 Step 4 detects it.
+- **`CheckEntry` serde variants:** if `cooklang-rs` uses `Check` / `Uncheck` instead of `Checked` / `Unchecked`, adjust `CheckEntry` union in Task 7 and the fakes in Task 14.

--- a/docs/superpowers/specs/2026-04-10-shopping-list-format-migration-design.md
+++ b/docs/superpowers/specs/2026-04-10-shopping-list-format-migration-design.md
@@ -1,0 +1,151 @@
+# Shopping List Format Migration
+
+**Status:** Draft
+**Date:** 2026-04-10
+**Related:** [cooklang/cookcli#318](https://github.com/cooklang/cookcli/pull/318)
+
+## Goal
+
+Migrate the editor's shopping list from the legacy tab-delimited `.shopping_list.txt` format to the new `.shopping-list` format introduced in cooklang-rs 0.18.5, and add persistent checked-ingredient state via `.shopping-checked`. Full feature parity with cookcli PR #318 — excluding backward-compatibility migration, which is not required.
+
+## Non-goals
+
+- Migration from the legacy `.shopping_list.txt` format. Existing users will start fresh.
+- File locking (`fs2`) — the editor is single-user, single-process.
+- UI for editing `included_references` on existing entries.
+- Treating `.shopping-list` as a first-class editable file with syntax highlighting.
+
+## Architecture
+
+Two files in the workspace root:
+
+- **`.shopping-list`** — recipe references in cooklang shopping-list format. Top-level items represent single recipes or menus. Menu entries carry their constituent recipes as `children`. Each recipe entry may carry `included_references` children to selectively expand sub-recipes.
+- **`.shopping-checked`** — append-only log of `+ name` / `- name` entries. Last-write-wins determines the checked set. Compacted on recipe removal to prune stale entries.
+
+### Component boundaries
+
+**Rust NAPI (`packages/cooklang-native`)** exposes stateless parse/serialize helpers — no direct filesystem access. Upgraded to `cooklang 0.18.5` with features `["aisle", "pantry", "shopping_list"]`.
+
+**TypeScript `ShoppingListService` (`packages/cooklang/src/browser`)** owns all file I/O via Theia `FileService`, orchestrates Rust helpers, holds in-memory state, and fires `onDidChange`.
+
+**Existing `generateShoppingList` RPC** stays intact. The service flattens `.shopping-list` entries into `RecipeInput[]` before calling it, applying any `included_references` and menu nesting.
+
+Rust doing filesystem I/O directly would bypass Theia's workspace abstraction (remote workspaces, file watchers, virtual filesystems) — hence the thin-Rust / fat-TS split.
+
+## Rust NAPI surface
+
+Added to `packages/cooklang-native/src/lib.rs`:
+
+```rust
+#[napi] pub fn parse_shopping_list(text: String) -> Result<String>
+#[napi] pub fn write_shopping_list(json: String) -> Result<String>
+#[napi] pub fn parse_checked(text: String) -> Result<String>
+#[napi] pub fn write_check_entry(entry_json: String) -> Result<String>
+#[napi] pub fn checked_set(entries_json: String) -> Result<Vec<String>>
+#[napi] pub fn compact_checked(entries_json: String, current_ingredients: Vec<String>) -> Result<String>
+```
+
+All helpers are stateless; JSON shapes mirror whatever serde tagging `cooklang::shopping_list` types use upstream — follow upstream rather than inventing. The TS side defines matching interfaces.
+
+## TypeScript types
+
+In `packages/cooklang/src/common/shopping-list-types.ts`:
+
+```ts
+export interface ShoppingListFile {
+    items: ShoppingListRecipeItem[];
+}
+
+export interface ShoppingListRecipeItem {
+    type: 'recipe';
+    path: string;
+    multiplier?: number;         // undefined = 1
+    children: ShoppingListRecipeItem[];
+}
+
+export type CheckEntry =
+    | { type: 'checked';   name: string }
+    | { type: 'unchecked'; name: string };
+```
+
+Existing `ShoppingListResult` (categories, `other`, `pantryItems`) is unchanged. The legacy `ShoppingListRecipe` interface is removed.
+
+## `ShoppingListService` behavior
+
+**State:**
+- `list: ShoppingListFile`
+- `checkedLog: CheckEntry[]`
+- `checkedSet: Set<string>` (derived)
+- `result: ShoppingListResult | undefined`
+
+**Load:** read `.shopping-list` → `parseShoppingList`; read `.shopping-checked` → `parseChecked`; derive `checkedSet`.
+
+**Save list:** `writeShoppingList(list)` → `fileService.write('.shopping-list')`.
+
+**Append check:** `writeCheckEntry(entry)` → read current file + concat + write. Theia's `FileService` has no native append; single-user event-loop serialization makes read-modify-write safe.
+
+**Compact:** `compactChecked(log, currentIngredientNames)` → write full file. Invoked after recipe removal, once `regenerate()` has provided the current ingredient set.
+
+**Public API:**
+- `addRecipe(path, scale, includedRefs?)` — top-level recipe item, optional sub-ref children
+- `addMenu(menuPath, menuScale, recipes[])` — menu with nested recipe children (grandchildren for each recipe's sub-refs)
+- `removeRecipe(index)` — drop top-level item, then `regenerate()` then compact
+- `updateScale(index, scale)` — updates `multiplier`
+- `clearAll()` — wipes both files
+- `checkItem(name)` / `uncheckItem(name)` — append log entry, update `checkedSet`
+- `isChecked(name)`
+- `regenerate()` — flattens to `RecipeInput[]`, calls `generateShoppingList` RPC, stores result
+
+**Compact policy:** on `removeRecipe`, attempt `regenerate()` first. If generation fails, skip compact (stale entries survive until next successful compact). Matches cookcli behavior.
+
+## UI
+
+**`ShoppingListWidget` / components:**
+- `IngredientRow` checkbox calls `service.checkItem` / `uncheckItem`. No rendering changes.
+- Checked state persists across restarts automatically via the new log.
+- Menu entries (items with `children.length > 0` sourced from a `.menu`) render as a single row with a secondary line showing nested recipe count (e.g. "Weekday dinners (3 recipes)"). Removal/scale operates on the menu as a whole.
+- After removal, trigger compact once `regenerate()` resolves.
+
+**Menu bulk-add command:**
+- `cooklang.addMenuToShoppingList` registered in editor title + explorer context menu with `when: resourceExtname == .menu`
+- Handler: resolve URI → call existing `parseMenu()` → for each referenced recipe, optionally parse to extract sub-references → call `service.addMenu(menuPath, 1, recipes[])`
+
+**Existing `cooklang.addToShoppingList`:** unchanged — adds a single recipe with no `includedRefs` (all sub-recipes expanded).
+
+## Cooklang crate upgrade
+
+- `cooklang-native/Cargo.toml`: bump `cooklang = "0.17"` → `"0.18.5"`, features `["aisle", "pantry", "shopping_list"]`.
+- Verify `cooklang-language-server = "0.2.1"` (sibling local dep) is compatible. If it pins to 0.17, either bump the sibling or pin both. Determine during implementation.
+- Audit existing `generateShoppingList` implementation against 0.18 API (`IngredientList`, `CooklangParser`, scaling, `aisle::parse`, `pantry::parse`). Fix signature breaks in place.
+
+## Testing
+
+**Rust unit tests** in `cooklang-native`:
+- Round-trip parse/write for `.shopping-list`
+- Round-trip parse/write for `.shopping-checked`
+- `checked_set` reflects last-write-wins
+- `compact_checked` drops entries whose name is absent from `current_ingredients`
+
+**TypeScript unit tests** for `ShoppingListService`:
+- Add/remove recipe updates file
+- Add menu produces nested structure
+- Check/uncheck appends log entries and updates `checkedSet`
+- Recipe removal triggers compact with current ingredient names
+- `clearAll` deletes both files
+
+**Manual smoke test:**
+- Add recipes via editor → check items → restart → verify persistence
+- Add a `.menu` via new command → verify nested display + single-row removal
+- Remove a recipe → verify stale checks disappear from log
+
+## Risks
+
+1. **`cooklang-language-server` coupling** may force a parallel upgrade. Isolate in a prep commit.
+2. **Append via read-modify-write** is O(n) per check. Shopping lists are small; flagged as accepted.
+3. **Compact-on-failure gap** — if aggregation fails after removal, log retains stale entries. Matches upstream.
+
+## Out-of-scope (future work)
+
+- UI to toggle individual `included_references` on a recipe entry already in the list
+- Syntax highlighting + language support for `.shopping-list` files
+- Legacy `.shopping_list.txt` migration path

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -280,35 +280,9 @@ dependencies = [
 
 [[package]]
 name = "cooklang"
-version = "0.17.14"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c4c23c94d7a3195645155ed76e9cb9ede0a549bfaf816b27c668de9237e090"
-dependencies = [
- "bitflags 2.11.0",
- "codesnake",
- "enum-map",
- "finl_unicode",
- "prettyplease",
- "proc-macro2",
- "quote",
- "serde",
- "serde_yaml",
- "smallvec",
- "strum",
- "syn",
- "thiserror",
- "toml 0.8.23",
- "tracing",
- "unicase",
- "unicode-width",
- "yansi",
-]
-
-[[package]]
-name = "cooklang"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c0354dc4f2405eadbb47a77e0f290bb0858234e8b533dd3bfbcfbbb6df1dde"
+checksum = "9c3a241ae9621d706658e24d626311057d09f0803b6bcc10ebbbe5f23816af8f"
 dependencies = [
  "bitflags 2.11.0",
  "codesnake",
@@ -325,6 +299,7 @@ dependencies = [
  "syn",
  "thiserror",
  "toml 0.8.23",
+ "toml_edit",
  "tracing",
  "unicase",
  "unicode-width",
@@ -336,7 +311,7 @@ name = "cooklang-language-server"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "cooklang 0.18.3",
+ "cooklang",
  "dashmap 6.1.0",
  "nohash-hasher",
  "ropey",
@@ -355,7 +330,7 @@ name = "cooklang-native"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "cooklang 0.17.14",
+ "cooklang",
  "cooklang-language-server",
  "cooklang-sync-client",
  "napi",
@@ -2418,6 +2393,7 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -96,6 +96,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +211,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +263,38 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "cc"
@@ -297,13 +388,29 @@ dependencies = [
  "smallvec",
  "strum",
  "syn",
- "thiserror",
+ "thiserror 2.0.18",
  "toml 0.8.23",
  "toml_edit",
  "tracing",
  "unicase",
  "unicode-width",
  "yansi",
+]
+
+[[package]]
+name = "cooklang-find"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a0ed8db092871bc031061a51a5f0752929f801b127f7ff0e918628b8596ef52"
+dependencies = [
+ "camino",
+ "glob",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "uniffi",
 ]
 
 [[package]]
@@ -318,7 +425,7 @@ dependencies = [
  "serde",
  "serde_json",
  "text-size",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tower-lsp",
  "tracing",
@@ -329,8 +436,10 @@ dependencies = [
 name = "cooklang-native"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "chrono",
  "cooklang",
+ "cooklang-find",
  "cooklang-language-server",
  "cooklang-sync-client",
  "napi",
@@ -364,7 +473,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-util",
@@ -702,6 +811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +964,23 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
 ]
 
 [[package]]
@@ -1352,6 +1487,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1595,16 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "notify"
@@ -1538,6 +1705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1759,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1671,7 +1850,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1692,7 +1871,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1883,7 +2062,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1977,10 +2156,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2122,6 +2325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2341,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -2160,6 +2375,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str_indices"
@@ -2252,12 +2473,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2385,6 +2635,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2662,6 +2921,134 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "uniffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cade167af943e189a55020eda2c314681e223f1e42aca7c4e52614c2b627698f"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7687007d2546c454d8ae609b105daceb88175477dac280707ad6d95bcd6f1f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml 0.5.11",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a74ed96c26882dac1ca9b93ca23c827e284bacbd7ec23c6f0b0372f747d59e4"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6f984f0781f892cc864a62c3a5c60361b1ccbd68e538e6c9fbced5d82268ac"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,6 +3290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = { version = "2", features = ["napi6", "serde-json", "tokio_rt"] }
 napi-derive = "2"
-cooklang = { version = "0.17", features = ["pantry"] }
+cooklang = { version = "0.18.5", features = ["aisle", "pantry", "shopping_list"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tower-lsp = "0.20"

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -10,6 +10,8 @@ crate-type = ["cdylib"]
 napi = { version = "2", features = ["napi6", "serde-json", "tokio_rt"] }
 napi-derive = "2"
 cooklang = { version = "0.18.5", features = ["aisle", "pantry", "shopping_list"] }
+cooklang-find = "0.5.8"
+camino = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tower-lsp = "0.20"

--- a/packages/cooklang-native/index.d.ts
+++ b/packages/cooklang-native/index.d.ts
@@ -50,6 +50,12 @@ export declare function getSyncStatus(): string
  * Replaces any previously registered callback.
  */
 export declare function onSyncStatusChanged(callback: (...args: any[]) => any): void
+export declare function parseShoppingList(text: string): string
+export declare function writeShoppingList(json: string): string
+export declare function parseChecked(text: string): string
+export declare function writeCheckEntry(entryJson: string): string
+export declare function checkedSet(entriesJson: string): Array<string>
+export declare function compactChecked(entriesJson: string, currentIngredients: Array<string>): string
 export declare class LspServer {
   constructor()
   sendMessage(message: string): void

--- a/packages/cooklang-native/index.d.ts
+++ b/packages/cooklang-native/index.d.ts
@@ -55,6 +55,12 @@ export declare function writeShoppingList(json: string): string
 export declare function parseChecked(text: string): string
 export declare function writeCheckEntry(entryJson: string): string
 export declare function checkedSet(entriesJson: string): Array<string>
+/**
+ * Resolve a recipe by name (with or without extension) inside `base_dir` using
+ * `cooklang-find`'s lookup rules (tries `.cook` then `.menu` when no extension).
+ * Returns the file content, or `null` if no matching file is found.
+ */
+export declare function findRecipe(baseDir: string, name: string): string | null
 export declare function compactChecked(entriesJson: string, currentIngredients: Array<string>): string
 export declare class LspServer {
   constructor()

--- a/packages/cooklang-native/index.js
+++ b/packages/cooklang-native/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged } = nativeBinding
+const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, compactChecked } = nativeBinding
 
 module.exports.parse = parse
 module.exports.generateShoppingList = generateShoppingList
@@ -320,3 +320,9 @@ module.exports.startSync = startSync
 module.exports.stopSync = stopSync
 module.exports.getSyncStatus = getSyncStatus
 module.exports.onSyncStatusChanged = onSyncStatusChanged
+module.exports.parseShoppingList = parseShoppingList
+module.exports.writeShoppingList = writeShoppingList
+module.exports.parseChecked = parseChecked
+module.exports.writeCheckEntry = writeCheckEntry
+module.exports.checkedSet = checkedSet
+module.exports.compactChecked = compactChecked

--- a/packages/cooklang-native/index.js
+++ b/packages/cooklang-native/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, compactChecked } = nativeBinding
+const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, compactChecked } = nativeBinding
 
 module.exports.parse = parse
 module.exports.generateShoppingList = generateShoppingList
@@ -325,4 +325,5 @@ module.exports.writeShoppingList = writeShoppingList
 module.exports.parseChecked = parseChecked
 module.exports.writeCheckEntry = writeCheckEntry
 module.exports.checkedSet = checkedSet
+module.exports.findRecipe = findRecipe
 module.exports.compactChecked = compactChecked

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 
+mod shopping_list;
+
 // ── Sync globals ─────────────────────────────────────────────────────────────
 
 /// Shared state that tracks the current sync status, updated by the listener.

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -801,3 +801,59 @@ pub fn on_sync_status_changed(callback: napi::JsFunction) -> napi::Result<()> {
     *cb = Some(tsfn);
     Ok(())
 }
+
+// ── Shopping list format (NAPI wrappers) ─────────────────────────────────────
+// Thin JSON-bridge wrappers around helpers in `shopping_list` module.
+// All functions are stateless; file I/O is performed by the TypeScript caller.
+
+#[napi(js_name = "parseShoppingList")]
+pub fn napi_parse_shopping_list(text: String) -> napi::Result<String> {
+    let list = shopping_list::parse_list(&text)
+        .map_err(|e| napi::Error::from_reason(format!("parse_shopping_list: {e}")))?;
+    serde_json::to_string(&list)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
+#[napi(js_name = "writeShoppingList")]
+pub fn napi_write_shopping_list(json: String) -> napi::Result<String> {
+    let list: cooklang::shopping_list::ShoppingList = serde_json::from_str(&json)
+        .map_err(|e| napi::Error::from_reason(format!("writeShoppingList parse json: {e}")))?;
+    shopping_list::write_list(&list)
+        .map_err(|e| napi::Error::from_reason(format!("writeShoppingList: {e}")))
+}
+
+#[napi(js_name = "parseChecked")]
+pub fn napi_parse_checked(text: String) -> napi::Result<String> {
+    let entries = shopping_list::parse_checked_log(&text);
+    serde_json::to_string(&entries)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}
+
+#[napi(js_name = "writeCheckEntry")]
+pub fn napi_write_check_entry(entry_json: String) -> napi::Result<String> {
+    let entry: cooklang::shopping_list::CheckEntry = serde_json::from_str(&entry_json)
+        .map_err(|e| napi::Error::from_reason(format!("writeCheckEntry parse json: {e}")))?;
+    shopping_list::write_checked_entry(&entry)
+        .map_err(|e| napi::Error::from_reason(format!("writeCheckEntry: {e}")))
+}
+
+#[napi(js_name = "checkedSet")]
+pub fn napi_checked_set(entries_json: String) -> napi::Result<Vec<String>> {
+    let entries: Vec<cooklang::shopping_list::CheckEntry> = serde_json::from_str(&entries_json)
+        .map_err(|e| napi::Error::from_reason(format!("checkedSet parse json: {e}")))?;
+    let set = shopping_list::checked_set_from_log(&entries);
+    Ok(set.into_iter().collect())
+}
+
+#[napi(js_name = "compactChecked")]
+pub fn napi_compact_checked(
+    entries_json: String,
+    current_ingredients: Vec<String>,
+) -> napi::Result<String> {
+    let entries: Vec<cooklang::shopping_list::CheckEntry> = serde_json::from_str(&entries_json)
+        .map_err(|e| napi::Error::from_reason(format!("compactChecked parse json: {e}")))?;
+    let refs: Vec<&str> = current_ingredients.iter().map(|s| s.as_str()).collect();
+    let compacted = shopping_list::compact_checked_log(&entries, refs);
+    serde_json::to_string(&compacted)
+        .map_err(|e| napi::Error::from_reason(e.to_string()))
+}

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -6,6 +6,8 @@ use tokio::sync::mpsc;
 
 mod shopping_list;
 
+use camino::Utf8PathBuf;
+
 // ── Sync globals ─────────────────────────────────────────────────────────────
 
 /// Shared state that tracks the current sync status, updated by the listener.
@@ -843,6 +845,23 @@ pub fn napi_checked_set(entries_json: String) -> napi::Result<Vec<String>> {
         .map_err(|e| napi::Error::from_reason(format!("checkedSet parse json: {e}")))?;
     let set = shopping_list::checked_set_from_log(&entries);
     Ok(set.into_iter().collect())
+}
+
+/// Resolve a recipe by name (with or without extension) inside `base_dir` using
+/// `cooklang-find`'s lookup rules (tries `.cook` then `.menu` when no extension).
+/// Returns the file content, or `null` if no matching file is found.
+#[napi(js_name = "findRecipe")]
+pub fn napi_find_recipe(base_dir: String, name: String) -> napi::Result<Option<String>> {
+    let base = Utf8PathBuf::from(base_dir);
+    let recipe_name = Utf8PathBuf::from(name);
+    match cooklang_find::get_recipe([base], recipe_name) {
+        Ok(entry) => entry
+            .content()
+            .map(Some)
+            .map_err(|e| napi::Error::from_reason(format!("findRecipe read: {e}"))),
+        Err(cooklang_find::fetcher::FetchError::InvalidPath(_)) => Ok(None),
+        Err(e) => Err(napi::Error::from_reason(format!("findRecipe: {e}"))),
+    }
 }
 
 #[napi(js_name = "compactChecked")]

--- a/packages/cooklang-native/src/shopping_list.rs
+++ b/packages/cooklang-native/src/shopping_list.rs
@@ -134,3 +134,46 @@ mod checked_tests {
         assert!(checked_set_from_log(&entries).is_empty());
     }
 }
+
+/// Return a compacted log: entries whose name is in `current_ingredients`
+/// (case-insensitive) are kept, others are dropped.
+///
+/// Delegates to cooklang-rs's `compact_checked`.
+pub fn compact_checked_log<'a, I>(
+    entries: &[CheckEntry],
+    current_ingredients: I,
+) -> Vec<CheckEntry>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    shopping_list::compact_checked(entries, current_ingredients)
+}
+
+#[cfg(test)]
+mod compact_tests {
+    use super::*;
+
+    #[test]
+    fn drops_entries_for_missing_ingredients() {
+        let entries = parse_checked_log("+ flour\n+ sugar\n+ milk\n");
+        let compacted = compact_checked_log(&entries, ["flour", "sugar"]);
+        let set = checked_set_from_log(&compacted);
+        assert!(set.contains("flour"));
+        assert!(set.contains("sugar"));
+        assert!(!set.contains("milk"));
+    }
+
+    #[test]
+    fn keeps_all_when_all_ingredients_present() {
+        let entries = parse_checked_log("+ flour\n+ sugar\n");
+        let compacted = compact_checked_log(&entries, ["flour", "sugar"]);
+        assert_eq!(compacted.len(), 2);
+    }
+
+    #[test]
+    fn empty_ingredients_drops_everything() {
+        let entries = parse_checked_log("+ flour\n");
+        let compacted = compact_checked_log(&entries, Vec::<&str>::new());
+        assert!(compacted.is_empty());
+    }
+}

--- a/packages/cooklang-native/src/shopping_list.rs
+++ b/packages/cooklang-native/src/shopping_list.rs
@@ -1,6 +1,7 @@
 //! Pure helpers around cooklang::shopping_list. No NAPI, no filesystem.
 
-use cooklang::shopping_list::{self, ShoppingList};
+use cooklang::shopping_list::{self, CheckEntry, ShoppingList};
+use std::collections::HashSet;
 
 /// Parse `.shopping-list` text → `ShoppingList`.
 pub fn parse_list(text: &str) -> Result<ShoppingList, String> {
@@ -12,6 +13,23 @@ pub fn write_list(list: &ShoppingList) -> Result<String, String> {
     let mut buf = Vec::new();
     shopping_list::write(list, &mut buf).map_err(|e| e.to_string())?;
     String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+/// Parse `.shopping-checked` text → list of log entries.
+pub fn parse_checked_log(text: &str) -> Vec<CheckEntry> {
+    shopping_list::parse_checked(text)
+}
+
+/// Serialize a single check entry to the line form used in `.shopping-checked`.
+pub fn write_checked_entry(entry: &CheckEntry) -> Result<String, String> {
+    let mut buf = Vec::new();
+    shopping_list::write_check_entry(entry, &mut buf).map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+/// Derive the set of currently-checked ingredient names (lowercased) from a log.
+pub fn checked_set_from_log(entries: &[CheckEntry]) -> HashSet<String> {
+    shopping_list::checked_set(entries)
 }
 
 #[cfg(test)]
@@ -72,5 +90,47 @@ mod tests {
         assert!(list.items.is_empty());
         let out = write_list(&list).expect("write");
         assert_eq!(out, "");
+    }
+}
+
+#[cfg(test)]
+mod checked_tests {
+    use super::*;
+
+    #[test]
+    fn last_write_wins_for_same_ingredient() {
+        let log_text = "+ flour\n- flour\n+ flour\n";
+        let entries = parse_checked_log(log_text);
+        let set = checked_set_from_log(&entries);
+        assert!(set.contains("flour"));
+
+        let log_text = "+ flour\n- flour\n";
+        let entries = parse_checked_log(log_text);
+        let set = checked_set_from_log(&entries);
+        assert!(!set.contains("flour"));
+    }
+
+    #[test]
+    fn entry_write_produces_parseable_line() {
+        let entry = CheckEntry::Checked("flour".into());
+        let line = write_checked_entry(&entry).unwrap();
+        let parsed = parse_checked_log(&line);
+        assert_eq!(parsed.len(), 1);
+        let set = checked_set_from_log(&parsed);
+        assert!(set.contains("flour"));
+    }
+
+    #[test]
+    fn checked_set_is_case_insensitive_lowercase() {
+        let entries = parse_checked_log("+ Flour\n");
+        let set = checked_set_from_log(&entries);
+        assert!(set.contains("flour"));
+    }
+
+    #[test]
+    fn empty_log_yields_empty_set() {
+        let entries = parse_checked_log("");
+        assert!(entries.is_empty());
+        assert!(checked_set_from_log(&entries).is_empty());
     }
 }

--- a/packages/cooklang-native/src/shopping_list.rs
+++ b/packages/cooklang-native/src/shopping_list.rs
@@ -1,0 +1,76 @@
+//! Pure helpers around cooklang::shopping_list. No NAPI, no filesystem.
+
+use cooklang::shopping_list::{self, ShoppingList};
+
+/// Parse `.shopping-list` text → `ShoppingList`.
+pub fn parse_list(text: &str) -> Result<ShoppingList, String> {
+    shopping_list::parse(text).map_err(|e| e.to_string())
+}
+
+/// Serialize `ShoppingList` → `.shopping-list` text.
+pub fn write_list(list: &ShoppingList) -> Result<String, String> {
+    let mut buf = Vec::new();
+    shopping_list::write(list, &mut buf).map_err(|e| e.to_string())?;
+    String::from_utf8(buf).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cooklang::shopping_list::ShoppingListItem;
+
+    #[test]
+    fn round_trips_single_ingredient() {
+        let text = "pasta\n";
+        let list = parse_list(text).expect("parse");
+        assert_eq!(list.items.len(), 1);
+        assert!(matches!(&list.items[0], ShoppingListItem::Ingredient(i) if i.name == "pasta"));
+        let out = write_list(&list).expect("write");
+        assert_eq!(out.trim(), "pasta");
+    }
+
+    #[test]
+    fn round_trips_recipe_with_multiplier() {
+        let text = "./pasta{2}\n";
+        let list = parse_list(text).expect("parse");
+        assert_eq!(list.items.len(), 1);
+        match &list.items[0] {
+            ShoppingListItem::Recipe(r) => {
+                assert_eq!(r.path, "pasta");
+                assert_eq!(r.multiplier, Some(2.0));
+            }
+            _ => panic!("expected recipe"),
+        }
+        let out = write_list(&list).expect("write");
+        assert!(out.contains("pasta"));
+        assert!(out.contains("2"));
+        // Round-trip parse-equals check
+        let reparsed = parse_list(&out).expect("reparse");
+        assert_eq!(reparsed, list);
+    }
+
+    #[test]
+    fn round_trips_nested_children() {
+        let text = "./menu/weekday{1}\n  ./pasta{1}\n  salad\n";
+        let list = parse_list(text).expect("parse");
+        assert_eq!(list.items.len(), 1);
+        match &list.items[0] {
+            ShoppingListItem::Recipe(r) => {
+                assert_eq!(r.path, "menu/weekday");
+                assert_eq!(r.children.len(), 2);
+            }
+            _ => panic!("expected recipe"),
+        }
+        let out = write_list(&list).expect("write");
+        let reparsed = parse_list(&out).expect("reparse");
+        assert_eq!(reparsed, list);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_list() {
+        let list = parse_list("").expect("parse");
+        assert!(list.items.is_empty());
+        let out = write_list(&list).expect("write");
+        assert_eq!(out, "");
+    }
+}

--- a/packages/cooklang/src/browser/shopping-list-components.tsx
+++ b/packages/cooklang/src/browser/shopping-list-components.tsx
@@ -3,30 +3,40 @@
 
 import * as React from '@theia/core/shared/react';
 import {
-    ShoppingListRecipe,
+    ShoppingListRecipeItem,
     ShoppingListResult,
     ShoppingListCategory,
     ShoppingListItem,
 } from '../common/shopping-list-types';
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Derive a human-friendly display name from a recipe path. */
+function displayNameFromPath(path: string): string {
+    const base = path.split('/').pop() ?? path;
+    return base.replace(/\.(cook|menu)$/i, '');
+}
+
+// ---------------------------------------------------------------------------
 // RecipeListPanel
 // ---------------------------------------------------------------------------
 
 interface RecipeListPanelProps {
-    recipes: readonly ShoppingListRecipe[];
+    items: readonly ShoppingListRecipeItem[];
     onRemove: (index: number) => void;
     onScaleChange: (index: number, scale: number) => void;
     onClearAll: () => void;
 }
 
 export const RecipeListPanel = ({
-    recipes,
+    items,
     onRemove,
     onScaleChange,
     onClearAll,
 }: RecipeListPanelProps): React.ReactElement => {
-    if (recipes.length === 0) {
+    if (items.length === 0) {
         return (
             <div className='shopping-list-empty-recipes'>
                 No recipes selected. Add recipes from the preview or explorer.
@@ -42,33 +52,45 @@ export const RecipeListPanel = ({
                     Clear All
                 </button>
             </div>
-            {recipes.map((recipe, idx) => (
-                <div key={recipe.path} className='shopping-list-recipe-row'>
-                    <span className='shopping-list-recipe-name'>{recipe.name}</span>
-                    <input
-                        className='shopping-list-scale-input'
-                        type='number'
-                        min='0.5'
-                        max='100'
-                        step='0.5'
-                        defaultValue={recipe.scale}
-                        onBlur={e => {
-                            const val = parseFloat(e.target.value);
-                            if (!isNaN(val) && val > 0) {
-                                onScaleChange(idx, val);
-                            }
-                        }}
-                        title='Scale factor'
-                    />
-                    <button
-                        className='shopping-list-remove-btn'
-                        onClick={() => onRemove(idx)}
-                        title='Remove from shopping list'
-                    >
-                        x
-                    </button>
-                </div>
-            ))}
+            {items.map((item, idx) => {
+                const name = displayNameFromPath(item.path);
+                const isMenu = item.children.length > 0 && item.path.toLowerCase().endsWith('.menu');
+                const scale = item.multiplier ?? 1;
+                return (
+                    <div key={`${item.path}-${idx}`} className='shopping-list-recipe-row'>
+                        <div className='shopping-list-recipe-main'>
+                            <span className='shopping-list-recipe-name'>{name}</span>
+                            {isMenu && (
+                                <span className='shopping-list-recipe-sub'>
+                                    menu ({item.children.length} recipes)
+                                </span>
+                            )}
+                        </div>
+                        <input
+                            className='shopping-list-scale-input'
+                            type='number'
+                            min='0.5'
+                            max='100'
+                            step='0.5'
+                            defaultValue={scale}
+                            onBlur={e => {
+                                const val = parseFloat(e.target.value);
+                                if (!isNaN(val) && val > 0) {
+                                    onScaleChange(idx, val);
+                                }
+                            }}
+                            title='Scale factor'
+                        />
+                        <button
+                            className='shopping-list-remove-btn'
+                            onClick={() => onRemove(idx)}
+                            title='Remove from shopping list'
+                        >
+                            x
+                        </button>
+                    </div>
+                );
+            })}
         </div>
     );
 };
@@ -114,10 +136,7 @@ export const CategorySection = ({
     checkedItems,
     onToggle,
 }: CategorySectionProps): React.ReactElement | null => {
-    if (category.items.length === 0) {
-        return null;
-    }
-
+    if (category.items.length === 0) { return null; }
     return (
         <div className='shopping-list-category'>
             <h3 className='shopping-list-category-header'>{category.name}</h3>
@@ -134,7 +153,7 @@ export const CategorySection = ({
 };
 
 // ---------------------------------------------------------------------------
-// PantrySection
+// PantrySection (unchanged)
 // ---------------------------------------------------------------------------
 
 interface PantrySectionProps {
@@ -143,11 +162,7 @@ interface PantrySectionProps {
 
 export const PantrySection = ({ pantryItems }: PantrySectionProps): React.ReactElement | null => {
     const [expanded, setExpanded] = React.useState(false);
-
-    if (pantryItems.length === 0) {
-        return null;
-    }
-
+    if (pantryItems.length === 0) { return null; }
     return (
         <div className='shopping-list-pantry'>
             <button
@@ -172,7 +187,7 @@ export const PantrySection = ({ pantryItems }: PantrySectionProps): React.ReactE
 // ---------------------------------------------------------------------------
 
 export interface ShoppingListViewProps {
-    recipes: readonly ShoppingListRecipe[];
+    items: readonly ShoppingListRecipeItem[];
     result: ShoppingListResult | undefined;
     checkedItems: Set<string>;
     onRemoveRecipe: (index: number) => void;
@@ -182,7 +197,7 @@ export interface ShoppingListViewProps {
 }
 
 export const ShoppingListView = ({
-    recipes,
+    items,
     result,
     checkedItems,
     onRemoveRecipe,
@@ -192,12 +207,11 @@ export const ShoppingListView = ({
 }: ShoppingListViewProps): React.ReactElement => (
     <div className='shopping-list-content'>
         <RecipeListPanel
-            recipes={recipes}
+            items={items}
             onRemove={onRemoveRecipe}
             onScaleChange={onScaleChange}
             onClearAll={onClearAll}
         />
-
         {result && (
             <>
                 {result.categories.map(category => (
@@ -208,7 +222,6 @@ export const ShoppingListView = ({
                         onToggle={onToggleItem}
                     />
                 ))}
-
                 {result.other.items.length > 0 && (
                     <CategorySection
                         key='other'
@@ -217,7 +230,6 @@ export const ShoppingListView = ({
                         onToggle={onToggleItem}
                     />
                 )}
-
                 <PantrySection pantryItems={result.pantryItems} />
             </>
         )}

--- a/packages/cooklang/src/browser/shopping-list-contribution.ts
+++ b/packages/cooklang/src/browser/shopping-list-contribution.ts
@@ -240,7 +240,10 @@ export class ShoppingListContribution
             return;
         }
 
-        let parsed: { sections?: Array<{ lines?: Array<Array<{ kind?: string; name?: string; path?: string; scale?: number }>> }> };
+        // Menu JSON shape from `parse_menu` in packages/cooklang-native/src/lib.rs:
+        // items are tagged by `type`: "text" | "recipeReference" | "ingredient".
+        // Only "recipeReference" items are real recipe references.
+        let parsed: { sections?: Array<{ lines?: Array<Array<{ type?: string; name?: string; scale?: number }>> }> };
         try {
             parsed = JSON.parse(await this.languageService.parseMenu(menuContent, 1));
         } catch (e) {
@@ -252,11 +255,10 @@ export class ShoppingListContribution
         for (const section of parsed.sections ?? []) {
             for (const line of section.lines ?? []) {
                 for (const item of line) {
-                    const refPath = item.path ?? item.name;
-                    if (!refPath) { continue; }
-                    if (item.kind && item.kind !== 'recipe-reference' && item.kind !== 'recipeReference') { continue; }
+                    if (item.type !== 'recipeReference') { continue; }
+                    if (!item.name) { continue; }
                     recipes.push({
-                        path: refPath.replace(/^\.\//, ''),
+                        path: item.name.replace(/^\.\//, ''),
                         scale: typeof item.scale === 'number' && item.scale > 0 ? item.scale : 1,
                     });
                 }

--- a/packages/cooklang/src/browser/shopping-list-contribution.ts
+++ b/packages/cooklang/src/browser/shopping-list-contribution.ts
@@ -14,9 +14,11 @@ import { NavigatableWidget } from '@theia/core/lib/browser/navigatable-types';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import URI from '@theia/core/lib/common/uri';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { ShoppingListWidget, SHOPPING_LIST_WIDGET_ID } from './shopping-list-widget';
 import { ShoppingListService } from './shopping-list-service';
 import { COOKLANG_LANGUAGE_ID } from '../common';
+import { CooklangLanguageService } from '../common/cooklang-language-service';
 
 // ---------------------------------------------------------------------------
 // Commands
@@ -30,6 +32,11 @@ export namespace ShoppingListCommands {
     export const ADD_TO_LIST: Command = {
         id: 'cooklang.addToShoppingList',
         label: 'Cooklang: Add to Shopping List',
+        iconClass: 'theia-shopping-cart-icon',
+    };
+    export const ADD_MENU_TO_LIST: Command = {
+        id: 'cooklang.addMenuToShoppingList',
+        label: 'Cooklang: Add Menu to Shopping List',
         iconClass: 'theia-shopping-cart-icon',
     };
 }
@@ -51,6 +58,12 @@ export class ShoppingListContribution
 
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(CooklangLanguageService)
+    protected readonly languageService: CooklangLanguageService;
 
     constructor() {
         super({
@@ -74,6 +87,11 @@ export class ShoppingListContribution
             isEnabled: (...args: unknown[]) => this.canAddRecipe(args),
             isVisible: (...args: unknown[]) => this.canAddRecipe(args),
         });
+        commands.registerCommand(ShoppingListCommands.ADD_MENU_TO_LIST, {
+            execute: (...args: unknown[]) => this.addMenu(args),
+            isEnabled: (...args: unknown[]) => this.canAddMenu(args),
+            isVisible: (...args: unknown[]) => this.canAddMenu(args),
+        });
     }
 
     override registerMenus(menus: MenuModelRegistry): void {
@@ -84,6 +102,11 @@ export class ShoppingListContribution
             label: 'Add to Shopping List',
             when: 'resourceExtname == .cook',
         });
+        menus.registerMenuAction(NavigatorContextMenu.NAVIGATION, {
+            commandId: ShoppingListCommands.ADD_MENU_TO_LIST.id,
+            label: 'Add Menu to Shopping List',
+            when: 'resourceExtname == .menu',
+        });
     }
 
     registerToolbarItems(toolbar: TabBarToolbarRegistry): void {
@@ -93,6 +116,12 @@ export class ShoppingListContribution
             command: ShoppingListCommands.ADD_TO_LIST.id,
             tooltip: 'Add to Shopping List',
             when: `editorLangId == ${COOKLANG_LANGUAGE_ID}`,
+        });
+        toolbar.registerItem({
+            id: ShoppingListCommands.ADD_MENU_TO_LIST.id + '.editor',
+            command: ShoppingListCommands.ADD_MENU_TO_LIST.id,
+            tooltip: 'Add Menu to Shopping List',
+            when: `resourceExtname == .menu`,
         });
     }
 
@@ -154,18 +183,92 @@ export class ShoppingListContribution
 
     protected async addRecipe(args: unknown[] = []): Promise<void> {
         const targetUri = this.resolveTargetUri(args);
-        if (!targetUri) {
-            return;
-        }
+        if (!targetUri) { return; }
 
         const scale = this.resolveScale(args);
-        const name = targetUri.path.base.replace(/\.cook$/i, '');
         const workspaceRoot = this.shoppingListService.getWorkspaceRootUri();
         const relativePath = workspaceRoot
             ? workspaceRoot.relative(targetUri)?.toString() ?? targetUri.path.base
             : targetUri.path.base;
 
-        await this.shoppingListService.addRecipe(relativePath, name, scale);
+        await this.shoppingListService.addRecipe(relativePath, scale);
+        await this.openView({ activate: true });
+    }
+
+    protected resolveMenuUri(args: unknown[]): URI | undefined {
+        if (args.length > 0 && args[0] instanceof URI) {
+            const uri = args[0] as URI;
+            if (uri.path.ext === '.menu') { return uri; }
+        }
+        if (args.length > 0 && NavigatableWidget.is(args[0])) {
+            const uri = (args[0] as NavigatableWidget).getResourceUri();
+            if (uri && uri.path.ext === '.menu') { return uri; }
+        }
+        const selection = this.selectionService.selection;
+        const selectedUri = UriSelection.getUri(selection);
+        if (selectedUri && selectedUri.path.ext === '.menu') { return selectedUri; }
+        const currentWidget = this.shell?.currentWidget;
+        if (NavigatableWidget.is(currentWidget)) {
+            const uri = currentWidget.getResourceUri();
+            if (uri && uri.path.ext === '.menu') { return uri; }
+        }
+        return undefined;
+    }
+
+    protected canAddMenu(args: unknown[] = []): boolean {
+        return this.resolveMenuUri(args) !== undefined;
+    }
+
+    protected async addMenu(args: unknown[] = []): Promise<void> {
+        const menuUri = this.resolveMenuUri(args);
+        if (!menuUri) { return; }
+
+        const workspaceRoot = this.shoppingListService.getWorkspaceRootUri();
+        const relativePath = workspaceRoot
+            ? workspaceRoot.relative(menuUri)?.toString() ?? menuUri.path.base
+            : menuUri.path.base;
+
+        // Parse the menu to enumerate referenced recipes.
+        let menuContent: string;
+        try {
+            const root = this.shoppingListService.getWorkspaceRootUri();
+            if (!root) { return; }
+            const content = await this.fileService.read(root.resolve(relativePath));
+            menuContent = content.value;
+        } catch (e) {
+            console.error('[shopping-list] Failed to read menu file:', e);
+            return;
+        }
+
+        let parsed: { sections?: Array<{ lines?: Array<Array<{ kind?: string; name?: string; path?: string; scale?: number }>> }> };
+        try {
+            parsed = JSON.parse(await this.languageService.parseMenu(menuContent, 1));
+        } catch (e) {
+            console.error('[shopping-list] Failed to parse menu:', e);
+            return;
+        }
+
+        const recipes: Array<{ path: string; scale: number; includedRefs?: string[] }> = [];
+        for (const section of parsed.sections ?? []) {
+            for (const line of section.lines ?? []) {
+                for (const item of line) {
+                    const refPath = item.path ?? item.name;
+                    if (!refPath) { continue; }
+                    if (item.kind && item.kind !== 'recipe-reference' && item.kind !== 'recipeReference') { continue; }
+                    recipes.push({
+                        path: refPath.replace(/^\.\//, ''),
+                        scale: typeof item.scale === 'number' && item.scale > 0 ? item.scale : 1,
+                    });
+                }
+            }
+        }
+
+        if (recipes.length === 0) {
+            console.warn('[shopping-list] Menu contained no recipe references:', relativePath);
+            return;
+        }
+
+        await this.shoppingListService.addMenu(relativePath, 1, recipes);
         await this.openView({ activate: true });
     }
 }

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -9,6 +9,7 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { ShoppingListService } from './shopping-list-service';
 import { ShoppingListRecipeItem } from '../common/shopping-list-types';
 
@@ -112,7 +113,7 @@ function makeService(): { svc: ShoppingListService; fs: FakeFileService; ls: Fak
     (svc as any).fileService = fs;
     (svc as any).languageService = ls;
     (svc as any).workspaceService = ws;
-    (svc as any).toDispose = { push: (): void => {} };
+    (svc as any).toDispose = new DisposableCollection();
     /* eslint-enable @typescript-eslint/no-explicit-any */
     return { svc, fs, ls };
 }
@@ -122,7 +123,7 @@ describe('ShoppingListService', () => {
         const { svc, fs } = makeService();
         await svc.addRecipe('pasta.cook', 1);
         expect(svc.getItems().length).to.equal(1);
-        expect(fs.files.get('file:///ws/.shopping-list')).to.contain('pasta.cook');
+        expect(fs.files.get('file:///ws/.shopping-list')).to.equal('pasta.cook\n');
     });
 
     it('addMenu creates a nested structure', async () => {
@@ -141,7 +142,7 @@ describe('ShoppingListService', () => {
         const { svc, fs } = makeService();
         await svc.checkItem('Flour');
         expect(svc.isChecked('flour')).to.equal(true);
-        expect(fs.files.get('file:///ws/.shopping-checked')).to.contain('+ Flour');
+        expect(fs.files.get('file:///ws/.shopping-checked')).to.equal('+ Flour\n');
     });
 
     it('uncheckItem reverses a prior check', async () => {
@@ -192,5 +193,6 @@ describe('ShoppingListService', () => {
         await svc.removeRecipe(1);
         const checkedContent = fs.files.get('file:///ws/.shopping-checked') ?? '';
         expect(checkedContent.includes('milk')).to.equal(false);
+        expect(checkedContent.includes('+ flour')).to.equal(true);
     });
 });

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -50,6 +50,11 @@ class FakeWorkspaceService {
  * the wire inside its helpers.
  */
 class FakeLanguageService {
+    /** Recipe content keyed by name (with or without extension). */
+    recipes = new Map<string, string>();
+    async findRecipe(_baseDir: string, name: string): Promise<string | undefined> {
+        return this.recipes.get(name) ?? this.recipes.get(`${name}.cook`);
+    }
     async parseShoppingList(text: string): Promise<string> {
         const items: WireShoppingItem[] = text
             .split('\n')
@@ -164,10 +169,12 @@ describe('ShoppingListService', () => {
 
     it('removeRecipe compacts stale checks', async () => {
         const { svc, fs, ls } = makeService();
-        // Seed recipe files so `regenerate()` can read them and the mock LS
-        // can decide its output based on which recipes are still present.
-        fs.files.set('file:///ws/pasta.cook', 'pasta');
-        fs.files.set('file:///ws/bread.cook', 'bread');
+        // Seed recipe content via the language service (which now resolves
+        // recipes through cooklang-find on the backend) so `regenerate()` can
+        // read them and the mock LS can decide its output based on which
+        // recipes are still present.
+        ls.recipes.set('pasta.cook', 'pasta');
+        ls.recipes.set('bread.cook', 'bread');
         ls.generateShoppingList = async recipesJson => {
             const recipes: Array<{ content: string; scale: number }> = JSON.parse(recipesJson);
             // `milk` is only present while bread.cook is in the list.
@@ -187,6 +194,7 @@ describe('ShoppingListService', () => {
         // `compactCheckedLog()` runs, pruning the stale `milk` entry.
         await svc.addRecipe('pasta.cook', 1);
         await svc.addRecipe('bread.cook', 1);
+        await svc.checkItem('flour');
         await svc.checkItem('milk');
         expect(svc.isChecked('milk')).to.equal(true);
 

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -1,0 +1,196 @@
+// Copyright (C) 2026 Cooklang contributors
+// SPDX-License-Identifier: MIT
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { ShoppingListService } from './shopping-list-service';
+import { ShoppingListRecipeItem } from '../common/shopping-list-types';
+
+after(() => disableJSDOM());
+
+// ── Wire shapes (mirror `packages/cooklang/src/common/shopping-list-types.ts`)
+type WireShoppingItem = { Recipe: { path: string; multiplier: number | null; children: WireShoppingItem[] } };
+type WireCheckEntry = { Checked: string } | { Unchecked: string };
+
+/** Minimal in-memory FileService stub — only the methods the service calls. */
+class FakeFileService {
+    files = new Map<string, string>();
+    async read(uri: { toString(): string }): Promise<{ value: string }> {
+        const key = uri.toString();
+        if (!this.files.has(key)) { throw new Error('ENOENT'); }
+        return { value: this.files.get(key)! };
+    }
+    async write(uri: { toString(): string }, content: string): Promise<void> {
+        this.files.set(uri.toString(), content);
+    }
+    async delete(uri: { toString(): string }): Promise<void> {
+        this.files.delete(uri.toString());
+    }
+}
+
+/** FakeWorkspaceService with a single root. */
+class FakeWorkspaceService {
+    roots = Promise.resolve([{ resource: { toString: () => 'file:///ws' } }]);
+    tryGetRoots(): Array<{ resource: { toString: () => string } }> {
+        return [{ resource: { toString: () => 'file:///ws' } }];
+    }
+}
+
+/**
+ * FakeCooklangLanguageService — emits/consumes the SAME wire JSON shape that the
+ * real Rust NAPI produces (externally-tagged). `CheckEntry` / `ShoppingListFile`
+ * in the assertions remain the internal shape because the service marshals to/from
+ * the wire inside its helpers.
+ */
+class FakeLanguageService {
+    async parseShoppingList(text: string): Promise<string> {
+        const items: WireShoppingItem[] = text
+            .split('\n')
+            .filter(l => l.trim().length > 0)
+            .map(l => ({ Recipe: { path: l.trim(), multiplier: null, children: [] } }));
+        return JSON.stringify({ items });
+    }
+    async writeShoppingList(json: string): Promise<string> {
+        const list: { items: WireShoppingItem[] } = JSON.parse(json);
+        return list.items.map(i => i.Recipe.path).join('\n') + (list.items.length > 0 ? '\n' : '');
+    }
+    async parseChecked(text: string): Promise<string> {
+        const entries: WireCheckEntry[] = [];
+        for (const line of text.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('+ ')) { entries.push({ Checked: trimmed.slice(2) }); }
+            else if (trimmed.startsWith('- ')) { entries.push({ Unchecked: trimmed.slice(2) }); }
+        }
+        return JSON.stringify(entries);
+    }
+    async writeCheckEntry(entryJson: string): Promise<string> {
+        const entry: WireCheckEntry = JSON.parse(entryJson);
+        return ('Checked' in entry ? '+ ' + entry.Checked : '- ' + entry.Unchecked) + '\n';
+    }
+    async checkedSet(entriesJson: string): Promise<string[]> {
+        const entries: WireCheckEntry[] = JSON.parse(entriesJson);
+        const set = new Set<string>();
+        for (const e of entries) {
+            if ('Checked' in e) { set.add(e.Checked.toLowerCase()); }
+            else { set.delete(e.Unchecked.toLowerCase()); }
+        }
+        return [...set];
+    }
+    async compactChecked(entriesJson: string, names: string[]): Promise<string> {
+        const entries: WireCheckEntry[] = JSON.parse(entriesJson);
+        const lc = new Set(names.map(n => n.toLowerCase()));
+        return JSON.stringify(entries.filter(e => lc.has(('Checked' in e ? e.Checked : e.Unchecked).toLowerCase())));
+    }
+    // Unused by the tested paths but required by the service interface.
+    async generateShoppingList(_recipes: string, _a: string | null, _p: string | null): Promise<string> {
+        return JSON.stringify({
+            categories: [],
+            other: { name: 'other', items: [{ name: 'flour', quantities: '' }] },
+            pantryItems: [],
+        });
+    }
+    async parse(_c: string): Promise<string> { return '{}'; }
+    async parseMenu(_c: string, _s: number): Promise<string> { return '{}'; }
+}
+
+/**
+ * Construct a ShoppingListService with injected fakes. We bypass Inversify and
+ * set protected fields directly — simpler than wiring a test container.
+ */
+function makeService(): { svc: ShoppingListService; fs: FakeFileService; ls: FakeLanguageService } {
+    const fs = new FakeFileService();
+    const ls = new FakeLanguageService();
+    const ws = new FakeWorkspaceService();
+    const svc = new ShoppingListService();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (svc as any).fileService = fs;
+    (svc as any).languageService = ls;
+    (svc as any).workspaceService = ws;
+    (svc as any).toDispose = { push: (): void => {} };
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return { svc, fs, ls };
+}
+
+describe('ShoppingListService', () => {
+    it('addRecipe appends to list and persists', async () => {
+        const { svc, fs } = makeService();
+        await svc.addRecipe('pasta.cook', 1);
+        expect(svc.getItems().length).to.equal(1);
+        expect(fs.files.get('file:///ws/.shopping-list')).to.contain('pasta.cook');
+    });
+
+    it('addMenu creates a nested structure', async () => {
+        const { svc } = makeService();
+        await svc.addMenu('weekday.menu', 1, [
+            { path: 'pasta.cook', scale: 1 },
+            { path: 'salad.cook', scale: 2 },
+        ]);
+        const items = svc.getItems() as readonly ShoppingListRecipeItem[];
+        expect(items.length).to.equal(1);
+        expect(items[0].children.length).to.equal(2);
+        expect(items[0].children[1].multiplier).to.equal(2);
+    });
+
+    it('checkItem appends to .shopping-checked and updates the set', async () => {
+        const { svc, fs } = makeService();
+        await svc.checkItem('Flour');
+        expect(svc.isChecked('flour')).to.equal(true);
+        expect(fs.files.get('file:///ws/.shopping-checked')).to.contain('+ Flour');
+    });
+
+    it('uncheckItem reverses a prior check', async () => {
+        const { svc } = makeService();
+        await svc.checkItem('flour');
+        await svc.uncheckItem('flour');
+        expect(svc.isChecked('flour')).to.equal(false);
+    });
+
+    it('clearAll deletes both files', async () => {
+        const { svc, fs } = makeService();
+        await svc.addRecipe('pasta.cook', 1);
+        await svc.checkItem('flour');
+        await svc.clearAll();
+        expect(fs.files.has('file:///ws/.shopping-list')).to.equal(false);
+        expect(fs.files.has('file:///ws/.shopping-checked')).to.equal(false);
+        expect(svc.getItems().length).to.equal(0);
+    });
+
+    it('removeRecipe compacts stale checks', async () => {
+        const { svc, fs, ls } = makeService();
+        // Seed recipe files so `regenerate()` can read them and the mock LS
+        // can decide its output based on which recipes are still present.
+        fs.files.set('file:///ws/pasta.cook', 'pasta');
+        fs.files.set('file:///ws/bread.cook', 'bread');
+        ls.generateShoppingList = async recipesJson => {
+            const recipes: Array<{ content: string; scale: number }> = JSON.parse(recipesJson);
+            // `milk` is only present while bread.cook is in the list.
+            const hasBread = recipes.some(r => r.content === 'bread');
+            const items = hasBread
+                ? [{ name: 'flour', quantities: '' }, { name: 'milk', quantities: '' }]
+                : [{ name: 'flour', quantities: '' }];
+            return JSON.stringify({
+                categories: [],
+                other: { name: 'other', items },
+                pantryItems: [],
+            });
+        };
+
+        // Two recipes: removing the one that contributes `milk` leaves a
+        // non-empty list so `regenerate()` produces a `result` and
+        // `compactCheckedLog()` runs, pruning the stale `milk` entry.
+        await svc.addRecipe('pasta.cook', 1);
+        await svc.addRecipe('bread.cook', 1);
+        await svc.checkItem('milk');
+        expect(svc.isChecked('milk')).to.equal(true);
+
+        await svc.removeRecipe(1);
+        const checkedContent = fs.files.get('file:///ws/.shopping-checked') ?? '';
+        expect(checkedContent.includes('milk')).to.equal(false);
+    });
+});

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -289,13 +289,17 @@ export class ShoppingListService implements Disposable {
         } catch {
             existing = '';
         }
-        const next = existing + (existing.endsWith('\n') || existing.length === 0 ? '' : '\n') + line;
-        await this.fileService.write(root.resolve(CHECKED_FILE), next);
+        // `line` always ends with '\n' (upstream Rust uses writeln!).
+        await this.fileService.write(root.resolve(CHECKED_FILE), existing + line);
 
-        // Update in-memory state
+        // Update in-memory state locally — cooklang-rs normalizes names to lowercase.
         this.checkedLog.push(entry);
-        const setArr = await this.languageService.checkedSet(toWireCheckedLog(this.checkedLog));
-        this.checkedSet = new Set(setArr.map(s => s.toLowerCase()));
+        const key = entry.name.toLowerCase();
+        if (entry.type === 'checked') {
+            this.checkedSet.add(key);
+        } else {
+            this.checkedSet.delete(key);
+        }
         this.onDidChangeEmitter.fire();
     }
 
@@ -327,28 +331,34 @@ export class ShoppingListService implements Disposable {
         );
         const compacted: CheckEntry[] = fromWireCheckedLog(compactedJson);
 
-        // If nothing changed, skip the write.
-        if (compacted.length === this.checkedLog.length) { return; }
-        this.checkedLog = compacted;
-
         // Serialize each entry back to a line, join, write.
+        // Every line ends with '\n' (upstream Rust uses writeln!).
         const lines: string[] = [];
         for (const entry of compacted) {
             lines.push(await this.languageService.writeCheckEntry(toWireCheckEntryJson(entry)));
         }
-        const text = lines.length > 0 ? lines.join('') : '';
+        const text = lines.join('');
         if (text.length === 0) {
             try { await this.fileService.delete(root.resolve(CHECKED_FILE)); } catch { /* already gone */ }
         } else {
-            // writeCheckEntry already emits a trailing newline per entry; if it
-            // doesn't, ensure separation:
-            const needsNewlines = !lines.every(l => l.endsWith('\n'));
-            const joined = needsNewlines ? lines.join('\n') + '\n' : text;
-            await this.fileService.write(root.resolve(CHECKED_FILE), joined);
+            await this.fileService.write(root.resolve(CHECKED_FILE), text);
         }
 
-        // Rebuild in-memory set
-        const setArr = await this.languageService.checkedSet(compactedJson);
-        this.checkedSet = new Set(setArr.map(s => s.toLowerCase()));
+        // Persist to memory only after successful write/delete.
+        this.checkedLog = compacted;
+
+        // Rebuild in-memory set locally — cooklang-rs normalizes names to lowercase.
+        const rebuilt = new Set<string>();
+        for (const entry of compacted) {
+            const key = entry.name.toLowerCase();
+            if (entry.type === 'checked') {
+                rebuilt.add(key);
+            } else {
+                rebuilt.delete(key);
+            }
+        }
+        this.checkedSet = rebuilt;
+
+        this.onDidChangeEmitter.fire();
     }
 }

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -303,11 +303,35 @@ export class ShoppingListService implements Disposable {
         this.onDidChangeEmitter.fire();
     }
 
+    /**
+     * Adds a menu as a single top-level item with nested recipe children.
+     * Each child recipe may itself have sub-recipe references as grandchildren.
+     */
     async addMenu(
-        _menuPath: string,
-        _menuScale: number,
-        _recipes: Array<{ path: string; scale: number; includedRefs?: string[] }>,
-    ): Promise<void> { /* Task 11 */ }
+        menuPath: string,
+        menuScale: number,
+        recipes: Array<{ path: string; scale: number; includedRefs?: string[] }>,
+    ): Promise<void> {
+        const children: ShoppingListRecipeItem[] = recipes.map(r => ({
+            type: 'recipe',
+            path: r.path,
+            multiplier: r.scale === 1 ? undefined : r.scale,
+            children: (r.includedRefs ?? []).map(p => ({
+                type: 'recipe',
+                path: p.replace(/^\.\//, ''),
+                multiplier: undefined,
+                children: [],
+            })),
+        }));
+        this.list.items.push({
+            type: 'recipe',
+            path: menuPath,
+            multiplier: menuScale === 1 ? undefined : menuScale,
+            children,
+        });
+        await this.saveList();
+        await this.regenerate();
+    }
 
     /**
      * Rewrite `.shopping-checked` keeping only entries whose ingredient name

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -193,9 +193,11 @@ export class ShoppingListService implements Disposable {
             if (seq !== this.regenerationSeq) { return; }
             this.result = JSON.parse(json);
         } catch (e) {
+            if (seq !== this.regenerationSeq) { return; }
             console.error('[shopping-list] Failed to generate shopping list:', e);
             this.result = undefined;
         }
+        if (seq !== this.regenerationSeq) { return; }
         this.onDidChangeEmitter.fire();
     }
 
@@ -239,6 +241,8 @@ export class ShoppingListService implements Disposable {
     }
 
     async clearAll(): Promise<void> {
+        // Invalidate any in-flight regenerate() so it won't overwrite state after we reset.
+        ++this.regenerationSeq;
         this.list = { items: [] };
         this.checkedLog = [];
         this.checkedSet.clear();

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -8,14 +8,26 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { CooklangLanguageService } from '../common/cooklang-language-service';
-import { ShoppingListRecipe, ShoppingListResult } from '../common/shopping-list-types';
+import {
+    ShoppingListFile,
+    ShoppingListRecipeItem,
+    CheckEntry,
+    ShoppingListResult,
+    fromWireShoppingList,
+    fromWireCheckedLog,
+    toWireShoppingList,
+} from '../common/shopping-list-types';
+
+const LIST_FILE = '.shopping-list';
+const CHECKED_FILE = '.shopping-checked';
 
 /**
- * Manages the shopping list state: the set of recipes contributing to the list,
- * the aggregated result from the backend, and which items have been checked off.
+ * Manages the shopping list using the new cooklang `.shopping-list` format
+ * plus a `.shopping-checked` append-only log.
  *
- * Persists the recipe list to `.shopping_list.txt` in the workspace root so that
- * it survives application restarts.
+ * All format parse/serialize is delegated to the Rust NAPI backend via
+ * CooklangLanguageService RPC. File I/O uses Theia FileService so remote /
+ * virtual workspaces work transparently.
  */
 @injectable()
 export class ShoppingListService implements Disposable {
@@ -30,249 +42,90 @@ export class ShoppingListService implements Disposable {
     protected readonly workspaceService: WorkspaceService;
 
     protected readonly toDispose = new DisposableCollection();
-    protected recipes: ShoppingListRecipe[] = [];
+    protected list: ShoppingListFile = { items: [] };
+    protected checkedLog: CheckEntry[] = [];
+    protected checkedSet = new Set<string>();
     protected result: ShoppingListResult | undefined;
-    protected checkedItems = new Set<string>();
     protected regenerationSeq = 0;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
-
-    /** Fired whenever the recipe list, result, or checked-item state changes. */
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
 
     @postConstruct()
     protected init(): void {
         this.toDispose.push(this.onDidChangeEmitter);
-        this.workspaceService.roots.then(() => this.loadFromFile());
+        this.workspaceService.roots.then(() => this.loadFromDisk());
     }
 
-    /** Returns the current ordered list of recipes. */
-    getRecipes(): readonly ShoppingListRecipe[] {
-        return this.recipes;
+    // -- Public getters --
+
+    getItems(): readonly ShoppingListRecipeItem[] {
+        return this.list.items;
     }
 
-    /** Returns the most recently generated shopping list result, or `undefined` if not yet generated. */
     getResult(): ShoppingListResult | undefined {
         return this.result;
     }
 
-    /** Returns `true` if the ingredient with the given name has been checked off. */
     isChecked(ingredientName: string): boolean {
-        return this.checkedItems.has(ingredientName);
+        // cooklang-rs normalizes to lowercase for the checked set
+        return this.checkedSet.has(ingredientName.toLowerCase());
     }
 
-    /**
-     * Toggles the checked state of an ingredient and fires `onDidChange`.
-     * Checked state is intentionally not persisted — it is ephemeral per session.
-     */
-    toggleChecked(ingredientName: string): void {
-        if (this.checkedItems.has(ingredientName)) {
-            this.checkedItems.delete(ingredientName);
-        } else {
-            this.checkedItems.add(ingredientName);
-        }
-        this.onDidChangeEmitter.fire();
-    }
-
-    /**
-     * Adds a recipe to the list, persists the updated list, and regenerates the
-     * shopping list via RPC.
-     */
-    async addRecipe(path: string, name: string, scale: number = 1): Promise<void> {
-        this.recipes.push({ path, name, scale });
-        await this.saveToFile();
-        await this.regenerate();
-    }
-
-    /**
-     * Removes the recipe at `index` from the list, persists, and regenerates.
-     * Does nothing when the index is out of range.
-     */
-    async removeRecipe(index: number): Promise<void> {
-        if (index >= 0 && index < this.recipes.length) {
-            this.recipes.splice(index, 1);
-            await this.saveToFile();
-            await this.regenerate();
-        }
-    }
-
-    /**
-     * Updates the scale factor for the recipe at `index`, persists, and regenerates.
-     * Does nothing when the index is out of range.
-     */
-    async updateScale(index: number, scale: number): Promise<void> {
-        if (index >= 0 && index < this.recipes.length) {
-            this.recipes[index].scale = scale;
-            await this.saveToFile();
-            await this.regenerate();
-        }
-    }
-
-    /**
-     * Removes all recipes, clears the result and checked items, persists the empty
-     * state, and fires `onDidChange`.
-     */
-    async clearAll(): Promise<void> {
-        this.recipes = [];
-        this.result = undefined;
-        this.checkedItems.clear();
-        await this.saveToFile();
-        this.onDidChangeEmitter.fire();
-    }
-
-    /**
-     * Reads recipe file contents from disk, calls the backend RPC to generate the
-     * aggregated shopping list, stores the result, and fires `onDidChange`.
-     *
-     * Silently skips recipes whose files cannot be read (e.g. deleted from disk).
-     */
-    async regenerate(): Promise<void> {
-        const seq = ++this.regenerationSeq;
-
-        if (this.recipes.length === 0) {
-            this.result = undefined;
-            this.onDidChangeEmitter.fire();
-            return;
-        }
-
-        const rootUri = this.getWorkspaceRootUri();
-        if (!rootUri) {
-            return;
-        }
-
-        const recipeInputs: Array<{ content: string; scale: number }> = [];
-        for (const recipe of this.recipes) {
-            try {
-                const fileUri = rootUri.resolve(recipe.path);
-                const content = await this.fileService.read(fileUri);
-                recipeInputs.push({ content: content.value, scale: recipe.scale });
-            } catch (e) {
-                console.warn(`[shopping-list] Failed to read recipe ${recipe.path}:`, e);
-            }
-        }
-
-        if (seq !== this.regenerationSeq) {
-            return;
-        }
-
-        const aisleConf = await this.readConfigFile(rootUri, 'config/aisle.conf');
-        const pantryConf = await this.readConfigFile(rootUri, 'config/pantry.conf');
-
-        if (seq !== this.regenerationSeq) {
-            return;
-        }
-
-        try {
-            const json = await this.languageService.generateShoppingList(
-                JSON.stringify(recipeInputs),
-                aisleConf,
-                pantryConf
-            );
-            if (seq !== this.regenerationSeq) {
-                return;
-            }
-            this.result = JSON.parse(json);
-        } catch (e) {
-            console.error('[shopping-list] Failed to generate shopping list:', e);
-            this.result = undefined;
-        }
-
-        this.onDidChangeEmitter.fire();
-    }
-
-    // --- File I/O ---
-
-    /**
-     * Attempts to read `.shopping_list.txt` from the workspace root and restore the
-     * recipe list from it. Triggers a `regenerate()` call if any recipes were loaded.
-     * Silently no-ops when the file does not exist yet.
-     */
-    protected async loadFromFile(): Promise<void> {
-        const rootUri = this.getWorkspaceRootUri();
-        if (!rootUri) {
-            return;
-        }
-
-        const fileUri = rootUri.resolve('.shopping_list.txt');
-        try {
-            const content = await this.fileService.read(fileUri);
-            this.recipes = this.parseShoppingListFile(content.value);
-            if (this.recipes.length > 0) {
-                await this.regenerate();
-            }
-        } catch {
-            // File does not exist yet; start with an empty list.
-        }
-    }
-
-    /**
-     * Parses the tab-delimited `.shopping_list.txt` format.
-     * Each non-blank, non-comment line is expected to be: `path\tname\tscale`.
-     */
-    protected parseShoppingListFile(content: string): ShoppingListRecipe[] {
-        const recipes: ShoppingListRecipe[] = [];
-        for (const line of content.split('\n')) {
-            const trimmed = line.trim();
-            if (!trimmed || trimmed.startsWith('#')) {
-                continue;
-            }
-            const parts = trimmed.split('\t');
-            if (parts.length >= 3) {
-                recipes.push({
-                    path: parts[0],
-                    name: parts[1],
-                    scale: Number.isFinite(parseFloat(parts[2])) && parseFloat(parts[2]) > 0 ? parseFloat(parts[2]) : 1,
-                });
-            }
-        }
-        return recipes;
-    }
-
-    /**
-     * Serialises the current recipe list to `.shopping_list.txt` in tab-delimited
-     * format and writes it to the workspace root via `FileService`.
-     */
-    protected async saveToFile(): Promise<void> {
-        const rootUri = this.getWorkspaceRootUri();
-        if (!rootUri) {
-            return;
-        }
-
-        const fileUri = rootUri.resolve('.shopping_list.txt');
-        const lines = this.recipes.map(r => `${r.path}\t${r.name}\t${r.scale}`);
-        const content = lines.length > 0 ? lines.join('\n') + '\n' : '';
-
-        try {
-            await this.fileService.write(fileUri, content);
-        } catch (e) {
-            console.error('[shopping-list] Failed to save shopping list:', e);
-        }
-    }
-
-    /**
-     * Reads a config file at `relativePath` relative to the workspace root.
-     * Returns `null` when the file does not exist or cannot be read.
-     */
-    protected async readConfigFile(rootUri: URI, relativePath: string): Promise<string | null> {
-        try {
-            const fileUri = rootUri.resolve(relativePath);
-            const content = await this.fileService.read(fileUri);
-            return content.value;
-        } catch {
-            return null;
-        }
-    }
-
-    /**
-     * Returns a `URI` pointing to the first workspace root, or `undefined` when no
-     * workspace is open.
-     */
     getWorkspaceRootUri(): URI | undefined {
         const roots = this.workspaceService.tryGetRoots();
         return roots.length > 0 ? new URI(roots[0].resource.toString()) : undefined;
     }
 
+    // -- Load / save --
+
+    protected async loadFromDisk(): Promise<void> {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+
+        // Load recipe list (marshal from externally-tagged wire JSON → internal shape)
+        try {
+            const content = await this.fileService.read(root.resolve(LIST_FILE));
+            const json = await this.languageService.parseShoppingList(content.value);
+            this.list = fromWireShoppingList(json);
+        } catch {
+            this.list = { items: [] };
+        }
+
+        // Load checked log
+        try {
+            const content = await this.fileService.read(root.resolve(CHECKED_FILE));
+            const json = await this.languageService.parseChecked(content.value);
+            this.checkedLog = fromWireCheckedLog(json);
+            const set = await this.languageService.checkedSet(json);
+            this.checkedSet = new Set(set.map(s => s.toLowerCase()));
+        } catch {
+            this.checkedLog = [];
+            this.checkedSet = new Set();
+        }
+
+        if (this.list.items.length > 0) {
+            await this.regenerate();
+        } else {
+            this.onDidChangeEmitter.fire();
+        }
+    }
+
+    protected async saveList(): Promise<void> {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+        const text = await this.languageService.writeShoppingList(toWireShoppingList(this.list));
+        await this.fileService.write(root.resolve(LIST_FILE), text);
+    }
+
     dispose(): void {
         this.toDispose.dispose();
     }
+
+    // Stubs — implemented in subsequent tasks.
+    async regenerate(): Promise<void> { /* Task 9 */ }
 }

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -171,11 +171,18 @@ export class ShoppingListService implements Disposable {
         }
 
         const flat = this.flattenForGeneration();
+        const baseDir = root.path.fsPath();
         const recipeInputs: Array<{ content: string; scale: number }> = [];
         for (const { path, scale } of flat) {
             try {
-                const content = await this.fileService.read(root.resolve(path));
-                recipeInputs.push({ content: content.value, scale });
+                // Use cooklang-find via RPC: auto-resolves `.cook`/`.menu` extensions
+                // when paths from menu references are stored without one.
+                const content = await this.languageService.findRecipe(baseDir, path);
+                if (content === undefined) {
+                    console.warn(`[shopping-list] Recipe not found: ${path}`);
+                    continue;
+                }
+                recipeInputs.push({ content, scale });
             } catch (e) {
                 console.warn(`[shopping-list] Failed to read recipe ${path}:`, e);
             }

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -46,6 +46,7 @@ export class ShoppingListService implements Disposable {
     protected checkedLog: CheckEntry[] = [];
     protected checkedSet = new Set<string>();
     protected result: ShoppingListResult | undefined;
+    /** Monotonic counter to discard stale `regenerate()` results. Used in Task 9. */
     protected regenerationSeq = 0;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
@@ -54,7 +55,9 @@ export class ShoppingListService implements Disposable {
     @postConstruct()
     protected init(): void {
         this.toDispose.push(this.onDidChangeEmitter);
-        this.workspaceService.roots.then(() => this.loadFromDisk());
+        this.workspaceService.roots
+            .then(() => this.loadFromDisk())
+            .catch(err => console.error('ShoppingListService: initial load failed', err));
     }
 
     // -- Public getters --

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -129,6 +129,144 @@ export class ShoppingListService implements Disposable {
         this.toDispose.dispose();
     }
 
-    // Stubs — implemented in subsequent tasks.
-    async regenerate(): Promise<void> { /* Task 9 */ }
+    /**
+     * Flattens nested items into a list of `{ path, scale }` pairs that the
+     * existing `generateShoppingList` RPC expects.
+     *
+     * Flattening rules:
+     * - A top-level item with no children contributes itself.
+     * - A top-level item with children contributes: itself (for its own
+     *   ingredients) AND each child (for expanded references / nested recipes).
+     * - Multipliers multiply down: a child under a menu scaled *2 is effectively *2.
+     */
+    protected flattenForGeneration(): Array<{ path: string; scale: number }> {
+        const out: Array<{ path: string; scale: number }> = [];
+        const walk = (item: ShoppingListRecipeItem, parentScale: number): void => {
+            const scale = (item.multiplier ?? 1) * parentScale;
+            out.push({ path: item.path, scale });
+            for (const child of item.children) {
+                walk(child, scale);
+            }
+        };
+        for (const item of this.list.items) {
+            walk(item, 1);
+        }
+        return out;
+    }
+
+    async regenerate(): Promise<void> {
+        const seq = ++this.regenerationSeq;
+
+        if (this.list.items.length === 0) {
+            this.result = undefined;
+            this.onDidChangeEmitter.fire();
+            return;
+        }
+
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+
+        const flat = this.flattenForGeneration();
+        const recipeInputs: Array<{ content: string; scale: number }> = [];
+        for (const { path, scale } of flat) {
+            try {
+                const content = await this.fileService.read(root.resolve(path));
+                recipeInputs.push({ content: content.value, scale });
+            } catch (e) {
+                console.warn(`[shopping-list] Failed to read recipe ${path}:`, e);
+            }
+        }
+        if (seq !== this.regenerationSeq) { return; }
+
+        const aisleConf = await this.readConfigFile(root, 'config/aisle.conf');
+        const pantryConf = await this.readConfigFile(root, 'config/pantry.conf');
+        if (seq !== this.regenerationSeq) { return; }
+
+        try {
+            const json = await this.languageService.generateShoppingList(
+                JSON.stringify(recipeInputs),
+                aisleConf,
+                pantryConf,
+            );
+            if (seq !== this.regenerationSeq) { return; }
+            this.result = JSON.parse(json);
+        } catch (e) {
+            console.error('[shopping-list] Failed to generate shopping list:', e);
+            this.result = undefined;
+        }
+        this.onDidChangeEmitter.fire();
+    }
+
+    async addRecipe(path: string, scale = 1, includedRefs?: string[]): Promise<void> {
+        const children: ShoppingListRecipeItem[] = includedRefs
+            ? includedRefs.map(p => ({
+                  type: 'recipe',
+                  path: p.replace(/^\.\//, ''),
+                  multiplier: undefined,
+                  children: [],
+              }))
+            : [];
+        this.list.items.push({
+            type: 'recipe',
+            path,
+            multiplier: scale === 1 ? undefined : scale,
+            children,
+        });
+        await this.saveList();
+        await this.regenerate();
+    }
+
+    async removeRecipe(index: number): Promise<void> {
+        if (index < 0 || index >= this.list.items.length) {
+            return;
+        }
+        this.list.items.splice(index, 1);
+        await this.saveList();
+        await this.regenerate();
+        // Compact the checked log against the now-current ingredient set.
+        await this.compactCheckedLog();
+    }
+
+    async updateScale(index: number, scale: number): Promise<void> {
+        if (index < 0 || index >= this.list.items.length) {
+            return;
+        }
+        this.list.items[index].multiplier = scale === 1 ? undefined : scale;
+        await this.saveList();
+        await this.regenerate();
+    }
+
+    async clearAll(): Promise<void> {
+        this.list = { items: [] };
+        this.checkedLog = [];
+        this.checkedSet.clear();
+        this.result = undefined;
+        const root = this.getWorkspaceRootUri();
+        if (root) {
+            try { await this.fileService.delete(root.resolve(LIST_FILE)); } catch { /* already gone */ }
+            try { await this.fileService.delete(root.resolve(CHECKED_FILE)); } catch { /* already gone */ }
+        }
+        this.onDidChangeEmitter.fire();
+    }
+
+    protected async readConfigFile(root: URI, relativePath: string): Promise<string | null> {
+        try {
+            const content = await this.fileService.read(root.resolve(relativePath));
+            return content.value;
+        } catch {
+            return null;
+        }
+    }
+
+    // Stubs — implemented in Task 10 and 11.
+    async checkItem(_name: string): Promise<void> { /* Task 10 */ }
+    async uncheckItem(_name: string): Promise<void> { /* Task 10 */ }
+    async addMenu(
+        _menuPath: string,
+        _menuScale: number,
+        _recipes: Array<{ path: string; scale: number; includedRefs?: string[] }>,
+    ): Promise<void> { /* Task 11 */ }
+    protected async compactCheckedLog(): Promise<void> { /* Task 10 */ }
 }

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -16,6 +16,8 @@ import {
     fromWireShoppingList,
     fromWireCheckedLog,
     toWireShoppingList,
+    toWireCheckEntryJson,
+    toWireCheckedLog,
 } from '../common/shopping-list-types';
 
 const LIST_FILE = '.shopping-list';
@@ -264,13 +266,89 @@ export class ShoppingListService implements Disposable {
         }
     }
 
-    // Stubs — implemented in Task 10 and 11.
-    async checkItem(_name: string): Promise<void> { /* Task 10 */ }
-    async uncheckItem(_name: string): Promise<void> { /* Task 10 */ }
+    async checkItem(name: string): Promise<void> {
+        await this.appendCheckEntry({ type: 'checked', name });
+    }
+
+    async uncheckItem(name: string): Promise<void> {
+        await this.appendCheckEntry({ type: 'unchecked', name });
+    }
+
+    protected async appendCheckEntry(entry: CheckEntry): Promise<void> {
+        const root = this.getWorkspaceRootUri();
+        if (!root) { return; }
+
+        const line = await this.languageService.writeCheckEntry(toWireCheckEntryJson(entry));
+
+        // Read-modify-write. FileService has no native append; single-user
+        // event-loop serialization keeps this safe.
+        let existing = '';
+        try {
+            const content = await this.fileService.read(root.resolve(CHECKED_FILE));
+            existing = content.value;
+        } catch {
+            existing = '';
+        }
+        const next = existing + (existing.endsWith('\n') || existing.length === 0 ? '' : '\n') + line;
+        await this.fileService.write(root.resolve(CHECKED_FILE), next);
+
+        // Update in-memory state
+        this.checkedLog.push(entry);
+        const setArr = await this.languageService.checkedSet(toWireCheckedLog(this.checkedLog));
+        this.checkedSet = new Set(setArr.map(s => s.toLowerCase()));
+        this.onDidChangeEmitter.fire();
+    }
+
     async addMenu(
         _menuPath: string,
         _menuScale: number,
         _recipes: Array<{ path: string; scale: number; includedRefs?: string[] }>,
     ): Promise<void> { /* Task 11 */ }
-    protected async compactCheckedLog(): Promise<void> { /* Task 10 */ }
+
+    /**
+     * Rewrite `.shopping-checked` keeping only entries whose ingredient name
+     * is still present in the current aggregated result. If `this.result` is
+     * missing (regeneration failed), skip — matches cookcli policy.
+     */
+    protected async compactCheckedLog(): Promise<void> {
+        if (!this.result) { return; }
+        const root = this.getWorkspaceRootUri();
+        if (!root) { return; }
+
+        const names: string[] = [];
+        for (const c of this.result.categories) {
+            for (const it of c.items) { names.push(it.name); }
+        }
+        for (const it of this.result.other.items) { names.push(it.name); }
+
+        const compactedJson = await this.languageService.compactChecked(
+            toWireCheckedLog(this.checkedLog),
+            names,
+        );
+        const compacted: CheckEntry[] = fromWireCheckedLog(compactedJson);
+
+        // If nothing changed, skip the write.
+        if (compacted.length === this.checkedLog.length) { return; }
+        this.checkedLog = compacted;
+
+        // Serialize each entry back to a line, join, write.
+        const lines: string[] = [];
+        for (const entry of compacted) {
+            lines.push(await this.languageService.writeCheckEntry(toWireCheckEntryJson(entry)));
+        }
+        const text = lines.length > 0 ? lines.join('') : '';
+        if (text.length === 0) {
+            try { await this.fileService.delete(root.resolve(CHECKED_FILE)); } catch { /* already gone */ }
+        } else {
+            // writeCheckEntry already emits a trailing newline per entry; if it
+            // doesn't, ensure separation:
+            const needsNewlines = !lines.every(l => l.endsWith('\n'));
+            const joined = needsNewlines ? lines.join('\n') + '\n' : text;
+            await this.fileService.write(root.resolve(CHECKED_FILE), joined);
+        }
+
+        // Rebuild in-memory set
+        const setArr = await this.languageService.checkedSet(compactedJson);
+        this.checkedSet = new Set(setArr.map(s => s.toLowerCase()));
+    }
 }

--- a/packages/cooklang/src/browser/shopping-list-widget.tsx
+++ b/packages/cooklang/src/browser/shopping-list-widget.tsx
@@ -40,10 +40,9 @@ export class ShoppingListWidget extends ReactWidget {
     }
 
     protected render(): React.ReactNode {
-        const recipes = this.shoppingListService.getRecipes();
+        const items = this.shoppingListService.getItems();
         const result = this.shoppingListService.getResult();
 
-        // Build checked set for rendering
         const checkedItems = new Set<string>();
         if (result) {
             const allItems = [
@@ -59,7 +58,7 @@ export class ShoppingListWidget extends ReactWidget {
 
         return (
             <ShoppingListView
-                recipes={recipes}
+                items={items}
                 result={result}
                 checkedItems={checkedItems}
                 onRemoveRecipe={this.handleRemoveRecipe}
@@ -71,18 +70,22 @@ export class ShoppingListWidget extends ReactWidget {
     }
 
     protected handleRemoveRecipe = (index: number): void => {
-        this.shoppingListService.removeRecipe(index);
+        void this.shoppingListService.removeRecipe(index);
     };
 
     protected handleScaleChange = (index: number, scale: number): void => {
-        this.shoppingListService.updateScale(index, scale);
+        void this.shoppingListService.updateScale(index, scale);
     };
 
     protected handleClearAll = (): void => {
-        this.shoppingListService.clearAll();
+        void this.shoppingListService.clearAll();
     };
 
     protected handleToggleItem = (name: string): void => {
-        this.shoppingListService.toggleChecked(name);
+        if (this.shoppingListService.isChecked(name)) {
+            void this.shoppingListService.uncheckItem(name);
+        } else {
+            void this.shoppingListService.checkItem(name);
+        }
     };
 }

--- a/packages/cooklang/src/browser/style/shopping-list.css
+++ b/packages/cooklang/src/browser/style/shopping-list.css
@@ -206,3 +206,13 @@
     color: var(--theia-descriptionForeground);
     padding: 2px 0;
 }
+
+.shopping-list-recipe-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.shopping-list-recipe-sub {
+    font-size: 0.85em;
+    color: var(--theia-descriptionForeground);
+}

--- a/packages/cooklang/src/common/cooklang-language-service.ts
+++ b/packages/cooklang/src/common/cooklang-language-service.ts
@@ -44,6 +44,17 @@ export interface CooklangLanguageService {
     writeCheckEntry(entryJson: string): Promise<string>;
     checkedSet(entriesJson: string): Promise<string[]>;
     compactChecked(entriesJson: string, currentIngredients: string[]): Promise<string>;
+
+    /**
+     * Resolve a recipe by `name` (with or without extension) inside `baseDir` using
+     * cooklang-find's lookup rules (auto-tries `.cook` then `.menu`).
+     * Returns the file content, or `undefined` if no matching file is found.
+     *
+     * `baseDir` must be an OS filesystem path (not a URI) — this RPC reads from
+     * disk directly via `cooklang-find` and bypasses Theia's `FileService`.
+     * Electron-only by design; remote/virtual workspaces are not supported.
+     */
+    findRecipe(baseDir: string, name: string): Promise<string | undefined>;
 }
 
 // Plain JSON DTOs — subsets of vscode-languageserver-protocol types

--- a/packages/cooklang/src/common/cooklang-language-service.ts
+++ b/packages/cooklang/src/common/cooklang-language-service.ts
@@ -36,6 +36,14 @@ export interface CooklangLanguageService {
 
     // Shopping list generation
     generateShoppingList(recipesJson: string, aisleConf: string | null, pantryConf: string | null): Promise<string>;
+
+    // Shopping list format (new in 2026-04)
+    parseShoppingList(text: string): Promise<string>;
+    writeShoppingList(json: string): Promise<string>;
+    parseChecked(text: string): Promise<string>;
+    writeCheckEntry(entryJson: string): Promise<string>;
+    checkedSet(entriesJson: string): Promise<string[]>;
+    compactChecked(entriesJson: string, currentIngredients: string[]): Promise<string>;
 }
 
 // Plain JSON DTOs — subsets of vscode-languageserver-protocol types

--- a/packages/cooklang/src/common/shopping-list-types.ts
+++ b/packages/cooklang/src/common/shopping-list-types.ts
@@ -1,21 +1,38 @@
 // Copyright (C) 2026 Cooklang contributors
 // SPDX-License-Identifier: MIT
 
+// ── Internal, ergonomic types used by ShoppingListService + UI ───────────────
+
 /**
- * A recipe entry in the shopping list with its scale factor.
+ * Persisted shopping list — internal representation.
+ * Only recipe entries are modeled; ingredient entries in the wire JSON are
+ * ignored on load (the editor never authors them).
  */
-export interface ShoppingListRecipe {
-    /** Workspace-relative path to the .cook file */
-    path: string;
-    /** Display name (derived from metadata or filename) */
-    name: string;
-    /** Scale factor (1 = original, 2 = double, etc.) */
-    scale: number;
+export interface ShoppingListFile {
+    items: ShoppingListRecipeItem[];
 }
 
 /**
- * Result returned by the backend shopping list generator.
+ * A recipe entry. A bare entry (empty `children`) represents a single recipe.
+ * An entry with children represents either a menu (children are recipes) or a
+ * recipe with selected sub-references.
+ *
+ * `multiplier` is `undefined` when the `.shopping-list` serializes without an
+ * explicit multiplier (equivalent to 1).
  */
+export interface ShoppingListRecipeItem {
+    type: 'recipe';
+    path: string;
+    multiplier?: number;
+    children: ShoppingListRecipeItem[];
+}
+
+/** Single entry in the `.shopping-checked` log — internal representation. */
+export type CheckEntry =
+    | { type: 'checked'; name: string }
+    | { type: 'unchecked'; name: string };
+
+/** Aggregated shopping-list result returned by `generateShoppingList`. Unchanged. */
 export interface ShoppingListResult {
     /** Ingredient categories from aisle.conf, in aisle order */
     categories: ShoppingListCategory[];
@@ -40,4 +57,104 @@ export interface ShoppingListItem {
     name: string;
     /** Pre-formatted quantity string, e.g. "500 g, 2 cups" */
     quantities: string;
+}
+
+// ── Wire types — mirror serde default (externally-tagged) JSON from NAPI ─────
+// Kept separate from the internal model so UI/service code stays readable.
+
+interface WireShoppingList {
+    items: WireShoppingItem[];
+}
+
+type WireShoppingItem =
+    | { Recipe: WireRecipe }
+    | { Ingredient: WireIngredient };
+
+interface WireRecipe {
+    path: string;
+    multiplier: number | null;
+    children: WireShoppingItem[];
+}
+
+interface WireIngredient {
+    name: string;
+    quantity: string | null;
+}
+
+type WireCheckEntry =
+    | { Checked: string }
+    | { Unchecked: string };
+
+// ── Marshalling helpers ──────────────────────────────────────────────────────
+
+/** Parse the JSON produced by NAPI `parseShoppingList` into internal shape. */
+export function fromWireShoppingList(json: string): ShoppingListFile {
+    const wire = JSON.parse(json) as WireShoppingList;
+    return {
+        items: (wire.items ?? [])
+            .map(fromWireItem)
+            .filter((x): x is ShoppingListRecipeItem => x !== undefined)
+    };
+}
+
+function fromWireItem(item: WireShoppingItem): ShoppingListRecipeItem | undefined {
+    if ('Recipe' in item) {
+        const r = item.Recipe;
+        return {
+            type: 'recipe',
+            path: r.path,
+            multiplier: r.multiplier ?? undefined,
+            children: (r.children ?? [])
+                .map(fromWireItem)
+                .filter((x): x is ShoppingListRecipeItem => x !== undefined)
+        };
+    }
+    // Ignore Ingredient entries — editor never authors them.
+    return undefined;
+}
+
+/** Serialize internal shape to JSON for NAPI `writeShoppingList`. */
+export function toWireShoppingList(file: ShoppingListFile): string {
+    const wire: WireShoppingList = {
+        items: file.items.map(toWireItem)
+    };
+    return JSON.stringify(wire);
+}
+
+function toWireItem(item: ShoppingListRecipeItem): WireShoppingItem {
+    const r: WireRecipe = {
+        path: item.path,
+        multiplier: item.multiplier ?? null,
+        children: item.children.map(toWireItem)
+    };
+    return { Recipe: r };
+}
+
+/** Parse the JSON produced by NAPI `parseChecked` into internal CheckEntry[]. */
+export function fromWireCheckedLog(json: string): CheckEntry[] {
+    const wire = JSON.parse(json) as WireCheckEntry[];
+    return wire.map(fromWireCheckEntry);
+}
+
+function fromWireCheckEntry(entry: WireCheckEntry): CheckEntry {
+    if ('Checked' in entry) {
+        return { type: 'checked', name: entry.Checked };
+    }
+    return { type: 'unchecked', name: entry.Unchecked };
+}
+
+/** Serialize internal CheckEntry[] for NAPI (e.g. when passing to compactChecked). */
+export function toWireCheckedLog(entries: CheckEntry[]): string {
+    return JSON.stringify(entries.map(toWireCheckEntry));
+}
+
+/** Serialize a single internal CheckEntry for NAPI `writeCheckEntry`. */
+export function toWireCheckEntryJson(entry: CheckEntry): string {
+    return JSON.stringify(toWireCheckEntry(entry));
+}
+
+function toWireCheckEntry(entry: CheckEntry): WireCheckEntry {
+    return entry.type === 'checked'
+        ? { Checked: entry.name }
+        : { Unchecked: entry.name };
 }

--- a/packages/cooklang/src/node/cooklang-language-service-impl.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.ts
@@ -212,4 +212,10 @@ export class CooklangLanguageServiceImpl implements CooklangLanguageService {
         const native = require('@theia/cooklang-native');
         return native.compactChecked(entriesJson, currentIngredients);
     }
+
+    async findRecipe(baseDir: string, name: string): Promise<string | undefined> {
+        const native = require('@theia/cooklang-native');
+        const result = native.findRecipe(baseDir, name);
+        return result ?? undefined;
+    }
 }

--- a/packages/cooklang/src/node/cooklang-language-service-impl.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.ts
@@ -182,4 +182,34 @@ export class CooklangLanguageServiceImpl implements CooklangLanguageService {
             return JSON.stringify({ categories: [], other: { name: 'other', items: [] }, pantryItems: [] });
         }
     }
+
+    async parseShoppingList(text: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.parseShoppingList(text);
+    }
+
+    async writeShoppingList(json: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.writeShoppingList(json);
+    }
+
+    async parseChecked(text: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.parseChecked(text);
+    }
+
+    async writeCheckEntry(entryJson: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.writeCheckEntry(entryJson);
+    }
+
+    async checkedSet(entriesJson: string): Promise<string[]> {
+        const native = require('@theia/cooklang-native');
+        return native.checkedSet(entriesJson);
+    }
+
+    async compactChecked(entriesJson: string, currentIngredients: string[]): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.compactChecked(entriesJson, currentIngredients);
+    }
 }


### PR DESCRIPTION
## Summary

- Migrates the shopping list from the legacy `.shopping_list.txt` to the new cooklang-rs 0.18.5 `.shopping-list` format with a persistent `.shopping-checked` append-only log (matches cookcli #318).
- Architecture: thin Rust NAPI layer for parse/serialize/compact, fat TypeScript `ShoppingListService` that handles file I/O via Theia's `FileService`, in-memory check state, and regeneration race-condition guards.
- Adds an `Add Menu to Shopping List` command + context menu entry for `.menu` files; menus are stored as a single top-level item with nested recipe children.

## Test plan

- [x] Rust: 11 unit tests in `packages/cooklang-native/src/shopping_list.rs` (parse, write, checked log, compact).
- [x] TypeScript: 6 unit tests in `packages/cooklang/src/browser/shopping-list-service.spec.ts` covering load, add/remove, check/uncheck round-trip, and compact-on-remove.
- [ ] Manual smoke test in a workspace with `.cook` and `.menu` files:
  - [ ] Add a recipe → appears in panel, `.shopping-list` written
  - [ ] Check/uncheck items → `.shopping-checked` updates, persists across restart
  - [ ] Add a `.menu` → appears as a parent row with nested recipe rows
  - [ ] Scale a recipe → quantities update
  - [ ] Remove a recipe → entry removed, checked log compacted
  - [ ] Clear all → both files deleted