### PR TITLE
ci(release): raise Node heap for webpack bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Bundle Electron app
         working-directory: examples/electron
         run: npm run bundle
+        env:
+          # webpack hits the default 2 GB heap on Windows; give it room
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Package & Publish
         working-directory: examples/electron


### PR DESCRIPTION
Windows bundle step OOM'd (run 24393927787). Bumping `NODE_OPTIONS=--max-old-space-size=8192`.