### PR TITLE
ci(release): fix Linux native deps and npm install rate limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      # native-keymap compiles against libx11/libxkbfile headers on Linux
+      - name: Install Linux native build deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev
+
       - name: Install dependencies
         run: npm install
+        env:
+          # @vscode/ripgrep and other GitHub-release downloads hit anonymous
+          # rate limits (403) without a token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build native addon
         working-directory: packages/cooklang-native


### PR DESCRIPTION
Dry run surfaced two install failures:

- Linux: node-gyp build of `native-keymap` failed without `libx11` / `libxkbfile` headers. Added an apt-get step gated on `runner.os == 'Linux'`.
- macOS arm64: `@vscode/ripgrep` got a 403 downloading from GitHub. Passed `GITHUB_TOKEN` to the npm install step so downloads are authenticated.

Failure evidence: run 24393927787.