### PR TITLE
refactor(account): rename "AI tokens" to "AI credits" in account widget

### DIFF
--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -98,7 +98,7 @@ export class AccountWidget extends ReactWidget {
 
     protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
-        // Pull latest subscription state so tokens_remaining and plan reflect reality
+        // Pull latest subscription state so ai_credits_remaining and plan reflect reality
         // whenever the user opens/focuses the account widget.
         this.subscriptionFrontendService.refresh().catch(err => {
             console.warn('Failed to refresh subscription on widget activation:', err);
@@ -209,7 +209,7 @@ export class AccountWidget extends ReactWidget {
                     <i className='codicon codicon-link-external' />
                     <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/manageSubscription', 'Manage Subscription')}</span>
                 </div>
-                {subscription.features.includes('ai') && this.renderAiTokensSection(subscription)}
+                {subscription.features.includes('ai') && this.renderAiCreditsSection(subscription)}
                 {this.renderSyncSection(statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
@@ -255,9 +255,9 @@ export class AccountWidget extends ReactWidget {
         );
     }
 
-    protected renderAiTokensSection(subscription: SubscriptionState): React.ReactNode {
-        const tokens = subscription.tokensRemaining;
-        const tokensClass = tokens <= 0
+    protected renderAiCreditsSection(subscription: SubscriptionState): React.ReactNode {
+        const credits = subscription.aiCreditsRemaining;
+        const creditsClass = credits <= 0
             ? 'theia-account-row-label theia-account-sync-error'
             : 'theia-account-row-label';
         const resetsLabel = subscription.billingPeriodEnd
@@ -268,15 +268,15 @@ export class AccountWidget extends ReactWidget {
                 <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/aiHeader', 'AI Assistant')}</div>
                 <div className='theia-account-row'>
                     <i className='codicon codicon-sparkle' />
-                    <span className={tokensClass}>
-                        {nls.localize('theia/cooklang-account/aiTokensRemaining', '{0} tokens remaining', tokens.toLocaleString())}
+                    <span className={creditsClass}>
+                        {nls.localize('theia/cooklang-account/aiCreditsRemaining', '{0} credits remaining', credits.toLocaleString())}
                     </span>
                 </div>
                 {resetsLabel && (
                     <div className='theia-account-row theia-account-sync-status'>
                         <i className='codicon codicon-history' />
                         <span className='theia-account-row-label'>
-                            {nls.localize('theia/cooklang-account/aiTokensResets', 'Resets {0}', resetsLabel)}
+                            {nls.localize('theia/cooklang-account/aiCreditsResets', 'Resets {0}', resetsLabel)}
                         </span>
                     </div>
                 )}

--- a/packages/cooklang-account/src/common/subscription-protocol.ts
+++ b/packages/cooklang-account/src/common/subscription-protocol.ts
@@ -14,7 +14,7 @@ export interface SubscriptionState {
     features: string[];
     planSlug: string | undefined;
     planName: string | undefined;
-    tokensRemaining: number;
+    aiCreditsRemaining: number;
     expiresAt: string | undefined;
     trialDaysRemaining: number | undefined;
     trialAvailable: boolean;

--- a/packages/cooklang-account/src/node/subscription-service.ts
+++ b/packages/cooklang-account/src/node/subscription-service.ts
@@ -244,7 +244,7 @@ p { color: #666; }`;
                 features: data.features ?? [],
                 planSlug: data.plan_slug ?? undefined,
                 planName: data.plan_name ?? undefined,
-                tokensRemaining: typeof data.tokens_remaining === 'number' ? data.tokens_remaining : 0,
+                aiCreditsRemaining: typeof data.ai_credits_remaining === 'number' ? data.ai_credits_remaining : 0,
                 expiresAt: data.expires_at ?? undefined,
                 trialDaysRemaining: data.trial_days_remaining ?? undefined,
                 trialAvailable: data.trial_available ?? false,


### PR DESCRIPTION
## Summary
- `SubscriptionState.tokensRemaining` -> `aiCreditsRemaining` (integer count of credits, not tokens)
- Subscription service now reads `data.ai_credits_remaining` from the API response
- Account widget renders "AI credits remaining" with a credit count, and renames `renderAiTokensSection` → `renderAiCreditsSection`

## Why
Pairs with cook-md/cook-md#55 which renames the API field and updates pricing/account pages. User-facing copy switches from "tokens" (unintuitive) to "AI credits" (coarse, round) at a ratio of 1 credit = 5,000 tokens. Atomic metering on the backend stays in tokens.

## Dependencies
- **Base branch:** `feat/subscription-refactor-alignment` (PR #22). Stacked on that PR so diff stays small; once #22 merges the base will flip to `main` automatically
- Requires paired Rails PR cook-md/cook-md#55 to land first, otherwise the field lookup on the API response misses and credits display as 0

## Test plan
- [x] `npx lerna run compile --scope @theia/cooklang-account --scope @theia/cooklang-branding` succeeds
- [ ] With Rails PR deployed to a staging env: log in as Pro user, open Account widget, confirm "N credits remaining" matches `tokens_remaining / 5000`
- [ ] With 0 tokens: confirm the error-red styling still triggers