### PR TITLE
ci(release): fix mac-x64 native module arch mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,23 +143,34 @@ jobs:
       - name: Compile TypeScript
         run: npm run compile
 
-      - name: Bundle Electron app
-        working-directory: examples/electron
-        run: npm run bundle
-        env:
-          # webpack hits the default 2 GB heap on Windows; give it room
-          NODE_OPTIONS: --max-old-space-size=8192
-
-      # `theia rebuild:electron` only rebuilds native deps for host arch.
-      # When cross-compiling x64 on an arm64 mac runner we need a second pass
-      # targeting x64 so node-pty/native-keymap/etc. ship as x64 binaries.
-      - name: Rebuild native deps for target arch (macOS cross-compile)
-        if: matrix.electron_arch == 'x64'
+      # `theia rebuild:electron` (invoked by `npm run bundle`) only builds for
+      # the host arch (arm64 on macos-latest). When cross-compiling x64 we must
+      # rebuild for x64 BEFORE webpack bundles, because webpack's node-loader
+      # copies native modules out of node_modules/ into lib/backend/native/.
+      # If we rebuild after bundling, those copies stay host-arch.
+      - name: Rebuild native deps for x64 target (macOS cross-compile)
+        if: matrix.electron_arch == 'x64' && runner.os == 'macOS'
         run: |
           ./node_modules/.bin/electron-rebuild \
             --arch=x64 \
             --force \
             --only=node-pty,native-keymap,find-git-repositories,drivelist,keytar,ssh2,cpu-features
+
+      - name: Bundle Electron app
+        working-directory: examples/electron
+        shell: bash
+        run: |
+          # Cross-compile case: native modules are already target-arch from the
+          # step above. `npm run bundle` would run `theia rebuild:electron` and
+          # clobber them with host-arch (arm64) binaries — run webpack directly.
+          if [ "${{ matrix.electron_arch }}" = "x64" ] && [ "${{ runner.os }}" = "macOS" ]; then
+            npx theia build --mode development
+          else
+            npm run bundle
+          fi
+        env:
+          # webpack hits the default 2 GB heap on Windows; give it room
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Package & Publish
         working-directory: examples/electron


### PR DESCRIPTION
## Summary

- Rebuild x64 native modules **before** webpack bundles, not after, so the copies webpack places in `examples/electron/lib/backend/native/` are target-arch.
- For the `mac-x64` job, invoke `theia build` directly instead of `npm run bundle` so its internal host-arch `theia rebuild:electron` doesn't overwrite the x64 binaries webpack is about to read.

## Root cause

CI matrix cross-compiles `mac-x64` on an arm64 runner (`macos-latest`). The old step order:

1. `npm run bundle` → internally runs `theia rebuild:electron` (host arch = arm64) → webpack's node-loader copies arm64 `.node` files into `lib/backend/native/`.
2. `electron-rebuild --arch=x64` → rebuilds `node_modules/` to x64, **but `lib/backend/native/` is already arm64**.

Result: the published x64 DMG contains a mix of architectures. Reproduced on the v0.1.0-alpha.2 release installed on an Intel Mac:

- `app.asar.unpacked/lib/backend/native/drivelist.node` → **arm64** ✗
- `app.asar.unpacked/node_modules/keytar/build/Release/keytar.node` → **x86_64** ✓

App crashes on launch with `dlopen ... incompatible architecture (have 'arm64', need 'x86_64')`.

## Test plan

- [ ] Trigger the workflow via \`workflow_dispatch\` with \`publish=false\`
- [ ] Download \`Cook-Editor-mac-x64\` artifact, extract the DMG
- [ ] Verify \`file \"Cook Editor.app/Contents/Resources/app.asar.unpacked/lib/backend/native/drivelist.node\"\` reports \`x86_64\`
- [ ] Install on an Intel Mac and confirm the app launches (no dlopen error)
- [ ] Verify \`mac-arm64\` job still produces an arm64 bundle (unchanged path)