### PR TITLE
ci(release): aggressive caching for node_modules, TS, electron-builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,17 +78,57 @@ jobs:
             ${{ runner.os }}-${{ matrix.rust_target || 'host' }}-cargo-
             ${{ runner.os }}-cargo-
 
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            packages/*/node_modules
+            dev-packages/*/node_modules
+            examples/*/node_modules
+          key: ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-nm-v1-${{ hashFiles('package-lock.json', 'lerna.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-nm-v1-
+
       # native-keymap compiles against libx11/libxkbfile headers on Linux
       - name: Install Linux native build deps
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libx11-dev libxkbfile-dev
 
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: npm install
         env:
           # @vscode/ripgrep and other GitHub-release downloads hit anonymous
           # rate limits (403) without a token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache TypeScript build
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/*/lib
+            dev-packages/*/lib
+            packages/*/*.tsbuildinfo
+            dev-packages/*/*.tsbuildinfo
+          key: ${{ runner.os }}-tsc-v1-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-tsc-v1-
+
+      - name: Cache electron-builder downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/electron
+            ~/Library/Caches/electron-builder
+            ~/.cache/electron
+            ~/.cache/electron-builder
+            ~/AppData/Local/electron/Cache
+            ~/AppData/Local/electron-builder/Cache
+          key: ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-eb-${{ hashFiles('examples/electron/electron-builder.yml', 'examples/electron/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-eb-
 
       - name: Build native addon
         working-directory: packages/cooklang-native


### PR DESCRIPTION
## Summary
Layered three new caches on top of existing setup-node + Cargo caches:

1. **node_modules** — scoped per OS + electron_arch, keyed on lockfile + lerna.json. Skips \`npm install\` (and its 3–8 min postinstall including theia-patch + lerna afterInstall) entirely on exact cache hit.
2. **TypeScript build output** — \`packages/*/lib\` + \`*.tsbuildinfo\`, keyed on commit SHA with OS-only restore-keys. Every build saves, next build's \`tsc --build\` only recompiles changed packages.
3. **electron-builder downloads** — \`~/Library/Caches/electron{,-builder}\` and Linux/Windows equivalents, keyed on \`electron-builder.yml\` + \`package.json\` (pins Electron version).

## Expected savings
- Per job on cache hit: 5–12 min
- Per release (4 matrix rows): ~20–50 min wall-clock

## Risks
- node_modules cache key includes arch, so cross-compile jobs don't share caches incorrectly.
- TypeScript project references with \`composite: true\` means \`tsc --build\` verifies source hashes on restore — stale outputs always trigger rebuild.
- Version suffix \`-v1\` can be bumped if any cache goes stale (e.g., on Node version bump).

## Test plan
- [ ] First push: all three caches miss → baseline timing
- [ ] Second push on same SHA range: all three hit → measure savings
- [ ] Push with \`package-lock.json\` bump: node_modules miss, TS hit, electron-builder hit
- [ ] Cut a test tag and watch the macOS matrix logs for \`Cache restored successfully\` on each cache entry