### PR TITLE
ci(release): add electron-builder metadata, drop unavailable Intel Mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,11 @@ jobs:
         include:
           - os: macos-latest
             platform: mac-arm64
-          - os: macos-13
-            platform: mac-x64
+          # macos-13 (Intel) runners are unavailable on this account and
+          # consistently never allocate. Re-enable when Intel Mac builds
+          # are needed and runner availability is confirmed.
+          # - os: macos-13
+          #   platform: mac-x64
           - os: windows-latest
             platform: win
           - os: ubuntu-latest

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -5,6 +5,11 @@
   "version": "1.70.0",
   "main": "lib/backend/electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "homepage": "https://cooklang.org",
+  "author": {
+    "name": "Cooklang",
+    "email": "dubovskoy.a@gmail.com"
+  },
   "theia": {
     "target": "electron",
     "frontend": {


### PR DESCRIPTION
Second dry-run (24395494746):
- Linux Package & Publish failed — `electron-builder` requires `homepage` (and conventionally `author`) in package.json. Added both to `examples/electron/package.json`.
- macos-13 Intel job never got a runner (runner_id=0, 0 steps) in two consecutive runs. Commented out with a re-enable note.
- macOS arm64 bundle+package succeeded; Windows still running at time of push.