### PR TITLE
release: v0.1.0-alpha.0

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@theia/example-electron",
   "productName": "CookMD",
-  "version": "1.70.0",
+  "version": "0.1.0-alpha.0",
   "main": "lib/backend/electron-main.js",
   "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
   "homepage": "https://cooklang.org",


### PR DESCRIPTION
First alpha of CookMD. Version bump only — `@theia/*` workspace packages stay at 1.70.0. After merge I'll tag `v0.1.0-alpha.0` to trigger the release pipeline with `--publish always`.