### PR TITLE
feat(cooklang-ai): compact indented-tree directory structure output

### DIFF
--- a/docs/superpowers/plans/2026-06-06-directory-structure-token-optimization.md
+++ b/docs/superpowers/plans/2026-06-06-directory-structure-token-optimization.md
@@ -1,0 +1,439 @@
+# Directory Structure Token Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `GetWorkspaceDirectoryStructure` AI tool emit a compact indented-tree string instead of verbose JSON, and exclude hidden (dotfile) directories by default with an opt-in `includeHidden` parameter.
+
+**Architecture:** Rewrite the tool's recursive builder to append indented lines directly during traversal (returning a `string`), layering a local dotfile filter on top of the existing `WorkspaceFunctionScope.shouldExclude`. The shared scope logic and sibling tools are untouched. The `includeHidden` flag is threaded from the tool handler down through the recursion.
+
+**Tech Stack:** TypeScript, Theia `ToolProvider` API, `@theia/core` `URI`, Mocha + Chai unit tests run via `theiaext` against compiled `lib/`.
+
+---
+
+## File Structure
+
+- **Modify:** `packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts`
+  — class `GetWorkspaceDirectoryStructure` only (`getTool`, `getDirectoryStructure`, replace `buildDirectoryStructure` with `appendDirectoryLines`).
+- **Create:** `packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts`
+  — unit tests for the directory-structure tool with in-memory `FileService` / `WorkspaceFunctionScope` fakes.
+
+No other files change. `workspace-function-scope.ts`, `workspace-preferences.ts`, and the other tool classes in `workspace-functions.ts` are out of scope.
+
+---
+
+## Task 1: Indented-tree output + dotfiles hidden by default
+
+Rewrite the output to a sorted indented-tree string, exclude dotfile directories and `shouldExclude`d directories, keep directories-only behavior, return `(empty)` for an empty tree and `Error: <msg>` strings on failure. The recursion already accepts an `includeHidden` flag, but the handler hardcodes `false` in this task (the parameter is exposed in Task 2).
+
+**Files:**
+- Modify: `packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts:36-97`
+- Test: `packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts` (create)
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts`:
+
+```ts
+// *****************************************************************************
+// Copyright (C) 2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { GetWorkspaceDirectoryStructure } from './workspace-functions';
+
+after(() => disableJSDOM());
+
+// ── Test fakes ──────────────────────────────────────────────────────────
+
+/** Minimal FileStat shape the tool relies on. */
+interface FakeStat {
+    resource: URI;
+    isDirectory: boolean;
+    children?: FakeStat[];
+}
+
+/** Nested tree spec: a string value 'file' marks a file, an object marks a directory. */
+type TreeSpec = { [name: string]: TreeSpec | 'file' };
+
+/** Build a flat uri-string -> FakeStat map from a nested tree spec rooted at `rootUri`. */
+function buildStats(rootUri: URI, spec: TreeSpec): Map<string, FakeStat> {
+    const map = new Map<string, FakeStat>();
+    const build = (uri: URI, node: TreeSpec): FakeStat => {
+        const children: FakeStat[] = [];
+        for (const [name, child] of Object.entries(node)) {
+            const childUri = uri.resolve(name);
+            if (child === 'file') {
+                const fileStat: FakeStat = { resource: childUri, isDirectory: false };
+                map.set(childUri.toString(), fileStat);
+                children.push(fileStat);
+            } else {
+                children.push(build(childUri, child));
+            }
+        }
+        const stat: FakeStat = { resource: uri, isDirectory: true, children };
+        map.set(uri.toString(), stat);
+        return stat;
+    };
+    build(rootUri, spec);
+    return map;
+}
+
+class FakeFileService {
+    constructor(private readonly map: Map<string, FakeStat>) {}
+    async resolve(uri: URI): Promise<FakeStat> {
+        const stat = this.map.get(uri.toString());
+        if (!stat) {
+            throw new Error('ENOENT');
+        }
+        return stat;
+    }
+}
+
+class FakeWorkspaceScope {
+    constructor(private readonly root: URI | undefined, private readonly excludes: Set<string>) {}
+    async getWorkspaceRoot(): Promise<URI> {
+        if (!this.root) {
+            throw new Error('No workspace open');
+        }
+        return this.root;
+    }
+    async shouldExclude(stat: FakeStat): Promise<boolean> {
+        return this.excludes.has(stat.resource.path.base);
+    }
+}
+
+/** Construct the tool with injected fakes and return its output for the given args. */
+async function run(spec: TreeSpec, args: string, options?: { excludes?: string[]; noWorkspace?: boolean }): Promise<string> {
+    const root = new URI('file:///root');
+    const map = buildStats(root, spec);
+    const tool = new GetWorkspaceDirectoryStructure();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tool as any).fileService = new FakeFileService(map);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tool as any).workspaceScope = new FakeWorkspaceScope(
+        options?.noWorkspace ? undefined : root,
+        new Set(options?.excludes ?? ['node_modules', 'lib']),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await tool.getTool().handler(args, undefined as any);
+    return result as string;
+}
+
+describe('GetWorkspaceDirectoryStructure', () => {
+
+    it('renders a sorted indented tree of directories', async () => {
+        const out = await run({
+            src: { utils: {}, components: { widgets: {} } },
+            packages: { cooklang: {}, 'cooklang-native': {} },
+        }, '{}');
+        expect(out).to.equal([
+            'packages/',
+            '  cooklang/',
+            '  cooklang-native/',
+            'src/',
+            '  components/',
+            '    widgets/',
+            '  utils/',
+        ].join('\n'));
+    });
+
+    it('lists directories only, never files', async () => {
+        const out = await run({
+            src: { 'index.ts': 'file' },
+            'package.json': 'file',
+        }, '{}');
+        expect(out).to.equal('src/');
+    });
+
+    it('hides dotfile directories by default', async () => {
+        const out = await run({
+            '.git': { objects: {} },
+            '.vscode': {},
+            src: {},
+        }, '{}');
+        expect(out).to.equal('src/');
+    });
+
+    it('excludes directories rejected by shouldExclude regardless of args', async () => {
+        const out = await run({
+            node_modules: { left_pad: {} },
+            lib: {},
+            src: {},
+        }, '{}');
+        expect(out).to.equal('src/');
+    });
+
+    it('returns (empty) when there are no included directories', async () => {
+        const out = await run({ 'README.md': 'file' }, '{}');
+        expect(out).to.equal('(empty)');
+    });
+
+    it('returns an error string when no workspace is open', async () => {
+        const out = await run({}, '{}', { noWorkspace: true });
+        expect(out).to.equal('Error: No workspace open');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd packages/cooklang-ai && npm run compile && npx lerna run test --scope @theia/cooklang-ai --stream
+```
+
+Expected: FAIL — the current tool returns a nested object (not the indented strings), e.g. the first test reports the handler result is not equal to the expected tree string. (The `(empty)` / error tests will also fail because today it returns objects.)
+
+- [ ] **Step 3: Rewrite the tool's output methods**
+
+In `packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts`, replace the `getTool` description and the `getDirectoryStructure` / `buildDirectoryStructure` methods (lines 45-96) with:
+
+```ts
+    getTool(): ToolRequest {
+        return {
+            id: GetWorkspaceDirectoryStructure.ID,
+            name: GetWorkspaceDirectoryStructure.ID,
+            displayName: 'Get Directory Structure',
+            description:
+                'Retrieves the directory tree of the workspace as a compact indented-tree string ' +
+                '(2-space indentation per level, directory names suffixed with "/", one per line, sorted alphabetically). ' +
+                'Lists only directories (no files), excluding hidden (dotfile) directories such as .git and .vscode, ' +
+                'as well as common non-essential directories (node_modules, etc.). ' +
+                'Useful for getting a high-level overview of project organization. ' +
+                'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
+                'For finding specific files, use findFilesByPattern.',
+            parameters: {
+                type: 'object',
+                properties: {},
+            },
+            handler: (_, ctx) => this.getDirectoryStructure(false, ctx?.cancellationToken),
+        };
+    }
+
+    protected async getDirectoryStructure(includeHidden: boolean, cancellationToken?: CancellationToken): Promise<string> {
+        if (cancellationToken?.isCancellationRequested) {
+            return 'Error: Operation cancelled by user';
+        }
+        let workspaceRoot: URI;
+        try {
+            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+        } catch (error) {
+            return `Error: ${(error as Error).message}`;
+        }
+        const lines: string[] = [];
+        await this.appendDirectoryLines(workspaceRoot, 0, includeHidden, lines, cancellationToken);
+        return lines.length > 0 ? lines.join('\n') : '(empty)';
+    }
+
+    protected async appendDirectoryLines(
+        uri: URI,
+        depth: number,
+        includeHidden: boolean,
+        lines: string[],
+        cancellationToken?: CancellationToken,
+    ): Promise<void> {
+        if (cancellationToken?.isCancellationRequested) {
+            return;
+        }
+        const stat = await this.fileService.resolve(uri);
+        if (!stat || !stat.isDirectory || !stat.children) {
+            return;
+        }
+        const childDirs = stat.children
+            .filter(child => child.isDirectory)
+            .sort((a, b) => a.resource.path.base.localeCompare(b.resource.path.base));
+        for (const child of childDirs) {
+            if (cancellationToken?.isCancellationRequested) {
+                return;
+            }
+            const name = child.resource.path.base;
+            if (!includeHidden && name.startsWith('.')) {
+                continue;
+            }
+            if (await this.workspaceScope.shouldExclude(child)) {
+                continue;
+            }
+            lines.push(`${'  '.repeat(depth)}${name}/`);
+            await this.appendDirectoryLines(child.resource, depth + 1, includeHidden, lines, cancellationToken);
+        }
+    }
+```
+
+Note: the `Record<string, unknown>` return type and the old `buildDirectoryStructure` are fully replaced. Leave the class's imports and `@inject` fields as-is.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd packages/cooklang-ai && npm run compile && npx lerna run test --scope @theia/cooklang-ai --stream
+```
+
+Expected: PASS — all six tests in `GetWorkspaceDirectoryStructure` pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts \
+        packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts
+git commit -m "feat(cooklang-ai): indented-tree directory structure output, hide dotfiles"
+```
+
+---
+
+## Task 2: Add the `includeHidden` parameter
+
+Expose `includeHidden` on the tool schema and parse it in the handler so callers can opt into seeing dotfile directories. The recursion already honors the flag; this task wires it through the handler and documents it.
+
+**Files:**
+- Modify: `packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts` (the `getTool` method of `GetWorkspaceDirectoryStructure`)
+- Test: `packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the `describe('GetWorkspaceDirectoryStructure', ...)` block in `workspace-functions.spec.ts`:
+
+```ts
+    it('includes dotfile directories when includeHidden is true', async () => {
+        const out = await run({
+            '.github': {},
+            src: {},
+        }, '{"includeHidden": true}');
+        expect(out).to.equal([
+            '.github/',
+            'src/',
+        ].join('\n'));
+    });
+
+    it('still hides dotfiles when includeHidden is false', async () => {
+        const out = await run({
+            '.github': {},
+            src: {},
+        }, '{"includeHidden": false}');
+        expect(out).to.equal('src/');
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd packages/cooklang-ai && npm run compile && npx lerna run test --scope @theia/cooklang-ai --stream
+```
+
+Expected: FAIL — the `includeHidden is true` test fails because the handler currently ignores the argument and always passes `false`, so `.github/` is omitted. (The `false` test already passes.)
+
+- [ ] **Step 3: Parse `includeHidden` in the handler and document it**
+
+In `packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts`, update the `GetWorkspaceDirectoryStructure.getTool` method: add the schema property, update the description, and parse the argument in the handler.
+
+Replace the `parameters` and `handler` of `getTool` with:
+
+```ts
+            parameters: {
+                type: 'object',
+                properties: {
+                    includeHidden: {
+                        type: 'boolean',
+                        description:
+                            'Include hidden (dotfile) directories such as .git and .vscode. Defaults to false.',
+                    },
+                },
+            },
+            handler: (argString, ctx) => this.getDirectoryStructure(this.parseIncludeHidden(argString), ctx?.cancellationToken),
+```
+
+And update the description string in the same `getTool` to mention the parameter — change the sentence that begins `'Lists only directories ...'` so the block reads:
+
+```ts
+            description:
+                'Retrieves the directory tree of the workspace as a compact indented-tree string ' +
+                '(2-space indentation per level, directory names suffixed with "/", one per line, sorted alphabetically). ' +
+                'Lists only directories (no files), excluding common non-essential directories (node_modules, etc.). ' +
+                'Hidden (dotfile) directories such as .git and .vscode are excluded unless includeHidden is set to true. ' +
+                'Useful for getting a high-level overview of project organization. ' +
+                'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
+                'For finding specific files, use findFilesByPattern.',
+```
+
+Then add this helper method to the `GetWorkspaceDirectoryStructure` class (e.g. directly after `getTool`):
+
+```ts
+    protected parseIncludeHidden(argString: string): boolean {
+        try {
+            const parsed = JSON.parse(argString);
+            return parsed?.includeHidden === true;
+        } catch {
+            return false;
+        }
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd packages/cooklang-ai && npm run compile && npx lerna run test --scope @theia/cooklang-ai --stream
+```
+
+Expected: PASS — all eight tests pass, including both `includeHidden` cases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts \
+        packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts
+git commit -m "feat(cooklang-ai): add includeHidden parameter to directory structure tool"
+```
+
+---
+
+## Task 3: Lint and final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint the package**
+
+```bash
+cd packages/cooklang-ai && npx eslint --ext .ts src/browser/file-tools/workspace-functions.ts src/browser/file-tools/workspace-functions.spec.ts
+```
+
+Expected: no errors. Fix any reported lint issues (e.g. import ordering, missing return types) inline and re-run until clean.
+
+- [ ] **Step 2: Full compile + test for the package**
+
+```bash
+cd packages/cooklang-ai && npm run compile && npx lerna run test --scope @theia/cooklang-ai --stream
+```
+
+Expected: PASS — all `GetWorkspaceDirectoryStructure` tests green, compile succeeds with no TypeScript errors.
+
+- [ ] **Step 3: Commit any lint fixes (if needed)**
+
+```bash
+git add packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts \
+        packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts
+git commit -m "chore(cooklang-ai): lint fixes for directory structure tool"
+```
+
+(Skip this commit if Step 1 reported no issues.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** indented-tree format (Task 1, test 1) ✓; directories-only (Task 1, test 2) ✓; dotfiles hidden by default (Task 1, test 3) ✓; `includeHidden` reveals them (Task 2) ✓; node_modules/lib still excluded (Task 1, test 4) ✓; `(empty)` (Task 1, test 5) ✓; error string (Task 1, test 6) ✓; description/schema updates (Tasks 1 & 2 Step 3) ✓.
+- **Scope:** only `GetWorkspaceDirectoryStructure` and its new spec change; `shouldExclude` and sibling tools untouched, matching the spec's non-goals.
+- **Type consistency:** `appendDirectoryLines` and `getDirectoryStructure(includeHidden, cancellationToken)` signatures are used identically in the implementation and exercised through the public `getTool().handler`; `parseIncludeHidden` is defined in Task 2 before its use in the handler.

--- a/docs/superpowers/specs/2026-06-06-directory-structure-token-optimization-design.md
+++ b/docs/superpowers/specs/2026-06-06-directory-structure-token-optimization-design.md
@@ -1,0 +1,138 @@
+# Directory Structure Tool — Token Optimization
+
+**Date:** 2026-06-06
+**Status:** Approved, pending implementation
+
+## Problem
+
+The `GetWorkspaceDirectoryStructure` AI tool (display name "Get Directory Structure")
+returns a nested JSON object that the tool framework serializes verbatim. This is
+wasteful in two ways:
+
+1. **JSON structural overhead** — every directory becomes a quoted key with `{ ... }`
+   braces, and every leaf directory becomes a redundant empty `{}`. For a deep tree
+   this is a large fraction of the output tokens.
+2. **Hidden directories are not excluded** — only `node_modules` and `lib` are filtered
+   by default (via `userExcludes`). Hidden dirs like `.git` are fully traversed, so the
+   `.git/objects/**` fan-out alone can dominate the entire output.
+
+Result: a single call can emit thousands of low-value tokens (see the `.git` object-dir
+dump that motivated this work).
+
+## Goals
+
+- Replace the JSON object output with a compact indented-tree string.
+- Exclude hidden (dotfile) directories by default, with an opt-in parameter to include them.
+- Keep the change scoped to this one tool.
+
+## Non-Goals
+
+- No changes to `GetWorkspaceFileList`, `FindFilesByPattern`, or the shared
+  `WorkspaceFunctionScope.shouldExclude`.
+- No depth limit, no file listing (tool remains directories-only), no pagination.
+
+## Affected Code
+
+- `packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts`
+  — class `GetWorkspaceDirectoryStructure` (`getTool`, `getDirectoryStructure`,
+  `buildDirectoryStructure`).
+- Corresponding `*.spec.ts` test file (located during planning).
+
+The shared scope/exclusion logic in `workspace-function-scope.ts` is unchanged; the
+dotfile filter is layered on locally so it cannot affect other tools.
+
+## Design
+
+### 1. Output format — indented tree string
+
+The tool returns a plain `string` instead of a `Record<string, unknown>`.
+
+- 2 spaces of indentation per depth level.
+- Directory names suffixed with `/`.
+- One entry per line.
+- Children sorted alphabetically (case-sensitive `localeCompare`) for stable, diff-friendly output.
+- Directories only (unchanged behavior — files are not listed).
+
+Example:
+
+```
+packages/
+  cooklang/
+  cooklang-native/
+src/
+  components/
+    widgets/
+  utils/
+test/
+```
+
+Edge cases:
+
+- Empty workspace (no included subdirectories) → return the literal string `(empty)`.
+- Errors (e.g. no workspace open, resolve failure) → return a short plain-text string,
+  e.g. `Error: <message>`. This replaces the previous `{ error: ... }` object and is
+  consistent with the new `string` return type.
+
+### 2. `includeHidden` parameter
+
+- New optional boolean parameter `includeHidden`, default `false`.
+- Added to the tool's JSON schema `properties` (not in `required`).
+- The handler parses it from the argument string; absent/invalid → `false`.
+
+Behavior:
+
+- `includeHidden: false` (default) — skip any child directory whose basename starts
+  with `.` (e.g. `.git`, `.vscode`, `.github`). This is the primary token saver.
+- `includeHidden: true` — include dotfile directories.
+
+The existing `shouldExclude` filtering (`node_modules`, `lib`, gitignore, user excludes)
+continues to apply in both modes. The dotfile check is an additional local filter applied
+only within this tool.
+
+### 3. Implementation shape
+
+`buildDirectoryStructure` is rewritten to append indented lines directly during the
+recursive traversal, threading `depth` and the `includeHidden` flag, rather than building
+an intermediate nested object and rendering it afterward. This is simpler and avoids the
+intermediate allocation.
+
+Sketch:
+
+```ts
+protected async getDirectoryStructure(includeHidden: boolean, cancellationToken?): Promise<string> {
+    // resolve workspace root; on failure return `Error: ${message}`
+    const lines: string[] = [];
+    await this.appendDirectoryLines(workspaceRoot, 0, includeHidden, lines, cancellationToken);
+    return lines.length ? lines.join('\n') : '(empty)';
+}
+
+protected async appendDirectoryLines(uri, depth, includeHidden, lines, cancellationToken): Promise<void> {
+    // resolve uri; for each child directory, sorted by name:
+    //   - skip if !child.isDirectory
+    //   - skip if !includeHidden && basename.startsWith('.')
+    //   - skip if await shouldExclude(child)
+    //   - push `${'  '.repeat(depth)}${basename}/`
+    //   - recurse at depth + 1
+}
+```
+
+Cancellation is honored at the same points as today (return early; surface
+`Error: Operation cancelled by user` or stop appending).
+
+### 4. Tool description / schema updates
+
+- `description` updated to state the tool returns an indented directory tree (2-space
+  indent, directories only) and to document the `includeHidden` parameter and its default.
+- `parameters.properties.includeHidden` documented as "Include hidden (dotfile)
+  directories such as .git and .vscode. Defaults to false."
+
+## Testing
+
+Unit tests (in the tool's `.spec.ts`) covering:
+
+1. Indented-tree format: correct indentation per depth, trailing `/`, alphabetical order.
+2. Dotfile directories excluded by default.
+3. `includeHidden: true` reveals dotfile directories.
+4. `node_modules` / `lib` still excluded regardless of `includeHidden`.
+5. Empty workspace returns `(empty)`.
+6. Files are not listed (directories only).

--- a/packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
+++ b/packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
@@ -23,8 +23,8 @@ import {
 } from './cookbot-server-tools';
 import { WorkspaceFunctionScope } from './file-tools/workspace-function-scope';
 import { WorkspacePreferencesSchema } from './file-tools/workspace-preferences';
+import { GetWorkspaceDirectoryStructure } from './file-tools/get-workspace-directory-structure';
 import {
-    GetWorkspaceDirectoryStructure,
     FileContentFunction,
     GetWorkspaceFileList,
     FindFilesByPattern,

--- a/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.spec.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.spec.ts
@@ -170,4 +170,29 @@ describe('GetWorkspaceDirectoryStructure', () => {
         const out = await run({}, '{}', { noWorkspace: true });
         expect(out).to.equal('Error: No workspace open');
     });
+
+    it('includes dotfile directories when includeHidden is true', async () => {
+        const out = await run({
+            '.github': {},
+            src: {},
+        }, '{"includeHidden": true}');
+        expect(out).to.equal([
+            '.github/',
+            'src/',
+        ].join('\n'));
+    });
+
+    it('still hides dotfiles when includeHidden is false', async () => {
+        const out = await run({
+            '.github': {},
+            src: {},
+        }, '{"includeHidden": false}');
+        expect(out).to.equal('src/');
+    });
+
+    it('defaults to hiding dotfiles for malformed or non-boolean args', async () => {
+        const spec: TreeSpec = { '.github': {}, src: {} };
+        expect(await run(spec, 'not json')).to.equal('src/');
+        expect(await run(spec, '{"includeHidden": "true"}')).to.equal('src/');
+    });
 });

--- a/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.spec.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.spec.ts
@@ -1,0 +1,173 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { GetWorkspaceDirectoryStructure } from './get-workspace-directory-structure';
+
+after(() => disableJSDOM());
+
+// ── Test fakes ──────────────────────────────────────────────────────────
+
+/** Minimal FileStat shape the tool relies on. */
+interface FakeStat {
+    resource: URI;
+    isDirectory: boolean;
+    children?: FakeStat[];
+}
+
+/** Nested tree spec: a string value 'file' marks a file, an object marks a directory. */
+interface TreeSpec { [name: string]: TreeSpec | 'file' }
+
+/** Build a flat uri-string -> FakeStat map from a nested tree spec rooted at `rootUri`. */
+function buildStats(rootUri: URI, spec: TreeSpec): Map<string, FakeStat> {
+    const map = new Map<string, FakeStat>();
+    const build = (uri: URI, node: TreeSpec): FakeStat => {
+        const children: FakeStat[] = [];
+        for (const [name, child] of Object.entries(node)) {
+            const childUri = uri.resolve(name);
+            if (child === 'file') {
+                const fileStat: FakeStat = { resource: childUri, isDirectory: false };
+                map.set(childUri.toString(), fileStat);
+                children.push(fileStat);
+            } else {
+                children.push(build(childUri, child));
+            }
+        }
+        const stat: FakeStat = { resource: uri, isDirectory: true, children };
+        map.set(uri.toString(), stat);
+        return stat;
+    };
+    build(rootUri, spec);
+    return map;
+}
+
+class FakeFileService {
+    constructor(private readonly map: Map<string, FakeStat>) {}
+    async resolve(uri: URI): Promise<FakeStat> {
+        const stat = this.map.get(uri.toString());
+        if (!stat) {
+            throw new Error('ENOENT');
+        }
+        return stat;
+    }
+}
+
+class FakeWorkspaceScope {
+    constructor(private readonly root: URI | undefined, private readonly excludes: Set<string>) {}
+    async getWorkspaceRoot(): Promise<URI> {
+        if (!this.root) {
+            throw new Error('No workspace open');
+        }
+        return this.root;
+    }
+    async shouldExclude(stat: FakeStat): Promise<boolean> {
+        return this.excludes.has(stat.resource.path.base);
+    }
+}
+
+/** Construct the tool with injected fakes and return its output for the given args. */
+async function run(spec: TreeSpec, args: string, options?: { excludes?: string[]; noWorkspace?: boolean }): Promise<string> {
+    const root = new URI('file:///root');
+    const map = buildStats(root, spec);
+    const tool = new GetWorkspaceDirectoryStructure();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tool as any).fileService = new FakeFileService(map);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tool as any).workspaceScope = new FakeWorkspaceScope(
+        options?.noWorkspace ? undefined : root,
+        new Set(options?.excludes ?? ['node_modules', 'lib']),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await tool.getTool().handler(args, undefined as any);
+    return result as string;
+}
+
+describe('GetWorkspaceDirectoryStructure', () => {
+
+    it('renders a sorted indented tree of directories', async () => {
+        const out = await run({
+            src: { utils: {}, components: { widgets: {} } },
+            packages: { cooklang: {}, 'cooklang-native': {} },
+        }, '{}');
+        expect(out).to.equal([
+            'packages/',
+            '  cooklang/',
+            '  cooklang-native/',
+            'src/',
+            '  components/',
+            '    widgets/',
+            '  utils/',
+        ].join('\n'));
+    });
+
+    it('lists directories only, never files', async () => {
+        const out = await run({
+            src: { 'index.ts': 'file' },
+            'package.json': 'file',
+        }, '{}');
+        expect(out).to.equal('src/');
+    });
+
+    it('hides dotfile directories by default', async () => {
+        const out = await run({
+            '.git': { objects: {} },
+            '.vscode': {},
+            src: {},
+        }, '{}');
+        expect(out).to.equal('src/');
+    });
+
+    it('keeps non-hidden siblings of hidden directories in sorted order', async () => {
+        const out = await run({
+            '.github': {},
+            zebra: {},
+            apple: {},
+            src: {},
+        }, '{}');
+        expect(out).to.equal([
+            'apple/',
+            'src/',
+            'zebra/',
+        ].join('\n'));
+    });
+
+    it('excludes directories rejected by shouldExclude regardless of args', async () => {
+        const out = await run({
+            node_modules: { left_pad: {} },
+            lib: {},
+            src: {},
+        }, '{}');
+        expect(out).to.equal('src/');
+    });
+
+    it('returns (empty) when there are no included directories', async () => {
+        const out = await run({ 'README.md': 'file' }, '{}');
+        expect(out).to.equal('(empty)');
+    });
+
+    it('returns an error string when no workspace is open', async () => {
+        const out = await run({}, '{}', { noWorkspace: true });
+        expect(out).to.equal('Error: No workspace open');
+    });
+});

--- a/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.ts
@@ -39,17 +39,32 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
             description:
                 'Retrieves the directory tree of the workspace as a compact indented-tree string ' +
                 '(2-space indentation per level, directory names suffixed with "/", one per line, sorted alphabetically). ' +
-                'Lists only directories (no files), excluding hidden (dotfile) directories such as .git and .vscode, ' +
-                'as well as common non-essential directories (node_modules, etc.). ' +
+                'Lists only directories (no files), excluding common non-essential directories (node_modules, etc.). ' +
+                'Hidden (dotfile) directories such as .git and .vscode are excluded unless includeHidden is set to true. ' +
                 'Useful for getting a high-level overview of project organization. ' +
                 'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
                 'For finding specific files, use findFilesByPattern.',
             parameters: {
                 type: 'object',
-                properties: {},
+                properties: {
+                    includeHidden: {
+                        type: 'boolean',
+                        description:
+                            'Include hidden (dotfile) directories such as .git and .vscode. Defaults to false.',
+                    },
+                },
             },
-            handler: (_, ctx) => this.getDirectoryStructure(false, ctx?.cancellationToken),
+            handler: (argString, ctx) => this.getDirectoryStructure(this.parseIncludeHidden(argString), ctx?.cancellationToken),
         };
+    }
+
+    protected parseIncludeHidden(argString: string): boolean {
+        try {
+            const parsed = JSON.parse(argString);
+            return parsed?.includeHidden === true;
+        } catch {
+            return false;
+        }
     }
 
     protected async getDirectoryStructure(includeHidden: boolean, cancellationToken?: CancellationToken): Promise<string> {

--- a/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/get-workspace-directory-structure.ts
@@ -1,0 +1,102 @@
+// *****************************************************************************
+// Copyright (C) 2024 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CancellationToken, URI } from '@theia/core';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceFunctionScope } from './workspace-function-scope';
+import { GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID } from './function-ids';
+
+@injectable()
+export class GetWorkspaceDirectoryStructure implements ToolProvider {
+    static ID = GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
+    getTool(): ToolRequest {
+        return {
+            id: GetWorkspaceDirectoryStructure.ID,
+            name: GetWorkspaceDirectoryStructure.ID,
+            displayName: 'Get Directory Structure',
+            description:
+                'Retrieves the directory tree of the workspace as a compact indented-tree string ' +
+                '(2-space indentation per level, directory names suffixed with "/", one per line, sorted alphabetically). ' +
+                'Lists only directories (no files), excluding hidden (dotfile) directories such as .git and .vscode, ' +
+                'as well as common non-essential directories (node_modules, etc.). ' +
+                'Useful for getting a high-level overview of project organization. ' +
+                'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
+                'For finding specific files, use findFilesByPattern.',
+            parameters: {
+                type: 'object',
+                properties: {},
+            },
+            handler: (_, ctx) => this.getDirectoryStructure(false, ctx?.cancellationToken),
+        };
+    }
+
+    protected async getDirectoryStructure(includeHidden: boolean, cancellationToken?: CancellationToken): Promise<string> {
+        if (cancellationToken?.isCancellationRequested) {
+            return 'Error: Operation cancelled by user';
+        }
+        let workspaceRoot: URI;
+        try {
+            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+        } catch (error) {
+            return `Error: ${(error as Error).message}`;
+        }
+        const lines: string[] = [];
+        await this.appendDirectoryLines(workspaceRoot, 0, includeHidden, lines, cancellationToken);
+        return lines.length > 0 ? lines.join('\n') : '(empty)';
+    }
+
+    protected async appendDirectoryLines(
+        uri: URI,
+        depth: number,
+        includeHidden: boolean,
+        lines: string[],
+        cancellationToken?: CancellationToken,
+    ): Promise<void> {
+        if (cancellationToken?.isCancellationRequested) {
+            return;
+        }
+        const stat = await this.fileService.resolve(uri);
+        if (!stat || !stat.isDirectory || !stat.children) {
+            return;
+        }
+        const childDirs = stat.children
+            .filter(child => child.isDirectory)
+            .sort((a, b) => a.resource.path.base.localeCompare(b.resource.path.base));
+        for (const child of childDirs) {
+            if (cancellationToken?.isCancellationRequested) {
+                return;
+            }
+            const name = child.resource.path.base;
+            if (!includeHidden && name.startsWith('.')) {
+                continue;
+            }
+            if (await this.workspaceScope.shouldExclude(child)) {
+                continue;
+            }
+            lines.push(`${'  '.repeat(depth)}${name}/`);
+            await this.appendDirectoryLines(child.resource, depth + 1, includeHidden, lines, cancellationToken);
+        }
+    }
+}

--- a/packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts
@@ -25,76 +25,9 @@ import { WorkspaceFunctionScope } from './workspace-function-scope';
 import {
     FILE_CONTENT_FUNCTION_ID,
     GET_WORKSPACE_FILE_LIST_FUNCTION_ID,
-    GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID,
     FIND_FILES_BY_PATTERN_FUNCTION_ID,
 } from './function-ids';
 import { CONSIDER_GITIGNORE_PREF, FILE_CONTENT_MAX_SIZE_KB_PREF, USER_EXCLUDE_PATTERN_PREF } from './workspace-preferences';
-
-// ── GetWorkspaceDirectoryStructure ──────────────────────────────────────
-
-@injectable()
-export class GetWorkspaceDirectoryStructure implements ToolProvider {
-    static ID = GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID;
-
-    @inject(FileService)
-    protected readonly fileService: FileService;
-
-    @inject(WorkspaceFunctionScope)
-    protected readonly workspaceScope: WorkspaceFunctionScope;
-
-    getTool(): ToolRequest {
-        return {
-            id: GetWorkspaceDirectoryStructure.ID,
-            name: GetWorkspaceDirectoryStructure.ID,
-            displayName: 'Get Directory Structure',
-            description:
-                'Retrieves the complete directory tree structure of the workspace as a nested JSON object. ' +
-                'Lists only directories (no files), excluding common non-essential directories (node_modules, hidden files, etc.). ' +
-                'Useful for getting a high-level overview of project organization. ' +
-                'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
-                'For finding specific files, use findFilesByPattern.',
-            parameters: {
-                type: 'object',
-                properties: {},
-            },
-            handler: (_, ctx) => this.getDirectoryStructure(ctx?.cancellationToken),
-        };
-    }
-
-    protected async getDirectoryStructure(cancellationToken?: CancellationToken): Promise<Record<string, unknown> | string> {
-        if (cancellationToken?.isCancellationRequested) {
-            return { error: 'Operation cancelled by user' };
-        }
-        let workspaceRoot: URI;
-        try {
-            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-        } catch (error) {
-            return { error: (error as Error).message };
-        }
-        return this.buildDirectoryStructure(workspaceRoot, cancellationToken);
-    }
-
-    protected async buildDirectoryStructure(uri: URI, cancellationToken?: CancellationToken): Promise<Record<string, unknown>> {
-        if (cancellationToken?.isCancellationRequested) {
-            return { error: 'Operation cancelled by user' };
-        }
-        const stat = await this.fileService.resolve(uri);
-        const result: Record<string, unknown> = {};
-        if (stat && stat.isDirectory && stat.children) {
-            for (const child of stat.children) {
-                if (cancellationToken?.isCancellationRequested) {
-                    return { error: 'Operation cancelled by user' };
-                }
-                if (!child.isDirectory || (await this.workspaceScope.shouldExclude(child))) {
-                    continue;
-                }
-                const dirName = child.resource.path.base;
-                result[dirName] = await this.buildDirectoryStructure(child.resource, cancellationToken);
-            }
-        }
-        return result;
-    }
-}
 
 // ── FileContentFunction ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Optimizes the `GetWorkspaceDirectoryStructure` AI tool, which previously returned a deeply-nested JSON object describing the workspace tree — token-wasteful (every leaf is a redundant `{}`) and it traversed hidden directories like `.git`, whose `objects/` fan-out alone could dominate the output.

Changes:
- **Indented-tree string output** instead of nested JSON: 2-space indent per level, directories only, names suffixed with `/`, sorted alphabetically. Drops JSON's brace/quote overhead.
- **Hidden (dotfile) directories excluded by default** (`.git`, `.vscode`, …) — the largest token saver. Opt back in with the new optional `includeHidden: true` parameter.
- Empty tree returns `(empty)`; errors return a plain `Error: <msg>` string.
- Existing `node_modules`/gitignore/user exclusions still apply.
- Extracted the tool from the multi-class `workspace-functions.ts` into its own `get-workspace-directory-structure.ts` so its unit test doesn't transitively pull `@theia/monaco` (a `.css` import that breaks the mocha harness). Sibling tools and shared scope logic are untouched.

Design and implementation plan are included under `docs/superpowers/`.

## Test Plan
- [x] 10 unit tests in `get-workspace-directory-structure.spec.ts` (format, dirs-only, dotfile default-hide, sibling sort order, `shouldExclude`, `(empty)`, no-workspace error, `includeHidden` true/false, malformed-arg fallback)
- [x] `npx lerna run test --scope @theia/cooklang-ai` — 10 passing
- [x] `npm run compile` clean
- [x] `eslint` clean on all changed files