### PR TITLE
feat(account): align subscription protocol with Rails refactor

### DIFF
--- a/docs/superpowers/plans/2026-04-16-subscription-refactor-alignment.md
+++ b/docs/superpowers/plans/2026-04-16-subscription-refactor-alignment.md
@@ -1,0 +1,594 @@
+# Subscription Refactor Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align the editor's subscription client with the refactored Rails
+`/api/subscription` response (new `plan_slug`/`plan_name`/`tokens_remaining`
+fields, drop legacy `monthly`|`annual` plan field), surface AI token balance
+in the account widget, and remove the cosmetic sync paywall.
+
+**Architecture:** Pure client-side alignment. No Rails, proto, or gRPC changes.
+Subscription JSON mapping lives in `packages/cooklang-account/src/node/subscription-service.ts`;
+UI lives in `packages/cooklang-account/src/browser/account-widget.tsx`. The
+`SubscriptionService` RPC interface is unchanged — only the `SubscriptionState`
+payload shape changes.
+
+**Tech Stack:** TypeScript, InversifyJS, React (Theia ReactWidget), Lumino
+messaging (`onActivateRequest` lifecycle hook).
+
+---
+
+## Preconditions
+
+- Working directory: `/Users/alexeydubovskoy/Cooklang/editor`.
+- Branch: `main` is clean. Create a feature branch before starting.
+- Rails backend already returns the new fields (verified in `cook.md/web`
+  at `app/controllers/api/subscriptions_controller.rb`).
+- No backward compatibility required — fields are renamed/dropped cleanly.
+
+## Files touched
+
+- **Modify:** `packages/cooklang-account/src/common/subscription-protocol.ts`
+- **Modify:** `packages/cooklang-account/src/node/subscription-service.ts`
+- **Modify:** `packages/cooklang-account/src/browser/account-widget.tsx`
+- **Modify:** `packages/cooklang-account/src/browser/style/index.css`
+
+No new files. No package.json changes (dependencies already in place).
+
+---
+
+## Task 0: Create feature branch
+
+**Files:** none (git-only).
+
+- [ ] **Step 1: Verify clean tree and create branch**
+
+Run:
+```bash
+git status
+git checkout -b feat/subscription-refactor-alignment
+```
+Expected: `On branch feat/subscription-refactor-alignment`, clean tree.
+
+---
+
+## Task 1: Update `SubscriptionState` type
+
+**Files:**
+- Modify: `packages/cooklang-account/src/common/subscription-protocol.ts`
+
+- [ ] **Step 1: Replace the `SubscriptionState` interface**
+
+Current (lines 11–18) is:
+```ts
+export interface SubscriptionState {
+    status: 'trial' | 'active' | 'expired' | 'grandfathered' | 'canceled' | 'paused' | 'none';
+    hasAccess: boolean;
+    features: string[];
+    plan: 'monthly' | 'annual' | undefined;
+    expiresAt: string | undefined;
+    trialDaysRemaining: number | undefined;
+}
+```
+
+Replace with:
+```ts
+export interface SubscriptionState {
+    status: 'trial' | 'active' | 'past_due' | 'expired' | 'grandfathered' | 'canceled' | 'paused' | 'none';
+    hasAccess: boolean;
+    features: string[];
+    planSlug: string | undefined;
+    planName: string | undefined;
+    tokensRemaining: number;
+    expiresAt: string | undefined;
+    trialDaysRemaining: number | undefined;
+    trialAvailable: boolean;
+    billingPeriodStart: string | undefined;
+    billingPeriodEnd: string | undefined;
+}
+```
+
+- [ ] **Step 2: Compile the account package to surface all type errors**
+
+Run:
+```bash
+npx lerna run compile --scope @theia/cooklang-account
+```
+Expected: TypeScript errors in `subscription-service.ts` (missing fields) and
+`account-widget.tsx` (references to the removed `plan` field). These errors are
+resolved by the next tasks. Do **not** run the root compile yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang-account/src/common/subscription-protocol.ts
+git commit -m "refactor(account): update SubscriptionState to match Rails refactor"
+```
+
+---
+
+## Task 2: Map new JSON fields in subscription service
+
+**Files:**
+- Modify: `packages/cooklang-account/src/node/subscription-service.ts`
+
+- [ ] **Step 1: Update `fetchSubscription()` to map the new Rails shape**
+
+Replace the body of the `try` block that parses the response (current lines
+73–83) with:
+
+```ts
+            const data = JSON.parse(response);
+            this.cachedState = {
+                status: data.status ?? 'none',
+                hasAccess: data.has_access ?? false,
+                features: data.features ?? [],
+                planSlug: data.plan_slug ?? undefined,
+                planName: data.plan_name ?? undefined,
+                tokensRemaining: typeof data.tokens_remaining === 'number' ? data.tokens_remaining : 0,
+                expiresAt: data.expires_at ?? undefined,
+                trialDaysRemaining: data.trial_days_remaining ?? undefined,
+                trialAvailable: data.trial_available ?? false,
+                billingPeriodStart: data.billing_period_start ?? undefined,
+                billingPeriodEnd: data.billing_period_end ?? undefined,
+            };
+            this.cacheTimestamp = Date.now();
+            this.onDidChangeSubscriptionEmitter.fire(this.cachedState);
+```
+
+Leave the 401/403 handling in the `catch` unchanged.
+
+- [ ] **Step 2: Compile to verify the service is clean**
+
+Run:
+```bash
+npx lerna run compile --scope @theia/cooklang-account
+```
+Expected: errors in `account-widget.tsx` only (it still references the removed
+`plan` field). `subscription-service.ts` is clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang-account/src/node/subscription-service.ts
+git commit -m "feat(account): map plan_slug/plan_name/tokens_remaining from Rails"
+```
+
+---
+
+## Task 3: Account widget — plan label
+
+**Files:**
+- Modify: `packages/cooklang-account/src/browser/account-widget.tsx`
+
+- [ ] **Step 1: Rewrite `getPlanLabel` to prefer `planName` and handle `past_due`**
+
+Replace the current `getPlanLabel` method (lines 259–271):
+
+```ts
+    private getPlanLabel(subscription: SubscriptionState): string {
+        switch (subscription.status) {
+            case 'trial': return nls.localize('theia/cooklang-account/planTrial', 'Trial');
+            case 'active': return subscription.plan === 'annual'
+                ? nls.localize('theia/cooklang-account/planAnnual', 'Pro (Annual)')
+                : nls.localize('theia/cooklang-account/planMonthly', 'Pro (Monthly)');
+            case 'grandfathered': return nls.localize('theia/cooklang-account/planGrandfathered', 'Pro (Grandfathered)');
+            case 'canceled': return nls.localize('theia/cooklang-account/planCanceled', 'Canceled');
+            case 'paused': return nls.localize('theia/cooklang-account/planPaused', 'Paused');
+            case 'expired': return nls.localize('theia/cooklang-account/planExpired', 'Expired');
+            default: return nls.localize('theia/cooklang-account/planFree', 'Free');
+        }
+    }
+```
+
+with:
+
+```ts
+    private getPlanLabel(subscription: SubscriptionState): string {
+        // Rails owns the display name — prefer it when present.
+        if (subscription.planName) {
+            return subscription.planName;
+        }
+        switch (subscription.status) {
+            case 'trial': return nls.localize('theia/cooklang-account/planTrial', 'Trial');
+            case 'grandfathered': return nls.localize('theia/cooklang-account/planGrandfathered', 'Pro (Grandfathered)');
+            case 'past_due': return nls.localize('theia/cooklang-account/planPastDue', 'Pro (Payment Issue)');
+            case 'canceled': return nls.localize('theia/cooklang-account/planCanceled', 'Canceled');
+            case 'paused': return nls.localize('theia/cooklang-account/planPaused', 'Paused');
+            case 'expired': return nls.localize('theia/cooklang-account/planExpired', 'Expired');
+            default: return nls.localize('theia/cooklang-account/planFree', 'Free');
+        }
+    }
+```
+
+- [ ] **Step 2: Compile**
+
+Run:
+```bash
+npx lerna run compile --scope @theia/cooklang-account
+```
+Expected: clean. The removed `plan` field reference is gone.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang-account/src/browser/account-widget.tsx
+git commit -m "feat(account): use Rails plan_name for plan label, add past_due case"
+```
+
+---
+
+## Task 4: Account widget — AI token balance section
+
+**Files:**
+- Modify: `packages/cooklang-account/src/browser/account-widget.tsx`
+- Modify: `packages/cooklang-account/src/browser/style/index.css`
+
+- [ ] **Step 1: Add a `renderAiTokensSection` method**
+
+Insert this method immediately after `renderSyncSection` (around line 233,
+before `renderSubscriptionUpgrade`):
+
+```tsx
+    protected renderAiTokensSection(subscription: SubscriptionState): React.ReactNode {
+        const tokens = subscription.tokensRemaining;
+        const tokensClass = tokens <= 0
+            ? 'theia-account-row-label theia-account-sync-error'
+            : 'theia-account-row-label';
+        const resetsLabel = subscription.billingPeriodEnd
+            ? new Date(subscription.billingPeriodEnd).toLocaleDateString()
+            : undefined;
+        return (
+            <React.Fragment>
+                <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/aiHeader', 'AI Assistant')}</div>
+                <div className='theia-account-row'>
+                    <i className='codicon codicon-sparkle' />
+                    <span className={tokensClass}>
+                        {nls.localize('theia/cooklang-account/aiTokensRemaining', '{0} tokens remaining', tokens.toLocaleString())}
+                    </span>
+                </div>
+                {resetsLabel && (
+                    <div className='theia-account-row theia-account-sync-status'>
+                        <i className='codicon codicon-history' />
+                        <span className='theia-account-row-label'>
+                            {nls.localize('theia/cooklang-account/aiTokensResets', 'Resets {0}', resetsLabel)}
+                        </span>
+                    </div>
+                )}
+            </React.Fragment>
+        );
+    }
+```
+
+- [ ] **Step 2: Call `renderAiTokensSection` in `renderSubscriptionActive`**
+
+In `renderSubscriptionActive` (around lines 170–198), currently:
+
+```tsx
+                {hasSyncFeature && this.renderSyncSection(statusLabel)}
+```
+
+Add an AI tokens section immediately before the sync section. The block from
+`<div className='theia-account-row theia-account-row-interactive' onClick={this.handleManageSubscription}>` onward should look like:
+
+```tsx
+                <div className='theia-account-row theia-account-row-interactive' onClick={this.handleManageSubscription}>
+                    <i className='codicon codicon-link-external' />
+                    <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/manageSubscription', 'Manage Subscription')}</span>
+                </div>
+                {subscription.features.includes('ai') && this.renderAiTokensSection(subscription)}
+                {hasSyncFeature && this.renderSyncSection(statusLabel)}
+```
+
+(Task 5 will remove the `hasSyncFeature` gate; this task keeps it as-is.)
+
+- [ ] **Step 3: Compile**
+
+Run:
+```bash
+npx lerna run compile --scope @theia/cooklang-account
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-account/src/browser/account-widget.tsx
+git commit -m "feat(account): show AI token balance and reset date in widget"
+```
+
+---
+
+## Task 5: Remove sync paywall
+
+**Files:**
+- Modify: `packages/cooklang-account/src/browser/account-widget.tsx`
+
+- [ ] **Step 1: Drop the sync feature gate in `renderSubscriptionActive`**
+
+In `renderSubscriptionActive` (the block edited in Task 4), currently:
+
+```tsx
+    protected renderSubscriptionActive(subscription: SubscriptionState): React.ReactNode {
+        const planLabel = this.getPlanLabel(subscription);
+        const hasSyncFeature = subscription.features.includes('sync');
+        const statusLabel = this.syncStatus.status.charAt(0).toUpperCase() + this.syncStatus.status.slice(1);
+```
+
+Replace with:
+
+```tsx
+    protected renderSubscriptionActive(subscription: SubscriptionState): React.ReactNode {
+        const planLabel = this.getPlanLabel(subscription);
+        const statusLabel = this.syncStatus.status.charAt(0).toUpperCase() + this.syncStatus.status.slice(1);
+```
+
+And change the conditional sync render:
+
+```tsx
+                {hasSyncFeature && this.renderSyncSection(statusLabel)}
+```
+
+to:
+
+```tsx
+                {this.renderSyncSection(statusLabel)}
+```
+
+- [ ] **Step 2: Render sync section in `renderSubscriptionUpgrade`**
+
+Current `renderSubscriptionUpgrade` (lines 235–257):
+
+```tsx
+    protected renderSubscriptionUpgrade(): React.ReactNode {
+        return (
+            <React.Fragment>
+                <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/subscriptionHeader', 'Subscription')}</div>
+                <div className='theia-account-upgrade-section'>
+                    <div className='theia-account-upgrade-message'>
+                        {nls.localize('theia/cooklang-account/upgradeMessage', 'Upgrade to unlock sync, AI assistance, and more features.')}
+                    </div>
+                    <button
+                        className='theia-button main theia-account-upgrade-button'
+                        onClick={this.handleUpgrade}
+                    >
+                        {nls.localize('theia/cooklang-account/upgradeButton', 'Upgrade to Pro')}
+                    </button>
+                </div>
+                <div className='theia-account-divider' />
+                <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
+                    <i className='codicon codicon-sign-out' />
+                    <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/logOut', 'Log Out')}</span>
+                </div>
+            </React.Fragment>
+        );
+    }
+```
+
+Replace with (adds sync section; updates upgrade-message copy):
+
+```tsx
+    protected renderSubscriptionUpgrade(): React.ReactNode {
+        const statusLabel = this.syncStatus.status.charAt(0).toUpperCase() + this.syncStatus.status.slice(1);
+        return (
+            <React.Fragment>
+                <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/subscriptionHeader', 'Subscription')}</div>
+                <div className='theia-account-upgrade-section'>
+                    <div className='theia-account-upgrade-message'>
+                        {nls.localize('theia/cooklang-account/upgradeMessage', 'Upgrade to unlock AI assistance and more features.')}
+                    </div>
+                    <button
+                        className='theia-button main theia-account-upgrade-button'
+                        onClick={this.handleUpgrade}
+                    >
+                        {nls.localize('theia/cooklang-account/upgradeButton', 'Upgrade to Pro')}
+                    </button>
+                </div>
+                {this.renderSyncSection(statusLabel)}
+                <div className='theia-account-divider' />
+                <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
+                    <i className='codicon codicon-sign-out' />
+                    <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/logOut', 'Log Out')}</span>
+                </div>
+            </React.Fragment>
+        );
+    }
+```
+
+- [ ] **Step 3: Compile**
+
+Run:
+```bash
+npx lerna run compile --scope @theia/cooklang-account
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-account/src/browser/account-widget.tsx
+git commit -m "feat(account): remove sync feature paywall, sync available to all logged-in users"
+```
+
+---
+
+## Task 6: Refresh subscription when widget activates
+
+**Files:**
+- Modify: `packages/cooklang-account/src/browser/account-widget.tsx`
+
+- [ ] **Step 1: Import Lumino `Message` type**
+
+At the top of the file, add (after the existing imports):
+
+```ts
+import { Message } from '@lumino/messaging';
+```
+
+- [ ] **Step 2: Override `onActivateRequest`**
+
+Insert this method immediately before the existing `startSyncPolling` method
+(around line 85):
+
+```ts
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        // Pull latest subscription state so tokens_remaining and plan reflect reality
+        // whenever the user opens/focuses the account widget.
+        this.subscriptionFrontendService.refresh().catch(err => {
+            console.warn('Failed to refresh subscription on widget activation:', err);
+        });
+    }
+```
+
+- [ ] **Step 3: Compile**
+
+Run:
+```bash
+npx lerna run compile --scope @theia/cooklang-account
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-account/src/browser/account-widget.tsx
+git commit -m "feat(account): refresh subscription state when account widget activates"
+```
+
+---
+
+## Task 7: Full build
+
+**Files:** none (build-only).
+
+- [ ] **Step 1: Compile the whole workspace**
+
+Run:
+```bash
+npm run compile
+```
+Expected: clean. If errors reference `subscription-protocol`, `SubscriptionState`,
+or the removed `plan` field in any other package, fix them in place with the
+same renames used in Tasks 1–3 and add a follow-up commit scoped to that file.
+
+- [ ] **Step 2: Lint the touched packages**
+
+Run:
+```bash
+npx lerna run lint --scope @theia/cooklang-account
+```
+Expected: clean.
+
+- [ ] **Step 3: Bundle the Electron app**
+
+Run:
+```bash
+cd examples/electron && npm run bundle && cd -
+```
+Expected: bundle completes without errors.
+
+- [ ] **Step 4: Commit any follow-ups if produced**
+
+If Step 1 required fixes outside `cooklang-account`, commit them with a message
+like:
+```bash
+git commit -m "refactor: propagate SubscriptionState rename to <package>"
+```
+
+---
+
+## Task 8: Manual verification
+
+**Files:** none (manual test only).
+
+- [ ] **Step 1: Start the Electron app**
+
+Run:
+```bash
+npm run start:electron
+```
+
+- [ ] **Step 2: Verify AI user (feature includes `'ai'`)**
+
+Log in as a user with the `pro_early_adopter_v1` plan. Open the account panel.
+
+Expected:
+- Plan label shows `AI (Early Adopter)` (from Rails `plan_name`).
+- AI section shows `1,000,000 tokens remaining` (or the real balance).
+- Sync section is visible under AI section.
+- Close and re-open the account widget → values reflect the latest Rails
+  state (refresh-on-activate fired; inspect network tab or backend logs if
+  in doubt).
+
+- [ ] **Step 3: Verify free / non-AI user**
+
+Log in as a user with no active subscription (or trigger an expired one).
+
+Expected:
+- Widget shows the upgrade section with copy "Upgrade to unlock AI
+  assistance and more features." (no "sync" in the message).
+- Sync section is **still visible** and toggle-able.
+- No AI token row.
+- Open the branded chat widget (Cookbot) → still shows the "Get AI Addon"
+  overlay (unchanged behavior from `cooklang-branding`).
+
+- [ ] **Step 4: Verify logged-out state**
+
+Log out.
+
+Expected:
+- Widget shows login prompt only; no sync UI, no plan badge, no AI row.
+
+- [ ] **Step 5: Verify past_due (optional — requires a prepared account)**
+
+If a `past_due` test account is available, log in.
+
+Expected:
+- Plan label shows `AI (Early Adopter)` (Rails still returns `plan_name`; we
+  prefer that over the status fallback). If Rails clears `plan_name` for
+  `past_due`, the status fallback `Pro (Payment Issue)` kicks in.
+- AI and sync sections still accessible (`active_for_access?` is true for
+  `past_due` server-side).
+
+- [ ] **Step 6: Open PR**
+
+Run:
+```bash
+git push -u origin feat/subscription-refactor-alignment
+gh pr create --title "Align subscription client with refactored Rails API" \
+    --body "$(cat <<'EOF'
+## Summary
+- Replace `SubscriptionState.plan` (`'monthly'|'annual'`) with `planSlug`, `planName`, `tokensRemaining`, `billingPeriodStart/End`, `trialAvailable`.
+- Map new fields from `/api/subscription` in `subscription-service.ts`.
+- Show AI token balance and reset date in the account widget (gated on `features.includes('ai')`).
+- Remove the cosmetic sync paywall — sync is available to any logged-in user.
+- Refresh subscription state when the account widget is activated.
+- Add `past_due` case to status handling.
+
+Spec: `docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md`
+Plan: `docs/superpowers/plans/2026-04-16-subscription-refactor-alignment.md`
+
+## Test plan
+- [ ] AI user: plan name, token balance, sync all show correctly
+- [ ] Free user: upgrade copy updated, sync still visible
+- [ ] Logged out: login prompt only
+- [ ] Widget re-open triggers subscription refresh
+EOF
+)"
+```
+
+---
+
+## Rollback
+
+If any task produces unexpected behavior in production and a quick revert is
+needed:
+
+```bash
+git revert <merge-commit-sha>
+```
+
+Rails is already returning the new fields; reverting the editor just means the
+widget shows the old labels (`Pro (Monthly)`/`Pro (Annual)`) and sync
+re-paywalls, but nothing breaks.

--- a/docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md
@@ -1,0 +1,205 @@
+# Subscription refactor alignment (editor ↔ cook.md/web)
+
+## Background
+
+`cook.md/web` recently refactored billing (commits `3af93a43…0bdfceb5`):
+
+- Dropped legacy `subscriptions.plan` (`'monthly'|'annual'`) and `purchased_features` columns.
+- New source of truth: `plan_slug` → `Plans` catalog (`lib/plans.rb`) → `features` array + `monthly_token_allowance`.
+- `GET /api/subscription` now returns `plan_slug`, `plan_name`, `tokens_remaining`,
+  `billing_period_start/end`, `trial_available`, `usage`; no longer returns `plan`.
+- New endpoint `GET /api/cookbot/session_snapshot` feeds the Rust cookbot server
+  for AI gating and token quota.
+- Only plan in the catalog today: `pro_early_adopter_v1` — features
+  `%w[sync image_clipping ai]`, allowance `1_000_000` tokens/month.
+
+The editor (`editor`) still speaks the pre-refactor protocol:
+
+- `SubscriptionState.plan: 'monthly' | 'annual' | undefined` — dead field.
+- `getPlanLabel()` in `account-widget.tsx` branches on the dead field.
+- No `planSlug`, `planName`, `tokensRemaining`, `billingPeriodStart/End`,
+  `trialAvailable` in `SubscriptionState`.
+- Account widget shows no token balance (the refactored web UI does; commit `2a103770`).
+- `cooklang-ai` has no client-side feature gating; gRPC call fails with
+  `permission_denied: ai_feature_not_available` for non-AI users — opaque in chat.
+- Account widget hides sync UI behind `features.includes('sync')`. Rails/sync-server
+  don't actually enforce a `sync` feature flag, so this is a cosmetic paywall.
+
+## Goals
+
+1. Align editor's subscription protocol with Rails' current JSON.
+2. Surface AI token balance and billing cycle in the account widget.
+3. Client-side gate AI chat for users without the `ai` feature.
+4. Remove the cosmetic sync paywall from the account widget.
+
+No backward-compatibility shims: fields are renamed/dropped cleanly.
+
+## Non-goals
+
+- Changing the Rails `Plans` catalog (including whether `sync` should remain in
+  plan features now that the client treats it as free).
+- Refreshing subscription state after each cookbot message — the 5-min cache is
+  acceptable for v1.
+- Token allowance / usage progress bar (we don't ship the `Plans` catalog to
+  the client; Rails' own page is authoritative for detailed usage).
+- Handling `past_due` specially beyond a status-aware label.
+- Touching `cooklang-ai/proto/cookbot.proto` — `subscription_tier` in the proto
+  is unused by the client.
+
+## Design
+
+### 1. Subscription protocol & data model
+
+Replace `SubscriptionState` in
+`packages/cooklang-account/src/common/subscription-protocol.ts` with the
+current-Rails-aligned shape:
+
+```ts
+export interface SubscriptionState {
+    status: 'trial' | 'active' | 'past_due' | 'expired' | 'grandfathered' | 'canceled' | 'paused' | 'none';
+    hasAccess: boolean;
+    features: string[];                       // e.g. ['sync', 'image_clipping', 'ai']
+    planSlug: string | undefined;             // e.g. 'pro_early_adopter_v1'
+    planName: string | undefined;             // e.g. 'AI (Early Adopter)'
+    tokensRemaining: number;                  // 0 if no AI plan
+    expiresAt: string | undefined;            // ISO8601
+    trialDaysRemaining: number | undefined;
+    trialAvailable: boolean;
+    billingPeriodStart: string | undefined;   // ISO8601
+    billingPeriodEnd: string | undefined;     // ISO8601
+}
+```
+
+Changes vs. today: drop `plan`; add `planSlug`, `planName`, `tokensRemaining`,
+`trialAvailable`, `billingPeriodStart`, `billingPeriodEnd`; expand `status` to
+include `'past_due'`.
+
+The rest of the file (the `SubscriptionService` RPC interface, the service
+path, the symbol) stays unchanged.
+
+### 2. Backend mapping
+
+`packages/cooklang-account/src/node/subscription-service.ts` —
+`fetchSubscription()` maps the new Rails JSON into the new `SubscriptionState`:
+
+```ts
+this.cachedState = {
+    status: data.status ?? 'none',
+    hasAccess: data.has_access ?? false,
+    features: data.features ?? [],
+    planSlug: data.plan_slug ?? undefined,
+    planName: data.plan_name ?? undefined,
+    tokensRemaining: typeof data.tokens_remaining === 'number' ? data.tokens_remaining : 0,
+    expiresAt: data.expires_at ?? undefined,
+    trialDaysRemaining: data.trial_days_remaining ?? undefined,
+    trialAvailable: data.trial_available ?? false,
+    billingPeriodStart: data.billing_period_start ?? undefined,
+    billingPeriodEnd: data.billing_period_end ?? undefined,
+};
+```
+
+401/403 handling (clear session) is unchanged.
+
+### 3. Account widget — plan label + token balance
+
+`packages/cooklang-account/src/browser/account-widget.tsx`:
+
+- **Plan label** (`getPlanLabel`):
+  - If `subscription.planName` is set → show verbatim. Rails owns the display
+    name (future plans, marketing changes — client stays dumb).
+  - Else fall back to status-based labels (`Trial`, `Grandfathered`,
+    `Canceled`, `Paused`, `Expired`, default `Free`).
+  - Add `'past_due'` → `'Pro (Payment Issue)'`.
+- **Token balance section**, rendered inside `renderSubscriptionActive()` above
+  the sync section, gated by `features.includes('ai')`:
+  - Row: `AI tokens: {tokensRemaining.toLocaleString()} remaining`.
+  - If `billingPeriodEnd` is set, muted sub-line: `Resets {localized date}`.
+  - If `tokensRemaining <= 0`, mark the value with the existing
+    `theia-account-sync-error` style so the depleted state reads clearly.
+  - No progress bar (no client-side allowance). Rails' page has the full
+    breakdown.
+
+### 4. AI client-side gating
+
+`packages/cooklang-ai/src/browser/cookbot-chat-agent.ts`:
+
+- Inject `SubscriptionFrontendService` from
+  `@theia/cooklang-account/lib/browser/subscription-frontend-service`.
+- Override the chat-agent request entry point (`invoke(request)` or the closest
+  `AbstractStreamParsingChatAgent` hook that lets us short-circuit before any
+  gRPC call).
+- Pre-check:
+  - If `subscription` loaded and `features.includes('ai') === false` → emit a
+    single assistant message: `AI assistance requires a Pro subscription.
+    [Upgrade at cook.md/pricing](https://cook.md/pricing)` (localized,
+    markdown link). Return a completed stream; skip gRPC.
+  - If `subscription === undefined` (loading) → `await
+    subscriptionFrontendService.refresh()` with a short timeout, then re-check.
+    If still undefined → fail open (let the request go; server will gate with
+    the existing `permission_denied` path).
+- Depletion (`tokens_remaining <= 0`): out of scope here; server returns a
+  separate error that can be handled later.
+- Add `@theia/cooklang-account` to `packages/cooklang-ai/package.json`
+  dependencies if not already present (verify before committing).
+
+### 5. Remove sync paywall
+
+`packages/cooklang-account/src/browser/account-widget.tsx`:
+
+- Delete the `hasSyncFeature = features.includes('sync')` check.
+- Render the sync section inside **both** `renderSubscriptionActive()` and
+  `renderSubscriptionUpgrade()` — factor/call `renderSyncSection(...)` from
+  both paths. Sync is free for any logged-in user.
+- Sync UI is **not** shown when logged out (same as today — `renderLoginPrompt`
+  unchanged).
+- Update the upgrade-prompt copy (`theia/cooklang-account/upgradeMessage`):
+  `'Upgrade to unlock sync, AI assistance, and more features.'` →
+  `'Upgrade to unlock AI assistance and more features.'`
+- Login-prompt copy (`theia/cooklang-account/loginMessage`) unchanged.
+
+Rails' `Plans` catalog still lists `'sync'` in plan features. The editor now
+ignores that bit for gating purposes. Deciding whether to remove it from the
+catalog is a separate pricing/marketing call.
+
+### 6. Refresh lifecycle
+
+- Keep the existing 5-min TTL cache in `subscription-service.ts`.
+- Keep the existing auth-change triggered refresh.
+- Call `subscriptionFrontendService.refresh()` when the account widget is
+  opened/activated so the token balance and plan reflect reality on user
+  action. Cheap, and the natural UX check-in moment.
+- No per-chat-message refresh.
+
+## Files touched
+
+1. `packages/cooklang-account/src/common/subscription-protocol.ts` — new `SubscriptionState` shape.
+2. `packages/cooklang-account/src/node/subscription-service.ts` — map new Rails JSON fields.
+3. `packages/cooklang-account/src/browser/account-widget.tsx` — new plan label, token balance, refresh-on-activate, remove sync paywall, updated copy.
+4. `packages/cooklang-ai/src/browser/cookbot-chat-agent.ts` — AI feature gating.
+5. `packages/cooklang-ai/package.json` — add `@theia/cooklang-account` dep if missing.
+
+## Files intentionally not touched
+
+- `packages/cooklang-ai/src/node/cookbot-language-model.ts`,
+  `cookbot-grpc-client.ts` — server gates AI via `session_snapshot`.
+- `packages/cooklang-ai/proto/cookbot.proto` — unused `subscription_tier` field.
+- `packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts` —
+  already gates on `hasFeature('ai')` correctly; no change needed.
+- Rails `cook.md/web` — this is a client-side alignment.
+
+## Testing
+
+Manual verification in Electron:
+
+- **AI user** (plan `pro_early_adopter_v1`, feature `ai`): plan name "AI (Early
+  Adopter)" shown, token balance visible, chat works as today, balance
+  refreshes on widget open.
+- **Non-AI / free user**: chat shows upgrade message instead of gRPC error;
+  sync section still visible and usable; no token balance.
+- **Logged out**: login prompt only; no sync UI.
+- **Past due**: label shows "Pro (Payment Issue)"; sync and AI still work
+  (`active_for_access?` is true server-side for `past_due`).
+- **Subscription still loading when chat invoked**: one-off load happens; if
+  still unresolved, request goes through and server handles.
+
+No new unit tests — changes are thin glue and UI.

--- a/docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md
@@ -20,17 +20,18 @@ The editor (`editor`) still speaks the pre-refactor protocol:
 - No `planSlug`, `planName`, `tokensRemaining`, `billingPeriodStart/End`,
   `trialAvailable` in `SubscriptionState`.
 - Account widget shows no token balance (the refactored web UI does; commit `2a103770`).
-- `cooklang-ai` has no client-side feature gating; gRPC call fails with
-  `permission_denied: ai_feature_not_available` for non-AI users — opaque in chat.
 - Account widget hides sync UI behind `features.includes('sync')`. Rails/sync-server
   don't actually enforce a `sync` feature flag, so this is a cosmetic paywall.
+
+(AI chat is already UI-gated in `cooklang-branding`'s chat widget — a full
+"Get AI Addon" overlay is shown when `features.includes('ai')` is false.
+No additional agent-level gating is needed.)
 
 ## Goals
 
 1. Align editor's subscription protocol with Rails' current JSON.
 2. Surface AI token balance and billing cycle in the account widget.
-3. Client-side gate AI chat for users without the `ai` feature.
-4. Remove the cosmetic sync paywall from the account widget.
+3. Remove the cosmetic sync paywall from the account widget.
 
 No backward-compatibility shims: fields are renamed/dropped cleanly.
 
@@ -119,30 +120,7 @@ this.cachedState = {
   - No progress bar (no client-side allowance). Rails' page has the full
     breakdown.
 
-### 4. AI client-side gating
-
-`packages/cooklang-ai/src/browser/cookbot-chat-agent.ts`:
-
-- Inject `SubscriptionFrontendService` from
-  `@theia/cooklang-account/lib/browser/subscription-frontend-service`.
-- Override the chat-agent request entry point (`invoke(request)` or the closest
-  `AbstractStreamParsingChatAgent` hook that lets us short-circuit before any
-  gRPC call).
-- Pre-check:
-  - If `subscription` loaded and `features.includes('ai') === false` → emit a
-    single assistant message: `AI assistance requires a Pro subscription.
-    [Upgrade at cook.md/pricing](https://cook.md/pricing)` (localized,
-    markdown link). Return a completed stream; skip gRPC.
-  - If `subscription === undefined` (loading) → `await
-    subscriptionFrontendService.refresh()` with a short timeout, then re-check.
-    If still undefined → fail open (let the request go; server will gate with
-    the existing `permission_denied` path).
-- Depletion (`tokens_remaining <= 0`): out of scope here; server returns a
-  separate error that can be handled later.
-- Add `@theia/cooklang-account` to `packages/cooklang-ai/package.json`
-  dependencies if not already present (verify before committing).
-
-### 5. Remove sync paywall
+### 4. Remove sync paywall
 
 `packages/cooklang-account/src/browser/account-widget.tsx`:
 
@@ -161,7 +139,7 @@ Rails' `Plans` catalog still lists `'sync'` in plan features. The editor now
 ignores that bit for gating purposes. Deciding whether to remove it from the
 catalog is a separate pricing/marketing call.
 
-### 6. Refresh lifecycle
+### 5. Refresh lifecycle
 
 - Keep the existing 5-min TTL cache in `subscription-service.ts`.
 - Keep the existing auth-change triggered refresh.
@@ -175,16 +153,16 @@ catalog is a separate pricing/marketing call.
 1. `packages/cooklang-account/src/common/subscription-protocol.ts` — new `SubscriptionState` shape.
 2. `packages/cooklang-account/src/node/subscription-service.ts` — map new Rails JSON fields.
 3. `packages/cooklang-account/src/browser/account-widget.tsx` — new plan label, token balance, refresh-on-activate, remove sync paywall, updated copy.
-4. `packages/cooklang-ai/src/browser/cookbot-chat-agent.ts` — AI feature gating.
-5. `packages/cooklang-ai/package.json` — add `@theia/cooklang-account` dep if missing.
+4. `packages/cooklang-account/src/browser/style/index.css` — styling for token balance row (if needed).
 
 ## Files intentionally not touched
 
-- `packages/cooklang-ai/src/node/cookbot-language-model.ts`,
-  `cookbot-grpc-client.ts` — server gates AI via `session_snapshot`.
+- `packages/cooklang-ai/**` — server gates AI via `session_snapshot`, and
+  `cooklang-branding`'s chat widget already gates the UI on
+  `hasFeature('ai')`. No client-side work needed in the AI package.
 - `packages/cooklang-ai/proto/cookbot.proto` — unused `subscription_tier` field.
 - `packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts` —
-  already gates on `hasFeature('ai')` correctly; no change needed.
+  existing AI gate stays as-is.
 - Rails `cook.md/web` — this is a client-side alignment.
 
 ## Testing
@@ -194,8 +172,8 @@ Manual verification in Electron:
 - **AI user** (plan `pro_early_adopter_v1`, feature `ai`): plan name "AI (Early
   Adopter)" shown, token balance visible, chat works as today, balance
   refreshes on widget open.
-- **Non-AI / free user**: chat shows upgrade message instead of gRPC error;
-  sync section still visible and usable; no token balance.
+- **Non-AI / free user**: chat widget shows the existing "Get AI Addon" gate
+  (unchanged); sync section still visible and usable; no token balance.
 - **Logged out**: login prompt only; no sync UI.
 - **Past due**: label shows "Pro (Payment Issue)"; sync and AI still work
   (`active_for_access?` is true server-side for `past_due`).

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -98,7 +98,7 @@ export class AccountWidget extends ReactWidget {
 
     protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
-        // Pull latest subscription state so tokens_remaining and plan reflect reality
+        // Pull latest subscription state so ai_credits_remaining and plan reflect reality
         // whenever the user opens/focuses the account widget.
         this.subscriptionFrontendService.refresh().catch(err => {
             console.warn('Failed to refresh subscription on widget activation:', err);
@@ -209,7 +209,7 @@ export class AccountWidget extends ReactWidget {
                     <i className='codicon codicon-link-external' />
                     <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/manageSubscription', 'Manage Subscription')}</span>
                 </div>
-                {subscription.features.includes('ai') && this.renderAiTokensSection(subscription)}
+                {subscription.features.includes('ai') && this.renderAiCreditsSection(subscription)}
                 {this.renderSyncSection(statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
@@ -255,9 +255,9 @@ export class AccountWidget extends ReactWidget {
         );
     }
 
-    protected renderAiTokensSection(subscription: SubscriptionState): React.ReactNode {
-        const tokens = subscription.tokensRemaining;
-        const tokensClass = tokens <= 0
+    protected renderAiCreditsSection(subscription: SubscriptionState): React.ReactNode {
+        const credits = subscription.aiCreditsRemaining;
+        const creditsClass = credits <= 0
             ? 'theia-account-row-label theia-account-sync-error'
             : 'theia-account-row-label';
         const resetsLabel = subscription.billingPeriodEnd
@@ -268,15 +268,15 @@ export class AccountWidget extends ReactWidget {
                 <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/aiHeader', 'AI Assistant')}</div>
                 <div className='theia-account-row'>
                     <i className='codicon codicon-sparkle' />
-                    <span className={tokensClass}>
-                        {nls.localize('theia/cooklang-account/aiTokensRemaining', '{0} tokens remaining', tokens.toLocaleString())}
+                    <span className={creditsClass}>
+                        {nls.localize('theia/cooklang-account/aiCreditsRemaining', '{0} credits remaining', credits.toLocaleString())}
                     </span>
                 </div>
                 {resetsLabel && (
                     <div className='theia-account-row theia-account-sync-status'>
                         <i className='codicon codicon-history' />
                         <span className='theia-account-row-label'>
-                            {nls.localize('theia/cooklang-account/aiTokensResets', 'Resets {0}', resetsLabel)}
+                            {nls.localize('theia/cooklang-account/aiCreditsResets', 'Resets {0}', resetsLabel)}
                         </span>
                     </div>
                 )}

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -169,7 +169,6 @@ export class AccountWidget extends ReactWidget {
 
     protected renderSubscriptionActive(subscription: SubscriptionState): React.ReactNode {
         const planLabel = this.getPlanLabel(subscription);
-        const hasSyncFeature = subscription.features.includes('sync');
         const statusLabel = this.syncStatus.status.charAt(0).toUpperCase() + this.syncStatus.status.slice(1);
 
         return (
@@ -188,7 +187,7 @@ export class AccountWidget extends ReactWidget {
                     <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/manageSubscription', 'Manage Subscription')}</span>
                 </div>
                 {subscription.features.includes('ai') && this.renderAiTokensSection(subscription)}
-                {hasSyncFeature && this.renderSyncSection(statusLabel)}
+                {this.renderSyncSection(statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
                     <i className='codicon codicon-sign-out' />
@@ -263,12 +262,13 @@ export class AccountWidget extends ReactWidget {
     }
 
     protected renderSubscriptionUpgrade(): React.ReactNode {
+        const statusLabel = this.syncStatus.status.charAt(0).toUpperCase() + this.syncStatus.status.slice(1);
         return (
             <React.Fragment>
                 <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/subscriptionHeader', 'Subscription')}</div>
                 <div className='theia-account-upgrade-section'>
                     <div className='theia-account-upgrade-message'>
-                        {nls.localize('theia/cooklang-account/upgradeMessage', 'Upgrade to unlock sync, AI assistance, and more features.')}
+                        {nls.localize('theia/cooklang-account/upgradeMessage', 'Upgrade to unlock AI assistance and more features.')}
                     </div>
                     <button
                         className='theia-button main theia-account-upgrade-button'
@@ -277,6 +277,7 @@ export class AccountWidget extends ReactWidget {
                         {nls.localize('theia/cooklang-account/upgradeButton', 'Upgrade to Pro')}
                     </button>
                 </div>
+                {this.renderSyncSection(statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
                     <i className='codicon codicon-sign-out' />

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -257,12 +257,14 @@ export class AccountWidget extends ReactWidget {
     }
 
     private getPlanLabel(subscription: SubscriptionState): string {
+        // Rails owns the display name — prefer it when present.
+        if (subscription.planName) {
+            return subscription.planName;
+        }
         switch (subscription.status) {
             case 'trial': return nls.localize('theia/cooklang-account/planTrial', 'Trial');
-            case 'active': return subscription.plan === 'annual'
-                ? nls.localize('theia/cooklang-account/planAnnual', 'Pro (Annual)')
-                : nls.localize('theia/cooklang-account/planMonthly', 'Pro (Monthly)');
             case 'grandfathered': return nls.localize('theia/cooklang-account/planGrandfathered', 'Pro (Grandfathered)');
+            case 'past_due': return nls.localize('theia/cooklang-account/planPastDue', 'Pro (Payment Issue)');
             case 'canceled': return nls.localize('theia/cooklang-account/planCanceled', 'Canceled');
             case 'paused': return nls.localize('theia/cooklang-account/planPaused', 'Paused');
             case 'expired': return nls.localize('theia/cooklang-account/planExpired', 'Expired');

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -263,6 +263,7 @@ export class AccountWidget extends ReactWidget {
         }
         switch (subscription.status) {
             case 'trial': return nls.localize('theia/cooklang-account/planTrial', 'Trial');
+            case 'active': return nls.localize('theia/cooklang-account/planPro', 'Pro');
             case 'grandfathered': return nls.localize('theia/cooklang-account/planGrandfathered', 'Pro (Grandfathered)');
             case 'past_due': return nls.localize('theia/cooklang-account/planPastDue', 'Pro (Payment Issue)');
             case 'canceled': return nls.localize('theia/cooklang-account/planCanceled', 'Canceled');

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -11,13 +11,14 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { CommandService } from '@theia/core/lib/common/command';
 import { nls } from '@theia/core/lib/common/nls';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import * as React from '@theia/core/shared/react';
 import { SubscriptionFrontendService } from './subscription-frontend-service';
 import { SubscriptionState } from '../common/subscription-protocol';
 import { SyncService, SyncStatus } from '../common/sync-protocol';
 import { AuthContribution, CookmdLoginCommand, CookmdLogoutCommand } from './auth-contribution';
 
-const WEB_BASE_URL = 'https://cook.md';
+const DEFAULT_WEB_BASE_URL = 'https://cook.md';
 
 export const ACCOUNT_WIDGET_ID = 'account-widget';
 
@@ -42,11 +43,15 @@ export class AccountWidget extends ReactWidget {
     @inject(SyncService)
     protected readonly syncService: SyncService;
 
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
+
     private static readonly SYNC_POLL_INTERVAL_MS = 2000;
 
     private syncEnabled = false;
     private syncStatus: SyncStatus = { status: 'stopped', lastSyncedAt: undefined, error: undefined };
     private syncPollTimer: ReturnType<typeof setInterval> | undefined;
+    private webBaseUrl: string = DEFAULT_WEB_BASE_URL;
 
     @postConstruct()
     protected init(): void {
@@ -73,6 +78,14 @@ export class AccountWidget extends ReactWidget {
             await this.refreshSyncStatus();
             this.startSyncPolling();
             this.update();
+        });
+
+        // Mirror the Node-side services' WEB_BASE_URL override so external links
+        // (Manage Subscription, Upgrade) point at the same backend during local dev.
+        this.envVariablesServer.getValue('WEB_BASE_URL').then(envVar => {
+            if (envVar?.value) {
+                this.webBaseUrl = envVar.value;
+            }
         });
 
         this.update();
@@ -345,7 +358,7 @@ export class AccountWidget extends ReactWidget {
     };
 
     private handleManageSubscription = (): void => {
-        this.windowService.openNewWindow(`${WEB_BASE_URL}/subscription`, { external: true });
+        this.windowService.openNewWindow(`${this.webBaseUrl}/subscription`, { external: true });
     };
 
     private handleLogout = (): void => {
@@ -353,7 +366,7 @@ export class AccountWidget extends ReactWidget {
     };
 
     private handleUpgrade = (): void => {
-        this.windowService.openNewWindow(`${WEB_BASE_URL}/pricing`, { external: true });
+        this.windowService.openNewWindow(`${this.webBaseUrl}/pricing`, { external: true });
     };
 
 }

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -5,6 +5,7 @@
 // terms of the MIT License, which is available in the project root.
 // *****************************************************************************
 
+import { Message } from '@lumino/messaging';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { CommandService } from '@theia/core/lib/common/command';
@@ -80,6 +81,15 @@ export class AccountWidget extends ReactWidget {
     override dispose(): void {
         this.stopSyncPolling();
         super.dispose();
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        // Pull latest subscription state so tokens_remaining and plan reflect reality
+        // whenever the user opens/focuses the account widget.
+        this.subscriptionFrontendService.refresh().catch(err => {
+            console.warn('Failed to refresh subscription on widget activation:', err);
+        });
     }
 
     private startSyncPolling(): void {

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -140,7 +140,7 @@ export class AccountWidget extends ReactWidget {
                     className='theia-button main theia-account-login-button'
                     onClick={this.handleLogin}
                 >
-                    {nls.localize('theia/cooklang-account/loginButton', 'Log In')}
+                    {nls.localizeByDefault('Log In')}
                 </button>
             </div>
         );
@@ -172,7 +172,7 @@ export class AccountWidget extends ReactWidget {
         return (
             <div className='theia-account-loading'>
                 <div className='theia-account-spinner' />
-                <span>{nls.localize('theia/cooklang-account/loading', 'Loading...')}</span>
+                <span>{nls.localizeByDefault('Loading...')}</span>
             </div>
         );
     }
@@ -213,7 +213,7 @@ export class AccountWidget extends ReactWidget {
                 <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/syncHeader', 'CookCloud Sync')}</div>
                 <div className='theia-account-row'>
                     <i className='codicon codicon-sync' />
-                    <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/syncEnabled', 'Enabled')}</span>
+                    <span className='theia-account-row-label'>{nls.localizeByDefault('Enabled')}</span>
                     <input
                         className='theia-account-sync-toggle'
                         type='checkbox'
@@ -308,9 +308,9 @@ export class AccountWidget extends ReactWidget {
             case 'grandfathered': return nls.localize('theia/cooklang-account/planGrandfathered', 'Pro (Grandfathered)');
             case 'past_due': return nls.localize('theia/cooklang-account/planPastDue', 'Pro (Payment Issue)');
             case 'canceled': return nls.localize('theia/cooklang-account/planCanceled', 'Canceled');
-            case 'paused': return nls.localize('theia/cooklang-account/planPaused', 'Paused');
+            case 'paused': return nls.localizeByDefault('Paused');
             case 'expired': return nls.localize('theia/cooklang-account/planExpired', 'Expired');
-            default: return nls.localize('theia/cooklang-account/planFree', 'Free');
+            default: return nls.localizeByDefault('Free');
         }
     }
 

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -187,6 +187,7 @@ export class AccountWidget extends ReactWidget {
                     <i className='codicon codicon-link-external' />
                     <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/manageSubscription', 'Manage Subscription')}</span>
                 </div>
+                {subscription.features.includes('ai') && this.renderAiTokensSection(subscription)}
                 {hasSyncFeature && this.renderSyncSection(statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
@@ -226,6 +227,35 @@ export class AccountWidget extends ReactWidget {
                     <div className='theia-account-row theia-account-sync-error'>
                         <i className='codicon codicon-error' />
                         <span className='theia-account-row-label'>{this.syncStatus.error}</span>
+                    </div>
+                )}
+            </React.Fragment>
+        );
+    }
+
+    protected renderAiTokensSection(subscription: SubscriptionState): React.ReactNode {
+        const tokens = subscription.tokensRemaining;
+        const tokensClass = tokens <= 0
+            ? 'theia-account-row-label theia-account-sync-error'
+            : 'theia-account-row-label';
+        const resetsLabel = subscription.billingPeriodEnd
+            ? new Date(subscription.billingPeriodEnd).toLocaleDateString()
+            : undefined;
+        return (
+            <React.Fragment>
+                <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/aiHeader', 'AI Assistant')}</div>
+                <div className='theia-account-row'>
+                    <i className='codicon codicon-sparkle' />
+                    <span className={tokensClass}>
+                        {nls.localize('theia/cooklang-account/aiTokensRemaining', '{0} tokens remaining', tokens.toLocaleString())}
+                    </span>
+                </div>
+                {resetsLabel && (
+                    <div className='theia-account-row theia-account-sync-status'>
+                        <i className='codicon codicon-history' />
+                        <span className='theia-account-row-label'>
+                            {nls.localize('theia/cooklang-account/aiTokensResets', 'Resets {0}', resetsLabel)}
+                        </span>
                     </div>
                 )}
             </React.Fragment>

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -365,8 +365,25 @@ export class AccountWidget extends ReactWidget {
         this.commandService.executeCommand(CookmdLogoutCommand.id);
     };
 
-    private handleUpgrade = (): void => {
-        this.windowService.openNewWindow(`${this.webBaseUrl}/pricing`, { external: true });
+    private handleUpgrade = async (): Promise<void> => {
+        let url: string;
+        try {
+            url = await this.subscriptionFrontendService.startUpgradeFlow();
+        } catch (err) {
+            console.warn('Failed to start upgrade flow, falling back to pricing page:', err);
+            this.windowService.openNewWindow(`${this.webBaseUrl}/pricing`, { external: true });
+            return;
+        }
+        this.windowService.openNewWindow(url, { external: true });
+        try {
+            const result = await this.subscriptionFrontendService.awaitUpgradeCallback();
+            if (result.status === 'ok') {
+                await this.subscriptionFrontendService.refresh();
+            }
+        } catch (err) {
+            // Timeout, state mismatch, or superseded flow — user can retry.
+            console.warn('Upgrade flow did not complete:', err);
+        }
     };
 
 }

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -5,7 +5,7 @@
 // terms of the MIT License, which is available in the project root.
 // *****************************************************************************
 
-import { Message } from '@lumino/messaging';
+import { Message } from '@theia/core/shared/@lumino/messaging';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { CommandService } from '@theia/core/lib/common/command';

--- a/packages/cooklang-account/src/browser/subscription-frontend-service.ts
+++ b/packages/cooklang-account/src/browser/subscription-frontend-service.ts
@@ -7,7 +7,7 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { Emitter, Event } from '@theia/core/lib/common';
-import { SubscriptionService, SubscriptionState } from '../common/subscription-protocol';
+import { SubscriptionService, SubscriptionState, UpgradeCallbackResult } from '../common/subscription-protocol';
 import { AuthContribution } from './auth-contribution';
 
 export const SubscriptionFrontendService = Symbol('SubscriptionFrontendService');
@@ -17,6 +17,8 @@ export interface SubscriptionFrontendService {
     readonly subscription: SubscriptionState | undefined;
     hasFeature(name: string): Promise<boolean>;
     refresh(): Promise<void>;
+    startUpgradeFlow(): Promise<string>;
+    awaitUpgradeCallback(): Promise<UpgradeCallbackResult>;
 }
 
 @injectable()
@@ -68,5 +70,13 @@ export class SubscriptionFrontendServiceImpl implements SubscriptionFrontendServ
         const sub = await this.subscriptionService.refresh();
         this.cachedState = sub;
         this.onDidChangeSubscriptionEmitter.fire(sub);
+    }
+
+    startUpgradeFlow(): Promise<string> {
+        return this.subscriptionService.startUpgradeFlow();
+    }
+
+    awaitUpgradeCallback(): Promise<UpgradeCallbackResult> {
+        return this.subscriptionService.awaitUpgradeCallback();
     }
 }

--- a/packages/cooklang-account/src/browser/subscription-frontend-service.ts
+++ b/packages/cooklang-account/src/browser/subscription-frontend-service.ts
@@ -63,6 +63,10 @@ export class SubscriptionFrontendServiceImpl implements SubscriptionFrontendServ
     }
 
     async refresh(): Promise<void> {
-        return this.subscriptionService.refresh();
+        // Backend events don't cross RPC, so we must re-seed our own cache
+        // from the refreshed backend state and fire the frontend emitter.
+        const sub = await this.subscriptionService.refresh();
+        this.cachedState = sub;
+        this.onDidChangeSubscriptionEmitter.fire(sub);
     }
 }

--- a/packages/cooklang-account/src/common/subscription-protocol.ts
+++ b/packages/cooklang-account/src/common/subscription-protocol.ts
@@ -14,7 +14,7 @@ export interface SubscriptionState {
     features: string[];
     planSlug: string | undefined;
     planName: string | undefined;
-    tokensRemaining: number;
+    aiCreditsRemaining: number;
     expiresAt: string | undefined;
     trialDaysRemaining: number | undefined;
     trialAvailable: boolean;

--- a/packages/cooklang-account/src/common/subscription-protocol.ts
+++ b/packages/cooklang-account/src/common/subscription-protocol.ts
@@ -22,6 +22,10 @@ export interface SubscriptionState {
     billingPeriodEnd: string | undefined;
 }
 
+export interface UpgradeCallbackResult {
+    status: 'ok' | 'cancelled';
+}
+
 /**
  * RPC-safe interface — no Event properties (see auth-protocol.ts for why).
  */
@@ -29,4 +33,23 @@ export interface SubscriptionService {
     getSubscription(): Promise<SubscriptionState | undefined>;
     hasFeature(name: string): Promise<boolean>;
     refresh(): Promise<SubscriptionState | undefined>;
+
+    /**
+     * Start an upgrade (purchase) flow. Spins up a local HTTP callback server
+     * and returns the URL the user should open in their browser. The URL
+     * carries a `callback` and `state` param; when the user completes or
+     * cancels checkout on the web, the web redirects to the callback with
+     * `status=ok|cancelled` and matching `state`.
+     *
+     * Frontends should call `awaitUpgradeCallback()` after opening the URL.
+     */
+    startUpgradeFlow(): Promise<string>;
+
+    /**
+     * Resolves when the callback server receives a valid redirect (matching
+     * state) from the web. On `ok`, the backend subscription cache is already
+     * refreshed by the time the promise resolves. Rejects on timeout, state
+     * mismatch, or if no flow is in progress.
+     */
+    awaitUpgradeCallback(): Promise<UpgradeCallbackResult>;
 }

--- a/packages/cooklang-account/src/common/subscription-protocol.ts
+++ b/packages/cooklang-account/src/common/subscription-protocol.ts
@@ -28,5 +28,5 @@ export interface SubscriptionState {
 export interface SubscriptionService {
     getSubscription(): Promise<SubscriptionState | undefined>;
     hasFeature(name: string): Promise<boolean>;
-    refresh(): Promise<void>;
+    refresh(): Promise<SubscriptionState | undefined>;
 }

--- a/packages/cooklang-account/src/common/subscription-protocol.ts
+++ b/packages/cooklang-account/src/common/subscription-protocol.ts
@@ -9,12 +9,17 @@ export const SubscriptionServicePath = '/services/cooked-subscription';
 export const SubscriptionService = Symbol('SubscriptionService');
 
 export interface SubscriptionState {
-    status: 'trial' | 'active' | 'expired' | 'grandfathered' | 'canceled' | 'paused' | 'none';
+    status: 'trial' | 'active' | 'past_due' | 'expired' | 'grandfathered' | 'canceled' | 'paused' | 'none';
     hasAccess: boolean;
     features: string[];
-    plan: 'monthly' | 'annual' | undefined;
+    planSlug: string | undefined;
+    planName: string | undefined;
+    tokensRemaining: number;
     expiresAt: string | undefined;
     trialDaysRemaining: number | undefined;
+    trialAvailable: boolean;
+    billingPeriodStart: string | undefined;
+    billingPeriodEnd: string | undefined;
 }
 
 /**

--- a/packages/cooklang-account/src/node/subscription-service.ts
+++ b/packages/cooklang-account/src/node/subscription-service.ts
@@ -75,9 +75,14 @@ export class SubscriptionServiceImpl implements SubscriptionService {
                 status: data.status ?? 'none',
                 hasAccess: data.has_access ?? false,
                 features: data.features ?? [],
-                plan: data.plan ?? undefined,
+                planSlug: data.plan_slug ?? undefined,
+                planName: data.plan_name ?? undefined,
+                tokensRemaining: typeof data.tokens_remaining === 'number' ? data.tokens_remaining : 0,
                 expiresAt: data.expires_at ?? undefined,
                 trialDaysRemaining: data.trial_days_remaining ?? undefined,
+                trialAvailable: data.trial_available ?? false,
+                billingPeriodStart: data.billing_period_start ?? undefined,
+                billingPeriodEnd: data.billing_period_end ?? undefined,
             };
             this.cacheTimestamp = Date.now();
             this.onDidChangeSubscriptionEmitter.fire(this.cachedState);

--- a/packages/cooklang-account/src/node/subscription-service.ts
+++ b/packages/cooklang-account/src/node/subscription-service.ts
@@ -244,7 +244,7 @@ p { color: #666; }`;
                 features: data.features ?? [],
                 planSlug: data.plan_slug ?? undefined,
                 planName: data.plan_name ?? undefined,
-                tokensRemaining: typeof data.tokens_remaining === 'number' ? data.tokens_remaining : 0,
+                aiCreditsRemaining: typeof data.ai_credits_remaining === 'number' ? data.ai_credits_remaining : 0,
                 expiresAt: data.expires_at ?? undefined,
                 trialDaysRemaining: data.trial_days_remaining ?? undefined,
                 trialAvailable: data.trial_available ?? false,

--- a/packages/cooklang-account/src/node/subscription-service.ts
+++ b/packages/cooklang-account/src/node/subscription-service.ts
@@ -45,8 +45,9 @@ export class SubscriptionServiceImpl implements SubscriptionService {
         return sub?.features.includes(name) ?? false;
     }
 
-    async refresh(): Promise<void> {
+    async refresh(): Promise<SubscriptionState | undefined> {
         await this.fetchSubscription();
+        return this.cachedState;
     }
 
     private async handleAuthChange(state: AuthState): Promise<void> {

--- a/packages/cooklang-account/src/node/subscription-service.ts
+++ b/packages/cooklang-account/src/node/subscription-service.ts
@@ -5,15 +5,21 @@
 // terms of the MIT License, which is available in the project root.
 // *****************************************************************************
 
+import * as crypto from 'crypto';
 import * as http from 'http';
 import * as https from 'https';
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { Emitter, Event } from '@theia/core/lib/common';
 import { AuthState } from '../common/auth-protocol';
 import { AuthServiceBackend } from './auth-service';
-import { SubscriptionService, SubscriptionState } from '../common/subscription-protocol';
+import { SubscriptionService, SubscriptionState, UpgradeCallbackResult } from '../common/subscription-protocol';
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+// Start at a different port than auth's callback (19285) so both servers can
+// coexist if auth somehow leaves its socket bound.
+const UPGRADE_CALLBACK_PORT_START = 19295;
+const UPGRADE_CALLBACK_PORT_RETRIES = 10;
+const UPGRADE_CALLBACK_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — Stripe checkout can take a while
 
 @injectable()
 export class SubscriptionServiceImpl implements SubscriptionService {
@@ -23,6 +29,15 @@ export class SubscriptionServiceImpl implements SubscriptionService {
 
     private cachedState: SubscriptionState | undefined;
     private cacheTimestamp = 0;
+
+    private upgradeFlow: {
+        expectedState: string;
+        server: http.Server;
+        timeout: ReturnType<typeof setTimeout>;
+        resolve: (result: UpgradeCallbackResult) => void;
+        reject: (err: Error) => void;
+        callbackPromise: Promise<UpgradeCallbackResult>;
+    } | undefined;
 
     private readonly onDidChangeSubscriptionEmitter = new Emitter<SubscriptionState | undefined>();
     readonly onDidChangeSubscription: Event<SubscriptionState | undefined> = this.onDidChangeSubscriptionEmitter.event;
@@ -48,6 +63,157 @@ export class SubscriptionServiceImpl implements SubscriptionService {
     async refresh(): Promise<SubscriptionState | undefined> {
         await this.fetchSubscription();
         return this.cachedState;
+    }
+
+    async startUpgradeFlow(): Promise<string> {
+        this.cleanupUpgradeFlow(new Error('Upgrade flow superseded'));
+
+        const expectedState = crypto.randomUUID();
+        const server = http.createServer((req, res) => this.handleUpgradeCallback(req, res));
+        const port = await this.listenOnAvailablePort(server);
+
+        let resolve!: (result: UpgradeCallbackResult) => void;
+        let reject!: (err: Error) => void;
+        const callbackPromise = new Promise<UpgradeCallbackResult>((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
+        // Swallow unhandled-rejection warnings if no one ends up awaiting.
+        callbackPromise.catch(() => { /* awaited via awaitUpgradeCallback */ });
+
+        const timeout = setTimeout(() => {
+            this.cleanupUpgradeFlow(new Error('Upgrade flow timed out'));
+        }, UPGRADE_CALLBACK_TIMEOUT_MS);
+
+        this.upgradeFlow = { expectedState, server, timeout, resolve, reject, callbackPromise };
+
+        const webBaseUrl = process.env.WEB_BASE_URL || 'https://cook.md';
+        const url = new URL('/pricing', webBaseUrl);
+        url.searchParams.set('callback', `http://localhost:${port}/upgrade-done`);
+        url.searchParams.set('state', expectedState);
+        return url.toString();
+    }
+
+    async awaitUpgradeCallback(): Promise<UpgradeCallbackResult> {
+        if (!this.upgradeFlow) {
+            throw new Error('No upgrade flow in progress');
+        }
+        return this.upgradeFlow.callbackPromise;
+    }
+
+    private handleUpgradeCallback(req: http.IncomingMessage, res: http.ServerResponse): void {
+        const flow = this.upgradeFlow;
+        const url = new URL(req.url || '/', 'http://localhost');
+
+        if (url.pathname !== '/upgrade-done' || !flow) {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('Not Found');
+            return;
+        }
+
+        const receivedState = url.searchParams.get('state');
+        if (receivedState !== flow.expectedState) {
+            res.writeHead(400, { 'Content-Type': 'text/html' });
+            res.end(this.upgradeResultHtml('Error', 'State mismatch. Please try again from the editor.'));
+            this.cleanupUpgradeFlow(new Error('State mismatch on upgrade callback'));
+            return;
+        }
+
+        const status = url.searchParams.get('status');
+        const result: UpgradeCallbackResult | undefined =
+            status === 'ok' ? { status: 'ok' } :
+            status === 'cancelled' ? { status: 'cancelled' } :
+            undefined;
+
+        if (!result) {
+            res.writeHead(400, { 'Content-Type': 'text/html' });
+            res.end(this.upgradeResultHtml('Error', 'Unexpected status returned. You can close this tab.'));
+            this.cleanupUpgradeFlow(new Error(`Unexpected upgrade status: ${status}`));
+            return;
+        }
+
+        const resolve = flow.resolve;
+
+        // Refresh the backend cache before resolving so the frontend can read
+        // the fresh state immediately after awaitUpgradeCallback returns.
+        const finish = (): void => {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            const heading = result.status === 'ok' ? 'Upgrade complete!' : 'Checkout cancelled';
+            const body = result.status === 'ok'
+                ? 'You can close this tab and return to the editor.'
+                : 'No changes were made. You can close this tab and return to the editor.';
+            res.end(this.upgradeResultHtml(heading, body));
+            this.teardownUpgradeFlow();
+            resolve(result);
+        };
+
+        if (result.status === 'ok') {
+            this.fetchSubscription().finally(finish);
+        } else {
+            finish();
+        }
+    }
+
+    private upgradeResultHtml(heading: string, body: string): string {
+        const style = `body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+    background: #f5f0eb;
+    color: #333;
+}
+.container { text-align: center; }
+h1 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.5rem; }
+p { color: #666; }`;
+        return `<html><head><style>${style}</style></head>`
+            + `<body><div class="container"><h1>${heading}</h1><p>${body}</p></div></body></html>`;
+    }
+
+    private listenOnAvailablePort(server: http.Server): Promise<number> {
+        return new Promise((resolve, reject) => {
+            let attempt = 0;
+
+            const tryPort = (port: number): void => {
+                const onError = (err: NodeJS.ErrnoException): void => {
+                    server.removeListener('error', onError);
+                    if (err.code === 'EADDRINUSE' && attempt < UPGRADE_CALLBACK_PORT_RETRIES) {
+                        attempt++;
+                        tryPort(port + 1);
+                    } else {
+                        reject(new Error(`Failed to start upgrade callback server: ${err.message}`));
+                    }
+                };
+
+                server.once('error', onError);
+                server.listen(port, '127.0.0.1', () => {
+                    server.removeListener('error', onError);
+                    resolve(port);
+                });
+            };
+
+            tryPort(UPGRADE_CALLBACK_PORT_START);
+        });
+    }
+
+    private teardownUpgradeFlow(): void {
+        if (!this.upgradeFlow) {
+            return;
+        }
+        clearTimeout(this.upgradeFlow.timeout);
+        this.upgradeFlow.server.close();
+        this.upgradeFlow = undefined;
+    }
+
+    private cleanupUpgradeFlow(error: Error): void {
+        const flow = this.upgradeFlow;
+        if (!flow) {
+            return;
+        }
+        this.teardownUpgradeFlow();
+        flow.reject(error);
     }
 
     private async handleAuthChange(state: AuthState): Promise<void> {

--- a/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
+++ b/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
@@ -126,7 +126,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
                 'The AI assistant requires the AI addon. Add it to your subscription to get started.');
             button.textContent = nls.localize('theia/ai-chat/gate/upgradeButton', 'Get AI Addon \u2192');
             button.addEventListener('click', () => {
-                this.windowService.openNewWindow(`${this.webBaseUrl}/pricing`, { external: true });
+                this.startUpgradeFlow();
             });
             const note = document.createElement('div');
             note.className = 'ai-chat-gate-note';
@@ -136,5 +136,26 @@ export class CooklangChatViewWidget extends ChatViewWidget {
         }
 
         this.gateOverlay.append(icon, title, message, button);
+    }
+
+    private async startUpgradeFlow(): Promise<void> {
+        let url: string;
+        try {
+            url = await this.subscriptionFrontendService.startUpgradeFlow();
+        } catch (err) {
+            console.warn('Failed to start upgrade flow, falling back to pricing page:', err);
+            this.windowService.openNewWindow(`${this.webBaseUrl}/pricing`, { external: true });
+            return;
+        }
+        this.windowService.openNewWindow(url, { external: true });
+        try {
+            const result = await this.subscriptionFrontendService.awaitUpgradeCallback();
+            if (result.status === 'ok') {
+                await this.subscriptionFrontendService.refresh();
+            }
+        } catch (err) {
+            // Timeout, state mismatch, or superseded flow — gate will stay as-is.
+            console.warn('Upgrade flow did not complete:', err);
+        }
     }
 }

--- a/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
+++ b/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
@@ -6,13 +6,14 @@
 
 import { nls } from '@theia/core/lib/common/nls';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
 import { SubscriptionFrontendService } from '@theia/cooklang-account/lib/browser/subscription-frontend-service';
 
-const WEB_BASE_URL = 'https://cook.md';
+const DEFAULT_WEB_BASE_URL = 'https://cook.md';
 
 @injectable()
 export class CooklangChatViewWidget extends ChatViewWidget {
@@ -26,9 +27,13 @@ export class CooklangChatViewWidget extends ChatViewWidget {
     @inject(WindowService)
     protected readonly windowService: WindowService;
 
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
+
     private authState: AuthState = { status: 'logged-out' };
     private hasAiFeature = false;
     private gateOverlay: HTMLDivElement;
+    private webBaseUrl: string = DEFAULT_WEB_BASE_URL;
 
     @postConstruct()
     protected override init(): void {
@@ -47,6 +52,14 @@ export class CooklangChatViewWidget extends ChatViewWidget {
         });
         this.subscriptionFrontendService.onDidChangeSubscription(() => {
             this.checkAiFeature();
+        });
+
+        // Mirror the Node-side services' WEB_BASE_URL override so the Get AI
+        // Addon button points at the same backend during local dev.
+        this.envVariablesServer.getValue('WEB_BASE_URL').then(envVar => {
+            if (envVar?.value) {
+                this.webBaseUrl = envVar.value;
+            }
         });
     }
 
@@ -113,7 +126,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
                 'The AI assistant requires the AI addon. Add it to your subscription to get started.');
             button.textContent = nls.localize('theia/ai-chat/gate/upgradeButton', 'Get AI Addon \u2192');
             button.addEventListener('click', () => {
-                this.windowService.openNewWindow(`${WEB_BASE_URL}/pricing`, { external: true });
+                this.windowService.openNewWindow(`${this.webBaseUrl}/pricing`, { external: true });
             });
             const note = document.createElement('div');
             note.className = 'ai-chat-gate-note';


### PR DESCRIPTION
## Summary

Aligns the editor's subscription protocol with the refactored Rails `/api/subscription` JSON shape, surfaces the AI token balance in the account widget, removes the cosmetic sync paywall, and adds a desktop-return callback so the widget refreshes automatically after a user completes checkout in their browser.

Spec: [docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md](docs/superpowers/specs/2026-04-16-subscription-refactor-alignment-design.md)
Plan: [docs/superpowers/plans/2026-04-16-subscription-refactor-alignment.md](docs/superpowers/plans/2026-04-16-subscription-refactor-alignment.md)

**Paired with Rails:** cook-md/cook-md#54 — checkout `success`/`cancel` redirect back to the editor's localhost callback server.

## Changes

### Alignment (original scope)

- **`SubscriptionState`** — drops legacy `plan: 'monthly'|'annual'`; adds `planSlug`, `planName`, `tokensRemaining`, `trialAvailable`, `billingPeriodStart/End`; expands `status` to include `'past_due'`
- **`subscription-service.ts`** — maps new Rails JSON fields (`plan_slug`, `plan_name`, `tokens_remaining`, `billing_period_start/end`, `trial_available`)
- **`account-widget.tsx`**:
  - `getPlanLabel` — prefers Rails `planName`; falls back to status-based labels. Adds `'past_due'` → `'Pro (Payment Issue)'`
  - `renderAiTokensSection` — shows `{n} tokens remaining` + reset date when `features.includes('ai')`; marks `<= 0` with the error style
  - Removes `hasSyncFeature` gate — sync is available to any logged-in user. Sync section now renders in both `renderSubscriptionActive()` and `renderSubscriptionUpgrade()`
  - Upgrade copy: `'Upgrade to unlock sync, AI assistance, and more features.'` → `'Upgrade to unlock AI assistance and more features.'`
  - `onActivateRequest` — calls `subscriptionFrontendService.refresh()` so the token balance and plan reflect reality on widget open
- **`WEB_BASE_URL`** — account widget's *Manage Subscription*/*Upgrade* buttons and branding's *Get AI Addon* button honor the env var for local dev
- **Lint hygiene** — switched standard strings (`'Log In'`, `'Loading...'`, `'Enabled'`, `'Paused'`, `'Free'`) to `nls.localizeByDefault`; fixed `@lumino/messaging` import to use Theia's shared-dependencies convention

### Desktop-return callback (added scope)

Without this, a user who completes a Stripe purchase in their browser returns to the editor and still sees the "Upgrade to Pro" button — the subscription cache never refreshes. Two fixes:

- **`SubscriptionFrontendService.refresh()`** now re-seeds its own cache from the refreshed backend state and fires its emitter. Previously it delegated to the backend, whose `onDidChangeSubscription` event cannot cross Theia's RpcConnectionHandler.
- **New RPC methods** `SubscriptionService.startUpgradeFlow()` / `awaitUpgradeCallback()`. `startUpgradeFlow` spins up a localhost HTTP server (port 19295+, 10-min timeout, state validation — mirroring `AuthServiceImpl.startCallbackServer`) and returns `WEB_BASE_URL/pricing?callback=…&state=…`. When the user returns via the callback, the backend refreshes `fetchSubscription()` so the cache is warm before `awaitUpgradeCallback` resolves.
- **Widgets** (account + branding chat gate) — click handlers now orchestrate: `startUpgradeFlow` → `openNewWindow(url, external)` → `awaitUpgradeCallback` → `refresh()`. On error or timeout they fall back to plain `/pricing`.

## Non-goals

- No AI-package changes — the gRPC cookbot server gates AI via `session_snapshot`, and `cooklang-branding`'s chat widget already renders a full "Get AI Addon" overlay when `features.includes('ai')` is false
- No changes to `cooklang-ai/proto/cookbot.proto` (`subscription_tier` field is unused)
- No changes to the Rails `Plans` catalog

## Test plan

Build verified locally:
- [x] `npm run compile` — clean (46 projects)
- [x] Lint clean for `account-widget.tsx`, `subscription-service.ts`, `subscription-frontend-service.ts`, `subscription-protocol.ts` (3 pre-existing errors remain in `auth-service.ts`/`sync-service.ts`, out of scope; `cooklang-branding` has a pre-existing ESLint config issue, out of scope)
- [x] `examples/electron` typechecks clean

Manual verification in Electron (pending):
- [ ] **AI user** (plan `pro_early_adopter_v1`): plan label shows "AI (Early Adopter)"; `{n} tokens remaining` visible with reset date; balance refreshes when widget is opened
- [ ] **Non-AI / free user**: no token balance section; chat widget shows existing "Get AI Addon" gate; sync section visible and functional
- [ ] **Logged out**: login prompt only; no sync UI
- [ ] **Past due**: plan label shows "Pro (Payment Issue)"; sync and AI still work (`active_for_access?` is true server-side for `past_due`)
- [ ] **Subscription still loading when chat invoked**: one-off load happens; request proceeds, server handles gating
- [ ] **Upgrade callback**: with Rails PR #54 deployed locally, click Upgrade, complete Stripe test checkout, verify widget refreshes to Pro state without restarting the editor
- [ ] **Upgrade cancel**: cancel Stripe flow, verify widget returns to upgrade gate without errors