### PR TITLE
fix(cookbot): externalize gRPC packages and add bundle structural check

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -74,7 +74,8 @@
   },
   "scripts": {
     "build": "theiaext build && npm run -s bundle",
-    "bundle": "npm run rebuild && theia build --mode development",
+    "bundle": "npm run rebuild && theia build --mode development && npm run -s check:bundle",
+    "check:bundle": "node scripts/check-bundle.js",
     "clean": "theiaext clean",
     "deploy": "electron-builder --publish always",
     "package": "electron-builder --publish never",

--- a/app/scripts/check-bundle.js
+++ b/app/scripts/check-bundle.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Structural sanity check on the bundled backend.
+ *
+ * Webpack rewrites unresolvable dynamic require(varName) calls into a
+ * `webpackEmptyContext` that throws MODULE_NOT_FOUND for any key. Some
+ * third-party libraries (e.g. protobufjs via @protobufjs/inquire) catch that
+ * error and silently fall back to a broken state — `util.fs` becomes null,
+ * and later code crashes deep inside the library with confusing errors like
+ * "Cannot read properties of null (reading 'readFileSync')".
+ *
+ * If we see any of these markers in the bundle, the corresponding package
+ * must be externalized in app/webpack.config.js.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const BACKEND_DIR = path.resolve(__dirname, '..', 'lib', 'backend');
+
+/**
+ * Each entry: a string that should NOT appear anywhere in the backend bundle,
+ * plus a hint pointing at the underlying cause and fix.
+ */
+const FORBIDDEN_MARKERS = [
+    {
+        marker: '@protobufjs/inquire sync recursive',
+        package: 'protobufjs',
+        fix: "Externalize '@grpc/grpc-js', '@grpc/proto-loader', 'protobufjs' in app/webpack.config.js"
+    }
+];
+
+function main() {
+    if (!fs.existsSync(BACKEND_DIR)) {
+        console.error(`check-bundle: backend bundle directory not found at ${BACKEND_DIR}`);
+        console.error('check-bundle: run `npm run bundle` first.');
+        process.exit(2);
+    }
+
+    const files = fs.readdirSync(BACKEND_DIR)
+        .filter(f => f.endsWith('.js') && !f.endsWith('.map'))
+        .map(f => path.join(BACKEND_DIR, f));
+
+    if (files.length === 0) {
+        console.error(`check-bundle: no .js files found in ${BACKEND_DIR}`);
+        process.exit(2);
+    }
+
+    /** @type {{ file: string, marker: string, package: string, fix: string }[]} */
+    const violations = [];
+
+    for (const file of files) {
+        const content = fs.readFileSync(file, 'utf8');
+        for (const entry of FORBIDDEN_MARKERS) {
+            if (content.includes(entry.marker)) {
+                violations.push({ file: path.relative(BACKEND_DIR, file), ...entry });
+            }
+        }
+    }
+
+    if (violations.length > 0) {
+        console.error('check-bundle: FAIL — backend bundle contains broken webpack empty-context references.');
+        console.error('');
+        for (const v of violations) {
+            console.error(`  ${v.file}:`);
+            console.error(`    marker:  ${v.marker}`);
+            console.error(`    package: ${v.package}`);
+            console.error(`    fix:     ${v.fix}`);
+            console.error('');
+        }
+        console.error('At runtime these become util.fs = null inside the dependency,');
+        console.error("which surfaces as confusing errors like \"Cannot read properties of null (reading 'readFileSync')\".");
+        process.exit(1);
+    }
+
+    console.log(`check-bundle: OK — scanned ${files.length} backend bundle file(s).`);
+}
+
+main();

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -21,8 +21,21 @@ configs[0].module.rules.push({
 // Exclude NAPI-RS native addon from webpack bundling.
 // The NAPI-RS index.js uses __dirname + existsSync to locate .node binaries,
 // which breaks when processed by webpack. Let Node.js resolve it at runtime.
+//
+// Externalize gRPC packages because protobufjs uses dynamic require('fs')
+// which webpack rewrites to an empty context, making util.fs null and breaking
+// protoLoader.loadSync at runtime ("Cannot read properties of null (reading 'readFileSync')").
+// Clean lib/backend/ between builds so stale chunks (e.g. from before
+// externals were added) don't linger and ship inside the .dmg.
+nodeConfig.config.output = Object.assign({}, nodeConfig.config.output, {
+    clean: true
+});
+
 nodeConfig.config.externals = Object.assign({}, nodeConfig.config.externals, {
-    '@theia/cooklang-native': 'commonjs @theia/cooklang-native'
+    '@theia/cooklang-native': 'commonjs @theia/cooklang-native',
+    '@grpc/grpc-js': 'commonjs @grpc/grpc-js',
+    '@grpc/proto-loader': 'commonjs @grpc/proto-loader',
+    'protobufjs': 'commonjs protobufjs'
 });
 
 // Copy the cookbot gRPC proto file to where the bundled backend expects it.

--- a/packages/cooklang-ai/src/node/cookbot-grpc-client.ts
+++ b/packages/cooklang-ai/src/node/cookbot-grpc-client.ts
@@ -41,11 +41,7 @@ export class CookbotGrpcClient {
 
     @postConstruct()
     protected init(): void {
-        try {
-            this.connect();
-        } catch (err) {
-            console.warn('CookbotGrpcClient: failed to connect on startup, will retry on first use:', (err as Error).message);
-        }
+        this.connect();
     }
 
     protected ensureConnected(): void {


### PR DESCRIPTION
## Summary

- Fixes the "Cannot read properties of null (reading 'readFileSync')" error in the Cookbot AI chat. Root cause: webpack bundled `@protobufjs/inquire`'s dynamic `require()` as a `webpackEmptyContext`, leaving `util.fs = null` and crashing `protoLoader.loadSync`. Fixed by externalizing `@grpc/grpc-js`, `@grpc/proto-loader`, `protobufjs` in `app/webpack.config.js`.
- Adds `app/scripts/check-bundle.js`, wired into `npm run bundle`, which scans the backend bundle for known dangerous webpack empty-context markers and fails the build with a fix hint. Extensible via `FORBIDDEN_MARKERS`.
- Removes the silent `try/catch` from `CookbotGrpcClient.init()` so future bundling/code bugs surface loudly via DI instead of becoming confusing runtime errors on first chat use.
- Adds `output.clean: true` so stale webpack chunks don't ship inside the .dmg.

## Test plan

- [ ] `cd app && npm run bundle` succeeds and `check:bundle` reports OK
- [ ] Manually break the fix (remove one of the new externals), re-bundle, confirm `check:bundle` fails with the marker + fix hint
- [ ] Launch the app and send a message in the Cookbot AI chat — no `readFileSync` error
- [ ] Stop the local cookbot gRPC server, send a message — error surfaces as a network/service error, not a null-deref