### PR TITLE
feat(build): enable macOS signing + notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,14 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.PUBLIC_REPO_PAT }}
+          # Code signing — electron-builder reads these automatically on macOS.
+          # Harmless on Windows/Linux matrix rows (ignored).
+          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          # Notarization — electron-builder reads these when mac.notarize is true
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/examples/electron/electron-builder.yml
+++ b/examples/electron/electron-builder.yml
@@ -54,9 +54,11 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+  # Submit to Apple's notarytool after signing; uses APPLE_* env vars.
+  notarize: true
 
 dmg:
-  sign: false
+  sign: true
   artifactName: Cook-Editor-${arch}.${ext}
 
 # --- Windows ---


### PR DESCRIPTION
## Summary
- Wires `MAC_CSC_LINK`, `MAC_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` secrets into the release workflow's "Package & Publish" step.
- Sets `mac.notarize: true` and `dmg.sign: true` in `electron-builder.yml`.
- After this lands, macOS releases are signed with our Developer ID Application cert and stapled with a notarytool ticket — no more Gatekeeper block on install.

## Dependencies
All five GitHub Secrets are already provisioned on the repo (verified by user).

## Test plan
- [ ] Cut `v0.1.0-alpha.2` tag after merge
- [ ] Download `Cook-Editor-x64.dmg` from release assets
- [ ] `spctl --assess --type execute --verbose=4 "/Applications/Cook Editor.app"` → `accepted`, `source=Notarized Developer ID`
- [ ] `codesign --verify --deep --strict --verbose=4 "/Applications/Cook Editor.app"` → `valid on disk`
- [ ] `xcrun stapler validate "/Applications/Cook Editor.app"` → `The validate action worked!`
- [ ] Install clean on Intel Mac — no `xattr -cr` needed — double-click launches

See `docs/superpowers/specs/2026-04-17-macos-release-fixes-design.md` (Fix 3 section) for full design.