### PR TITLE
feat(cooklang): watch .shopping-* files and reload on external change

### DIFF
--- a/docs/superpowers/plans/2026-04-13-shopping-list-file-watching.md
+++ b/docs/superpowers/plans/2026-04-13-shopping-list-file-watching.md
@@ -1,0 +1,626 @@
+# Shopping List File Watching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ShoppingListService` reload from disk whenever `.shopping-list` or `.shopping-checked` changes externally, so the UI stays in sync with cloud sync / multi-window / manual edits.
+
+**Architecture:** Subscribe to `FileService.onDidFilesChange`, filter to the two shopping files in the workspace root, debounce rapid events (~100ms), then call the existing `loadFromDisk()` — which already handles missing files as empty state and uses `regenerationSeq` to cancel stale regenerations.
+
+**Tech Stack:** Theia `FileService` (watch + onDidFilesChange), InversifyJS, TypeScript, mocha + chai (unit tests).
+
+**Spec:** [`docs/superpowers/specs/2026-04-13-shopping-list-file-watching-design.md`](../specs/2026-04-13-shopping-list-file-watching-design.md)
+
+---
+
+## File Structure
+
+- Modify: `packages/cooklang/src/browser/shopping-list-service.ts`
+  - Add watcher registration, debounce state, reload handler, dispose cleanup.
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+  - Extend `FakeFileService` with `watch()` + `onDidFilesChange` emitter.
+  - Add new test cases (one per behavior).
+
+No new files. No public API changes. No changes to the widget or contribution — they already subscribe to `onDidChange`.
+
+---
+
+## Task 1: Extend test fakes with file-watching support
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+The current `FakeFileService` only implements `read` / `write` / `delete`. The watcher code we'll add in Task 2 calls `fileService.watch(uri)` and `fileService.onDidFilesChange(listener)`. Tests need to be able to fire synthetic change events.
+
+We also need a helper that fully initializes the service (runs `@postConstruct`) so the watcher is registered before the test fires events.
+
+- [ ] **Step 1: Add imports and fake change-event infrastructure to the spec file**
+
+At the top of `packages/cooklang/src/browser/shopping-list-service.spec.ts`, add the `Emitter` import next to the existing imports:
+
+```typescript
+import { Emitter } from '@theia/core/lib/common/event';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+```
+
+(Keep the existing `DisposableCollection` import — just add `Disposable` and the `Emitter` import.)
+
+- [ ] **Step 2: Extend `FakeFileService` with `watch()` and a file-change emitter**
+
+Replace the existing `FakeFileService` class (currently at lines ~22–36) with:
+
+```typescript
+/** Minimal in-memory FileService stub — only the methods the service calls. */
+class FakeFileService {
+    files = new Map<string, string>();
+    readonly onDidFilesChangeEmitter = new Emitter<FakeFileChangesEvent>();
+    readonly onDidFilesChange = this.onDidFilesChangeEmitter.event;
+
+    async read(uri: { toString(): string }): Promise<{ value: string }> {
+        const key = uri.toString();
+        if (!this.files.has(key)) { throw new Error('ENOENT'); }
+        return { value: this.files.get(key)! };
+    }
+    async write(uri: { toString(): string }, content: string): Promise<void> {
+        this.files.set(uri.toString(), content);
+    }
+    async delete(uri: { toString(): string }): Promise<void> {
+        this.files.delete(uri.toString());
+    }
+    watch(_uri: { toString(): string }): Disposable {
+        return Disposable.create(() => { /* no-op */ });
+    }
+
+    /** Test helper: fire a synthetic change event for a URI string. */
+    fireChange(uriString: string): void {
+        this.onDidFilesChangeEmitter.fire({
+            contains: (resource: { toString(): string }) => resource.toString() === uriString,
+        });
+    }
+}
+
+/** Minimal shape the service uses from `FileChangesEvent`. */
+interface FakeFileChangesEvent {
+    contains(resource: { toString(): string }): boolean;
+}
+```
+
+> Why `contains(resource)` only? The service's `onFilesChanged` (Task 2) only calls `event.contains(uri)`. That's the entire surface the production code uses.
+
+- [ ] **Step 3: Add a `makeServiceReady()` helper that fully initializes the service**
+
+After the existing `makeService()` function, add a second helper that awaits the full `init()` cycle so the watcher is registered and initial load has completed:
+
+```typescript
+/**
+ * Like `makeService()` but also invokes the `@postConstruct` initializer and
+ * waits for initial `loadFromDisk()` + watcher registration to complete.
+ */
+async function makeServiceReady(): Promise<{ svc: ShoppingListService; fs: FakeFileService; ls: FakeLanguageService }> {
+    const { svc, fs, ls } = makeService();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    // Shrink the debounce so tests don't wait 100ms per reload.
+    (svc as any).reloadDebounceMs = 5;
+    // Invoke the @postConstruct init manually. It's a protected method, so we
+    // go through `as any`. `init()` fires-and-forgets an async loadFromDisk,
+    // so await its returned promise chain before handing back the service.
+    await (svc as any).init();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return { svc, fs, ls };
+}
+
+/** Sleep helper — used to let the debounce timer elapse in tests. */
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+```
+
+> `init()` as written returns `void` because the inner promise chain is `.then(...).catch(...)`. We'll change it in Task 2 to return a `Promise<void>` so tests can await it. If you prefer to keep `init()` void, the alternative is `await new Promise(r => setTimeout(r, 0))` here to let the microtask queue drain, but returning a promise is cleaner. Task 2's implementation step assumes `init()` returns `Promise<void>`.
+
+- [ ] **Step 4: Run the existing test suite to confirm the refactor didn't break anything**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang
+```
+
+Expected: all existing `ShoppingListService` tests still pass. (We haven't added a new test yet, just extended the fakes.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): extend shopping list fakes with watcher support"
+```
+
+---
+
+## Task 2: Reload on external update of `.shopping-list`
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.ts`
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+TDD: test first, then implement the watcher + debounce + reload plumbing.
+
+- [ ] **Step 1: Write the failing test**
+
+Add at the bottom of the `describe('ShoppingListService', ...)` block in the spec file (before the closing `});`):
+
+```typescript
+it('reloads when .shopping-list is updated externally', async () => {
+    const { svc, fs } = await makeServiceReady();
+    expect(svc.getItems().length).to.equal(0);
+
+    let changeFires = 0;
+    svc.onDidChange(() => { changeFires += 1; });
+
+    // External write (simulates cloud sync / another process).
+    fs.files.set('file:///ws/.shopping-list', 'pasta.cook\nsoup.cook\n');
+    fs.fireChange('file:///ws/.shopping-list');
+
+    // Wait past the debounce window.
+    await sleep(30);
+
+    expect(svc.getItems().length).to.equal(2);
+    expect(svc.getItems()[0].path).to.equal('pasta.cook');
+    expect(changeFires).to.be.greaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'reloads when .shopping-list is updated externally'
+```
+
+Expected: FAIL. `svc.getItems().length` is still 0 because the service never reloaded.
+
+- [ ] **Step 3: Add imports to the service for the watcher types**
+
+In `packages/cooklang/src/browser/shopping-list-service.ts`, update the existing `FileService` import line to also bring in `FileChangesEvent`:
+
+```typescript
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
+```
+
+- [ ] **Step 4: Add debounce fields and change `init()` to return a promise**
+
+Near the top of the `ShoppingListService` class (next to the existing `protected regenerationSeq = 0;` line), add:
+
+```typescript
+    /** Debounce window for reloading after an external file change. Overridable in tests. */
+    protected reloadDebounceMs = 100;
+
+    /** Active debounce timer, if any. */
+    protected reloadTimer: ReturnType<typeof setTimeout> | undefined;
+```
+
+Change the existing `init()` signature and body from:
+
+```typescript
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.onDidChangeEmitter);
+        this.workspaceService.roots
+            .then(() => this.loadFromDisk())
+            .catch(err => console.error('ShoppingListService: initial load failed', err));
+    }
+```
+
+to:
+
+```typescript
+    @postConstruct()
+    protected async init(): Promise<void> {
+        this.toDispose.push(this.onDidChangeEmitter);
+        try {
+            await this.workspaceService.roots;
+            await this.loadFromDisk();
+        } catch (err) {
+            console.error('ShoppingListService: initial load failed', err);
+        }
+        this.setupWatcher();
+    }
+```
+
+> Why `Promise<void>`? Tests need to await initialization. InversifyJS's `@postConstruct` tolerates async methods — their returned promise is awaited internally.
+
+- [ ] **Step 5: Add `setupWatcher()`, `onFilesChanged()`, and `scheduleReload()` methods**
+
+Add these three methods at the end of the class body (just before the closing `}` of the class):
+
+```typescript
+    protected setupWatcher(): void {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+        try {
+            this.toDispose.push(this.fileService.watch(root));
+        } catch (e) {
+            console.error('[shopping-list] Failed to register watcher:', e);
+        }
+        this.toDispose.push(this.fileService.onDidFilesChange(event => this.onFilesChanged(event)));
+        this.toDispose.push(Disposable.create(() => {
+            if (this.reloadTimer !== undefined) {
+                clearTimeout(this.reloadTimer);
+                this.reloadTimer = undefined;
+            }
+        }));
+    }
+
+    protected onFilesChanged(event: FileChangesEvent): void {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+        const listUri = root.resolve(LIST_FILE);
+        const checkedUri = root.resolve(CHECKED_FILE);
+        if (event.contains(listUri) || event.contains(checkedUri)) {
+            this.scheduleReload();
+        }
+    }
+
+    protected scheduleReload(): void {
+        if (this.reloadTimer !== undefined) {
+            clearTimeout(this.reloadTimer);
+        }
+        this.reloadTimer = setTimeout(() => {
+            this.reloadTimer = undefined;
+            this.loadFromDisk().catch(err =>
+                console.error('[shopping-list] Reload after file change failed:', err),
+            );
+        }, this.reloadDebounceMs);
+    }
+```
+
+> `Disposable` is already imported at the top of the file. `LIST_FILE` and `CHECKED_FILE` are the existing module constants. `FileChangesEvent.contains(uri)` already handles all change types (ADDED/UPDATED/DELETED), so no type filtering needed.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'reloads when .shopping-list is updated externally'
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite to confirm no regressions**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.ts packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "feat(cooklang): watch .shopping-list for external changes"
+```
+
+---
+
+## Task 3: External delete of `.shopping-list` resets state
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+The implementation from Task 2 already handles this via `loadFromDisk()`'s try/catch that treats a missing file as `{ items: [] }`. This task locks in the behavior with a test.
+
+- [ ] **Step 1: Write the test**
+
+Add at the bottom of the `describe('ShoppingListService', ...)` block:
+
+```typescript
+it('resets to empty when .shopping-list is deleted externally', async () => {
+    const { svc, fs } = await makeServiceReady();
+    // Seed an existing list, reload so in-memory state catches up.
+    fs.files.set('file:///ws/.shopping-list', 'pasta.cook\n');
+    fs.fireChange('file:///ws/.shopping-list');
+    await sleep(30);
+    expect(svc.getItems().length).to.equal(1);
+
+    // External delete.
+    fs.files.delete('file:///ws/.shopping-list');
+    fs.fireChange('file:///ws/.shopping-list');
+    await sleep(30);
+
+    expect(svc.getItems().length).to.equal(0);
+    expect(svc.getResult()).to.equal(undefined);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'resets to empty when .shopping-list is deleted externally'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): verify external delete of .shopping-list resets state"
+```
+
+---
+
+## Task 4: External update of `.shopping-checked` updates `isChecked()`
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+The existing `FakeLanguageService.parseChecked` reads lines starting with `+ ` as checked and `- ` as unchecked, and `checkedSet` deduces the final set. The watcher path from Task 2 handles this file the same way as `.shopping-list`.
+
+- [ ] **Step 1: Write the test**
+
+Add at the bottom of the `describe('ShoppingListService', ...)` block:
+
+```typescript
+it('reloads when .shopping-checked is updated externally', async () => {
+    const { svc, fs } = await makeServiceReady();
+    expect(svc.isChecked('flour')).to.equal(false);
+
+    fs.files.set('file:///ws/.shopping-checked', '+ flour\n');
+    fs.fireChange('file:///ws/.shopping-checked');
+    await sleep(30);
+    expect(svc.isChecked('flour')).to.equal(true);
+
+    // An external unchecked entry wins.
+    fs.files.set('file:///ws/.shopping-checked', '+ flour\n- flour\n');
+    fs.fireChange('file:///ws/.shopping-checked');
+    await sleep(30);
+    expect(svc.isChecked('flour')).to.equal(false);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'reloads when .shopping-checked is updated externally'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): verify external update of .shopping-checked reloads"
+```
+
+---
+
+## Task 5: Debounce coalesces rapid events
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+Verify that N events arriving within the debounce window cause exactly one reload. We measure reload count via a spy on `loadFromDisk`.
+
+- [ ] **Step 1: Write the test**
+
+Add at the bottom of the `describe('ShoppingListService', ...)` block:
+
+```typescript
+it('coalesces rapid file change events into one reload', async () => {
+    const { svc, fs } = await makeServiceReady();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const original = (svc as any).loadFromDisk.bind(svc);
+    let reloadCount = 0;
+    (svc as any).loadFromDisk = async () => {
+        reloadCount += 1;
+        return original();
+    };
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    fs.files.set('file:///ws/.shopping-list', 'a.cook\n');
+    // Fire 5 events back-to-back within the 5ms debounce window.
+    for (let i = 0; i < 5; i += 1) {
+        fs.fireChange('file:///ws/.shopping-list');
+    }
+    await sleep(30);
+
+    expect(reloadCount).to.equal(1);
+    expect(svc.getItems().length).to.equal(1);
+});
+```
+
+> The 5 events are synchronous (no awaits between them), so they all arrive before the first `setTimeout(..., 5)` fires. The debounce must coalesce them into one reload.
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'coalesces rapid file change events'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): verify file-change debounce coalesces events"
+```
+
+---
+
+## Task 6: Dispose stops further reloads
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+Verify the watcher subscription and the pending debounce timer are both torn down when the service is disposed.
+
+- [ ] **Step 1: Write the test**
+
+Add at the bottom of the `describe('ShoppingListService', ...)` block:
+
+```typescript
+it('stops reloading after dispose()', async () => {
+    const { svc, fs } = await makeServiceReady();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const original = (svc as any).loadFromDisk.bind(svc);
+    let reloadCount = 0;
+    (svc as any).loadFromDisk = async () => {
+        reloadCount += 1;
+        return original();
+    };
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    fs.files.set('file:///ws/.shopping-list', 'a.cook\n');
+    fs.fireChange('file:///ws/.shopping-list');
+
+    // Dispose before the debounce window elapses — the queued reload must be cancelled.
+    svc.dispose();
+
+    await sleep(30);
+    expect(reloadCount).to.equal(0);
+
+    // A fresh event after dispose must also not reload.
+    fs.fireChange('file:///ws/.shopping-list');
+    await sleep(30);
+    expect(reloadCount).to.equal(0);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'stops reloading after dispose'
+```
+
+Expected: PASS. The `Disposable.create(() => clearTimeout(...))` registered in `setupWatcher()` cancels the pending timer; disposing the `onDidFilesChange` subscription stops new events from scheduling reloads.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): verify dispose cancels pending reloads"
+```
+
+---
+
+## Task 7: Self-write echo is idempotent
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/shopping-list-service.spec.ts`
+
+When the service writes `.shopping-list` itself (e.g., via `addRecipe()`), the watcher will see its own write. The reload re-reads the same content. Verify state stays correct (no duplicated items, no lost checks).
+
+- [ ] **Step 1: Write the test**
+
+Add at the bottom of the `describe('ShoppingListService', ...)` block:
+
+```typescript
+it('handles self-write echo idempotently', async () => {
+    const { svc, fs } = await makeServiceReady();
+    await svc.addRecipe('pasta.cook', 1);
+    expect(svc.getItems().length).to.equal(1);
+
+    // Simulate the watcher firing for our own write.
+    fs.fireChange('file:///ws/.shopping-list');
+    await sleep(30);
+
+    // State is unchanged — still exactly one item with the same path.
+    expect(svc.getItems().length).to.equal(1);
+    expect(svc.getItems()[0].path).to.equal('pasta.cook');
+
+    // Checks survive a spurious .shopping-checked echo too.
+    await svc.checkItem('flour');
+    fs.fireChange('file:///ws/.shopping-checked');
+    await sleep(30);
+    expect(svc.isChecked('flour')).to.equal(true);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang -- --grep 'handles self-write echo idempotently'
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full suite one more time**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang/src/browser/shopping-list-service.spec.ts
+git commit -m "test(cooklang): verify self-write echo does not corrupt state"
+```
+
+---
+
+## Task 8: Lint and verify the whole package compiles
+
+**Files:** none changed — this is a verification task.
+
+- [ ] **Step 1: Run the compile step for the package**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: no TypeScript errors.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run lint --scope @theia/cooklang
+```
+
+Expected: no lint errors. If lint complains about unused imports or `any` casts, fix inline.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run:
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run test --scope @theia/cooklang
+```
+
+Expected: all ShoppingListService tests (original + 6 new) pass.
+
+- [ ] **Step 4: If any fixes were needed, commit them**
+
+```bash
+git add -u
+git commit -m "chore(cooklang): lint/compile fixes for shopping-list watcher"
+```
+
+(Skip if nothing changed.)

--- a/docs/superpowers/specs/2026-04-13-shopping-list-file-watching-design.md
+++ b/docs/superpowers/specs/2026-04-13-shopping-list-file-watching-design.md
@@ -1,0 +1,87 @@
+# Shopping List File Watching — Design
+
+## Problem
+
+`ShoppingListService` reads `.shopping-list` and `.shopping-checked` from the workspace root once during `init()` and never reloads them. External changes — cloud sync, another window, `git pull`, manual edits, `rm` — are invisible until the app restarts.
+
+## Goal
+
+Treat the two on-disk files as the source of truth. When either file changes on disk, the service's in-memory state catches up and the UI re-renders via the existing `onDidChange` event.
+
+## Non-goals
+
+- No conflict resolution between local edits and external changes. Last write wins; disk overwrites memory.
+- No cross-workspace watching. Only files in the current workspace root.
+- No watching of `config/aisle.conf` or `config/pantry.conf`. Those only matter during `regenerate()` and aren't the focus here.
+
+## Design
+
+### Behavior
+
+On any ADDED / UPDATED / DELETED event for `<root>/.shopping-list` or `<root>/.shopping-checked`:
+
+1. Schedule a reload after a ~100ms debounce. Subsequent events within the window reset the timer.
+2. When the timer fires, call the existing `loadFromDisk()`. It already:
+   - Treats a missing `.shopping-list` as `{ items: [] }` (matches deletion semantics).
+   - Treats a missing `.shopping-checked` as empty log + empty set.
+   - Calls `regenerate()` when items exist, or fires `onDidChange` directly when empty.
+   - Uses `regenerationSeq` to cancel stale in-flight regenerations.
+
+Our own writes (`saveList()`, `appendCheckEntry()`, `compactCheckedLog()`, `clearAll()`) will trigger the watcher too. The debounced reload re-parses the same content, fires `onDidChange` again, and the UI re-renders idempotently. No suppression flag, no content hash — simple over clever.
+
+### Implementation
+
+**File:** `packages/cooklang/src/browser/shopping-list-service.ts`
+
+1. Add fields:
+   - `protected reloadTimer: ReturnType<typeof setTimeout> | undefined;`
+   - Constant `RELOAD_DEBOUNCE_MS = 100`.
+
+2. After the initial `loadFromDisk()` completes in `init()`, call a new `protected setupWatcher(): void`.
+
+3. `setupWatcher()`:
+   - Get the workspace root URI (return early if none).
+   - Register `this.fileService.watch(root)` and push the returned `Disposable` into `this.toDispose`.
+   - Subscribe to `this.fileService.onDidFilesChange(event => this.onFilesChanged(event))` and push the subscription into `this.toDispose`.
+
+4. `protected onFilesChanged(event: FileChangesEvent): void`:
+   - Resolve `listUri = root.resolve('.shopping-list')` and `checkedUri = root.resolve('.shopping-checked')`.
+   - Use `event.contains(uri)` (or equivalent — check the actual `FileChangesEvent` API at implementation time) to test for any change type on either URI.
+   - If matched, call `scheduleReload()`.
+
+5. `protected scheduleReload(): void`:
+   - `clearTimeout(this.reloadTimer)` if set.
+   - `this.reloadTimer = setTimeout(() => { this.reloadTimer = undefined; this.loadFromDisk().catch(err => console.error(...)); }, RELOAD_DEBOUNCE_MS);`
+
+6. Update `dispose()` (or push into `toDispose` via a wrapper `Disposable`) to `clearTimeout(this.reloadTimer)`.
+
+**Workspace root changes:** Out of scope. A workspace switch tears down frontend widgets anyway; if this turns out to matter we can add `workspaceService.onWorkspaceChanged` later.
+
+### Race & ordering
+
+- `loadFromDisk()` itself is a sequence of awaits. Two overlapping reloads could interleave — but only the most recent `regenerate()` wins (via `regenerationSeq`), and the writes into `this.list` / `this.checkedLog` are simple assignments. Last one wins, which is what we want when disk is truth.
+- User actions (`addRecipe`, `removeRecipe`, etc.) call `saveList()` then `regenerate()`. A watcher-triggered reload arriving mid-action would re-read the file we just wrote — correct content, redundant regen. Acceptable.
+
+### Disposal
+
+All new resources (watcher, event subscription, timeout-clearing wrapper) flow through `this.toDispose`. Existing `dispose()` unchanged except for clearing the debounce timer.
+
+## Testing
+
+Extend `packages/cooklang/src/browser/shopping-list-service.spec.ts`:
+
+1. **External update of `.shopping-list`**: write a new list file out-of-band, fire the file-change event, advance fake timers past the debounce → `getItems()` reflects the new content and `onDidChange` fires.
+2. **External delete of `.shopping-list`**: fire DELETED event → `getItems()` is empty and `getResult()` is `undefined`.
+3. **External update of `.shopping-checked`**: fire event for the checked log → `isChecked(name)` reflects the new state.
+4. **Debounce coalesces**: fire N events within 100ms → exactly one `loadFromDisk` execution (assert via a spy or a counter).
+5. **Dispose stops reloads**: dispose the service, then fire an event → no further `onDidChange`.
+6. **Self-write echo is harmless**: call `addRecipe()` (which writes + fires change events), then fire the synthetic watcher event → state is unchanged (idempotent), `onDidChange` fires once more.
+
+Use the existing test harness patterns (fake `FileService`, `DisposableCollection`, sinon fake timers if not already in use).
+
+## Files touched
+
+- `packages/cooklang/src/browser/shopping-list-service.ts` — watcher, debounce, disposal.
+- `packages/cooklang/src/browser/shopping-list-service.spec.ts` — new test cases.
+
+No new files, no public API changes, no changes to widget or contribution code — the widget already subscribes to `onDidChange`.

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -9,7 +9,8 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
-import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Emitter } from '@theia/core/lib/common/event';
 import { ShoppingListService } from './shopping-list-service';
 import { ShoppingListRecipeItem } from '../common/shopping-list-types';
 
@@ -19,9 +20,17 @@ after(() => disableJSDOM());
 type WireShoppingItem = { Recipe: { path: string; multiplier: number | null; children: WireShoppingItem[] } };
 type WireCheckEntry = { Checked: string } | { Unchecked: string };
 
+/** Minimal shape the service uses from `FileChangesEvent`. */
+interface FakeFileChangesEvent {
+    contains(resource: { toString(): string }): boolean;
+}
+
 /** Minimal in-memory FileService stub — only the methods the service calls. */
 class FakeFileService {
     files = new Map<string, string>();
+    readonly onDidFilesChangeEmitter = new Emitter<FakeFileChangesEvent>();
+    readonly onDidFilesChange = this.onDidFilesChangeEmitter.event;
+
     async read(uri: { toString(): string }): Promise<{ value: string }> {
         const key = uri.toString();
         if (!this.files.has(key)) { throw new Error('ENOENT'); }
@@ -32,6 +41,16 @@ class FakeFileService {
     }
     async delete(uri: { toString(): string }): Promise<void> {
         this.files.delete(uri.toString());
+    }
+    watch(_uri: { toString(): string }): Disposable {
+        return Disposable.create(() => { /* no-op */ });
+    }
+
+    /** Test helper: fire a synthetic change event for a URI string. */
+    fireChange(uriString: string): void {
+        this.onDidFilesChangeEmitter.fire({
+            contains: (resource: { toString(): string }) => resource.toString() === uriString,
+        });
     }
 }
 
@@ -123,6 +142,28 @@ function makeService(): { svc: ShoppingListService; fs: FakeFileService; ls: Fak
     return { svc, fs, ls };
 }
 
+/**
+ * Like `makeService()` but also invokes the `@postConstruct` initializer and
+ * waits for initial `loadFromDisk()` + watcher registration to complete.
+ */
+async function makeServiceReady(): Promise<{ svc: ShoppingListService; fs: FakeFileService; ls: FakeLanguageService }> {
+    const { svc, fs, ls } = makeService();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    // Shrink the debounce so tests don't wait 100ms per reload.
+    (svc as any).reloadDebounceMs = 5;
+    // Invoke the @postConstruct init manually. It's a protected method, so we
+    // go through `as any`. `init()` fires-and-forgets an async loadFromDisk,
+    // so await its returned promise chain before handing back the service.
+    await (svc as any).init();
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return { svc, fs, ls };
+}
+
+/** Sleep helper — used to let the debounce timer elapse in tests. */
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 describe('ShoppingListService', () => {
     it('addRecipe appends to list and persists', async () => {
         const { svc, fs } = makeService();
@@ -204,3 +245,7 @@ describe('ShoppingListService', () => {
         expect(checkedContent.includes('+ flour')).to.equal(true);
     });
 });
+
+// Suppress "unused" warnings for helpers that are called in Task 2.
+void makeServiceReady;
+void sleep;

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -262,4 +262,21 @@ describe('ShoppingListService', () => {
         expect(svc.getItems()[0].path).to.equal('pasta.cook');
         expect(changeFires).to.be.greaterThan(0);
     });
+
+    it('resets to empty when .shopping-list is deleted externally', async () => {
+        const { svc, fs } = await makeServiceReady();
+        // Seed an existing list, reload so in-memory state catches up.
+        fs.files.set('file:///ws/.shopping-list', 'pasta.cook\n');
+        fs.fireChange('file:///ws/.shopping-list');
+        await sleep(30);
+        expect(svc.getItems().length).to.equal(1);
+
+        // External delete.
+        fs.files.delete('file:///ws/.shopping-list');
+        fs.fireChange('file:///ws/.shopping-list');
+        await sleep(30);
+
+        expect(svc.getItems().length).to.equal(0);
+        expect(svc.getResult()).to.equal(undefined);
+    });
 });

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -244,8 +244,22 @@ describe('ShoppingListService', () => {
         expect(checkedContent.includes('milk')).to.equal(false);
         expect(checkedContent.includes('+ flour')).to.equal(true);
     });
-});
+    it('reloads when .shopping-list is updated externally', async () => {
+        const { svc, fs } = await makeServiceReady();
+        expect(svc.getItems().length).to.equal(0);
 
-// Suppress "unused" warnings for helpers that are called in Task 2.
-void makeServiceReady;
-void sleep;
+        let changeFires = 0;
+        svc.onDidChange(() => { changeFires += 1; });
+
+        // External write (simulates cloud sync / another process).
+        fs.files.set('file:///ws/.shopping-list', 'pasta.cook\nsoup.cook\n');
+        fs.fireChange('file:///ws/.shopping-list');
+
+        // Wait past the debounce window.
+        await sleep(30);
+
+        expect(svc.getItems().length).to.equal(2);
+        expect(svc.getItems()[0].path).to.equal('pasta.cook');
+        expect(changeFires).to.be.greaterThan(0);
+    });
+});

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -317,4 +317,30 @@ describe('ShoppingListService', () => {
         expect(reloadCount).to.equal(1);
         expect(svc.getItems().length).to.equal(1);
     });
+
+    it('stops reloading after dispose()', async () => {
+        const { svc, fs } = await makeServiceReady();
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const original = (svc as any).loadFromDisk.bind(svc);
+        let reloadCount = 0;
+        (svc as any).loadFromDisk = async () => {
+            reloadCount += 1;
+            return original();
+        };
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+
+        fs.files.set('file:///ws/.shopping-list', 'a.cook\n');
+        fs.fireChange('file:///ws/.shopping-list');
+
+        // Dispose before the debounce window elapses — the queued reload must be cancelled.
+        svc.dispose();
+
+        await sleep(30);
+        expect(reloadCount).to.equal(0);
+
+        // A fresh event after dispose must also not reload.
+        fs.fireChange('file:///ws/.shopping-list');
+        await sleep(30);
+        expect(reloadCount).to.equal(0);
+    });
 });

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -279,4 +279,20 @@ describe('ShoppingListService', () => {
         expect(svc.getItems().length).to.equal(0);
         expect(svc.getResult()).to.equal(undefined);
     });
+
+    it('reloads when .shopping-checked is updated externally', async () => {
+        const { svc, fs } = await makeServiceReady();
+        expect(svc.isChecked('flour')).to.equal(false);
+
+        fs.files.set('file:///ws/.shopping-checked', '+ flour\n');
+        fs.fireChange('file:///ws/.shopping-checked');
+        await sleep(30);
+        expect(svc.isChecked('flour')).to.equal(true);
+
+        // An external unchecked entry wins.
+        fs.files.set('file:///ws/.shopping-checked', '+ flour\n- flour\n');
+        fs.fireChange('file:///ws/.shopping-checked');
+        await sleep(30);
+        expect(svc.isChecked('flour')).to.equal(false);
+    });
 });

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -295,4 +295,26 @@ describe('ShoppingListService', () => {
         await sleep(30);
         expect(svc.isChecked('flour')).to.equal(false);
     });
+
+    it('coalesces rapid file change events into one reload', async () => {
+        const { svc, fs } = await makeServiceReady();
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const original = (svc as any).loadFromDisk.bind(svc);
+        let reloadCount = 0;
+        (svc as any).loadFromDisk = async () => {
+            reloadCount += 1;
+            return original();
+        };
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+
+        fs.files.set('file:///ws/.shopping-list', 'a.cook\n');
+        // Fire 5 events back-to-back within the 5ms debounce window.
+        for (let i = 0; i < 5; i += 1) {
+            fs.fireChange('file:///ws/.shopping-list');
+        }
+        await sleep(30);
+
+        expect(reloadCount).to.equal(1);
+        expect(svc.getItems().length).to.equal(1);
+    });
 });

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -343,4 +343,24 @@ describe('ShoppingListService', () => {
         await sleep(30);
         expect(reloadCount).to.equal(0);
     });
+
+    it('handles self-write echo idempotently', async () => {
+        const { svc, fs } = await makeServiceReady();
+        await svc.addRecipe('pasta.cook', 1);
+        expect(svc.getItems().length).to.equal(1);
+
+        // Simulate the watcher firing for our own write.
+        fs.fireChange('file:///ws/.shopping-list');
+        await sleep(30);
+
+        // State is unchanged — still exactly one item with the same path.
+        expect(svc.getItems().length).to.equal(1);
+        expect(svc.getItems()[0].path).to.equal('pasta.cook');
+
+        // Checks survive a spurious .shopping-checked echo too.
+        await svc.checkItem('flour');
+        fs.fireChange('file:///ws/.shopping-checked');
+        await sleep(30);
+        expect(svc.isChecked('flour')).to.equal(true);
+    });
 });

--- a/packages/cooklang/src/browser/shopping-list-service.spec.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.spec.ts
@@ -143,18 +143,20 @@ function makeService(): { svc: ShoppingListService; fs: FakeFileService; ls: Fak
 }
 
 /**
- * Like `makeService()` but also invokes the `@postConstruct` initializer and
- * waits for initial `loadFromDisk()` + watcher registration to complete.
+ * Like `makeService()` but also drives the service through its initial load +
+ * watcher registration. Done by calling the protected methods directly — we
+ * intentionally do not call `init()`, which is a fire-and-forget `@postConstruct`
+ * (must return `void` so InversifyJS treats the binding as sync).
  */
 async function makeServiceReady(): Promise<{ svc: ShoppingListService; fs: FakeFileService; ls: FakeLanguageService }> {
     const { svc, fs, ls } = makeService();
     /* eslint-disable @typescript-eslint/no-explicit-any */
     // Shrink the debounce so tests don't wait 100ms per reload.
     (svc as any).reloadDebounceMs = 5;
-    // Invoke the @postConstruct init manually. It's a protected method, so we
-    // go through `as any`. `init()` fires-and-forgets an async loadFromDisk,
-    // so await its returned promise chain before handing back the service.
-    await (svc as any).init();
+    // Mirror init()'s steps awaitably: toDispose bookkeeping + load + watcher.
+    (svc as any).toDispose.push((svc as any).onDidChangeEmitter);
+    await (svc as any).loadFromDisk();
+    (svc as any).setupWatcher();
     /* eslint-enable @typescript-eslint/no-explicit-any */
     return { svc, fs, ls };
 }

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -62,15 +62,14 @@ export class ShoppingListService implements Disposable {
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
 
     @postConstruct()
-    protected async init(): Promise<void> {
+    protected init(): void {
         this.toDispose.push(this.onDidChangeEmitter);
-        try {
-            await this.workspaceService.roots;
-            await this.loadFromDisk();
-        } catch (err) {
-            console.error('ShoppingListService: initial load failed', err);
-        }
-        this.setupWatcher();
+        // Fire-and-forget: InversifyJS 6.x treats a Promise-returning @postConstruct
+        // as an async binding, which breaks synchronous container.get() callers.
+        this.workspaceService.roots
+            .then(() => this.loadFromDisk())
+            .catch(err => console.error('ShoppingListService: initial load failed', err))
+            .then(() => this.setupWatcher());
     }
 
     // -- Public getters --

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -5,6 +5,7 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { CooklangLanguageService } from '../common/cooklang-language-service';
@@ -51,15 +52,25 @@ export class ShoppingListService implements Disposable {
     /** Monotonic counter to discard stale `regenerate()` results. Used in Task 9. */
     protected regenerationSeq = 0;
 
+    /** Debounce window for reloading after an external file change. Overridable in tests. */
+    protected reloadDebounceMs = 100;
+
+    /** Active debounce timer, if any. */
+    protected reloadTimer: ReturnType<typeof setTimeout> | undefined;
+
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
 
     @postConstruct()
-    protected init(): void {
+    protected async init(): Promise<void> {
         this.toDispose.push(this.onDidChangeEmitter);
-        this.workspaceService.roots
-            .then(() => this.loadFromDisk())
-            .catch(err => console.error('ShoppingListService: initial load failed', err));
+        try {
+            await this.workspaceService.roots;
+            await this.loadFromDisk();
+        } catch (err) {
+            console.error('ShoppingListService: initial load failed', err);
+        }
+        this.setupWatcher();
     }
 
     // -- Public getters --
@@ -338,6 +349,49 @@ export class ShoppingListService implements Disposable {
         });
         await this.saveList();
         await this.regenerate();
+    }
+
+    protected setupWatcher(): void {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+        try {
+            this.toDispose.push(this.fileService.watch(root));
+        } catch (e) {
+            console.error('[shopping-list] Failed to register watcher:', e);
+        }
+        this.toDispose.push(this.fileService.onDidFilesChange(event => this.onFilesChanged(event)));
+        this.toDispose.push(Disposable.create(() => {
+            if (this.reloadTimer !== undefined) {
+                clearTimeout(this.reloadTimer);
+                this.reloadTimer = undefined;
+            }
+        }));
+    }
+
+    protected onFilesChanged(event: FileChangesEvent): void {
+        const root = this.getWorkspaceRootUri();
+        if (!root) {
+            return;
+        }
+        const listUri = root.resolve(LIST_FILE);
+        const checkedUri = root.resolve(CHECKED_FILE);
+        if (event.contains(listUri) || event.contains(checkedUri)) {
+            this.scheduleReload();
+        }
+    }
+
+    protected scheduleReload(): void {
+        if (this.reloadTimer !== undefined) {
+            clearTimeout(this.reloadTimer);
+        }
+        this.reloadTimer = setTimeout(() => {
+            this.reloadTimer = undefined;
+            this.loadFromDisk().catch(err =>
+                console.error('[shopping-list] Reload after file change failed:', err),
+            );
+        }, this.reloadDebounceMs);
     }
 
     /**

--- a/packages/cooklang/src/browser/shopping-list-service.ts
+++ b/packages/cooklang/src/browser/shopping-list-service.ts
@@ -125,6 +125,7 @@ export class ShoppingListService implements Disposable {
         if (this.list.items.length > 0) {
             await this.regenerate();
         } else {
+            this.result = undefined;
             this.onDidChangeEmitter.fire();
         }
     }


### PR DESCRIPTION
## Summary
- `ShoppingListService` now watches `.shopping-list` and `.shopping-checked` in the workspace root and reloads from disk on external change (cloud sync, `git pull`, other windows, manual edits). Disk is treated as source of truth.
- Rapid events are debounced ~100ms and coalesced into a single reload. Existing `regenerationSeq` cancels stale in-flight regens. Deletion resets state to empty. Self-write echo is idempotent.
- Small related bugfix: `loadFromDisk()` now clears `this.result` when the list becomes empty (previously only `clearAll()`/`regenerate()` did this — exposed by the new delete test).
- 6 new unit tests: external update, external delete, `.shopping-checked` update, debounce coalescing, dispose cancellation, self-write echo.

Spec: `docs/superpowers/specs/2026-04-13-shopping-list-file-watching-design.md`
Plan: `docs/superpowers/plans/2026-04-13-shopping-list-file-watching.md`

## Test plan
- [x] `npx lerna run compile --scope @theia/cooklang` — clean
- [x] `npx lerna run test --scope @theia/cooklang` — 12/12 pass
- [ ] Manual: edit `.shopping-list` externally (e.g., `echo pasta.cook > .shopping-list`) and confirm the UI updates without restart
- [ ] Manual: delete `.shopping-list` externally and confirm list resets to empty
- [ ] Manual: check an item in the UI, verify the watcher echo doesn't corrupt state