### PR TITLE
feat(build): enable macOS code signing + notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,14 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_REPO_PAT }}
+          # Code signing — electron-builder reads these automatically on macOS.
+          # Harmless on Windows/Linux matrix rows (ignored).
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # Notarization — electron-builder reads these when mac.notarize is true
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/examples/electron/electron-builder.yml
+++ b/examples/electron/electron-builder.yml
@@ -54,9 +54,11 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+  # Submit to Apple's notarytool after signing; uses APPLE_* env vars.
+  notarize: true
 
 dmg:
-  sign: false
+  sign: true
   artifactName: ${productName}-${arch}.${ext}
 
 # --- Windows ---


### PR DESCRIPTION
## Summary

- Wires 5 Apple secrets (`MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`) into the release workflow's Package & Publish step.
- Sets `mac.notarize: true` (triggers notarytool submission) and `dmg.sign: true` in `electron-builder.yml`.
- After this lands and a tag is cut, releases are signed with the Developer ID Application cert and stapled with a notarytool ticket. End-users can double-click the DMG on a clean Intel or arm64 Mac without any `xattr` dance.

## Stacked on #24

Base is `fix/macos-release-intel-crash` (PR #24). **Merge #24 first**, then this PR will auto-retarget to `main` (or I can retarget manually). The diff shown here is only the two Fix 3 commits, not the Fix 1 changes.

## Dependencies

- All 5 GitHub Secrets provisioned on `cook-md/editor-private` ✅ (done)
- Depends on PR #24 for the bundle hygiene fix (otherwise notarization would run against a broken DMG)

## Reviewer note — secret scope

The env block exposes `CSC_*`/`APPLE_*` secrets to all matrix rows (Linux, Windows). The spec evaluated this and marked it as Harmless — electron-builder ignores them on non-macOS, and GitHub Actions scrubs them from logs. Code review flagged this as defense-in-depth opportunity (conditional expression per env var). If you'd like to scope them down with `${{ runner.os == 'macOS' && secrets.X || '' }}`, say the word; otherwise the spec's design stands.

## Test plan

- [ ] Merge PR #24, then merge this
- [ ] Cut `v0.1.0-alpha.2` tag
- [ ] Download DMG from release assets
- [ ] `spctl --assess --type execute --verbose=4 /Applications/CookEd.app` → `accepted`
- [ ] `codesign --verify --deep --strict --verbose=4 /Applications/CookEd.app` → `valid on disk`
- [ ] `xcrun stapler validate /Applications/CookEd.app` → `The validate action worked!`
- [ ] Clean Intel Mac install — no `xattr -cr` needed — double-click launches

Spec: `docs/superpowers/specs/2026-04-17-macos-release-fixes-design.md`
Plan: `docs/superpowers/plans/2026-04-17-macos-release-fixes.md`