### PR TITLE
fix(ci): stop forcing host-arch Electron into x64 DMG

### DIFF
--- a/examples/electron/electron-builder.yml
+++ b/examples/electron/electron-builder.yml
@@ -1,7 +1,9 @@
 appId: md.cook.cooked
 productName: CookEd
 copyright: Copyright © 2026 Cooklang
-electronDist: ../../node_modules/electron/dist
+# Do NOT set electronDist — it would pin to the host-arch Electron installed
+# by npm and produce arm64 binaries even inside an x64 DMG. Let electron-
+# builder resolve and download the correct-arch Electron per target.
 electronVersion: 38.4.0
 asar: true
 asarUnpack:


### PR DESCRIPTION
## Summary
The x64 DMG we shipped in v0.1.0-alpha.0 was wrapper-x64 but its Electron binary + frameworks were still arm64, so it fails to launch on Intel Macs.

Root cause: \`electronDist: ../../node_modules/electron/dist\` in electron-builder.yml pins the packaged Electron to whatever arch was installed on the runner (arm64 on macos-latest). Cross-compile can't swap it.

Fix: drop \`electronDist\`. electron-builder now resolves the right-arch Electron per target via \`electronVersion: 38.4.0\`.

## Test plan
- [ ] Retag alpha, confirm x64 DMG contains x64 \`CookEd.app/Contents/MacOS/CookEd\` via \`file\`
- [ ] Install + launch on Intel Mac