### PR TITLE
feat(macos): Quick Look preview + file association for .cook/.menu

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -81,6 +81,36 @@ mac:
   entitlementsInherit: build/entitlements.mac.plist
   # Submit to Apple's notarytool after signing; uses APPLE_* env vars.
   notarize: true
+  # Custom file types for .cook / .menu. Conformance to public.plain-text lets
+  # macOS Quick Look render the source on spacebar with no native extension.
+  # The CFBundleDocumentTypes entries register Cook Editor as an Editor for them.
+  extendInfo:
+    CFBundleDocumentTypes:
+      - CFBundleTypeName: Cooklang Recipe
+        CFBundleTypeRole: Editor
+        LSHandlerRank: Owner
+        LSItemContentTypes:
+          - md.cook.editor.cook
+      - CFBundleTypeName: Cooklang Menu
+        CFBundleTypeRole: Editor
+        LSHandlerRank: Owner
+        LSItemContentTypes:
+          - md.cook.editor.menu
+    UTExportedTypeDeclarations:
+      - UTTypeIdentifier: md.cook.editor.cook
+        UTTypeDescription: Cooklang Recipe
+        UTTypeConformsTo:
+          - public.plain-text
+        UTTypeTagSpecification:
+          public.filename-extension:
+            - cook
+      - UTTypeIdentifier: md.cook.editor.menu
+        UTTypeDescription: Cooklang Menu
+        UTTypeConformsTo:
+          - public.plain-text
+        UTTypeTagSpecification:
+          public.filename-extension:
+            - menu
 
 dmg:
   sign: true

--- a/docs/superpowers/plans/2026-06-06-quicklook-cook-menu-preview.md
+++ b/docs/superpowers/plans/2026-06-06-quicklook-cook-menu-preview.md
@@ -1,0 +1,257 @@
+# macOS Quick Look Preview + File Association Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make macOS Finder show the source text of `.cook` / `.menu` files on Space (Quick Look), and make Cook Editor the default app that opens them on double-click.
+
+**Architecture:** Two changes, no native code. (1) Declare custom UTIs for `.cook`/`.menu` that conform to `public.plain-text` via `mac.extendInfo` in `app/electron-builder.yml` — this unlocks macOS's built-in text Quick Look generator and registers the document types. (2) Override `hookApplicationEvents()` in the existing `CooklangElectronMainApplication` subclass to handle macOS's `open-file` event (which Theia core does not listen for) by routing the file through Theia's existing `handleMainCommand` flow.
+
+**Tech Stack:** electron-builder (YAML `extendInfo` → `Info.plist`), Theia Electron main process (TypeScript), InversifyJS.
+
+**Design spec:** `docs/superpowers/specs/2026-06-06-quicklook-cook-menu-preview-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `app/electron-builder.yml` | Packaging config; adds UTI exported types + document types to the macOS `Info.plist` | Modify (`mac:` block) |
+| `packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts` | Electron main-process app subclass; add `open-file` handling | Modify (add `hookApplicationEvents` override) |
+
+No new files, no new packages, no entitlements changes.
+
+---
+
+## Task 1: Declare `.cook` / `.menu` UTIs and document types
+
+This is packaging metadata. There is no unit test; verification is building an unsigned
+`.app` and inspecting the generated `Info.plist` with `plutil`.
+
+**Files:**
+- Modify: `app/electron-builder.yml` (the `mac:` block, currently around lines 67-86)
+
+- [ ] **Step 1: Add the `extendInfo` block to the `mac:` section**
+
+Open `app/electron-builder.yml`. The `mac:` block currently ends with `notarize: true`.
+Add an `extendInfo:` key inside the `mac:` block (sibling of `icon:`, `target:`,
+`notarize:`, etc. — keep the existing keys). Insert this immediately after the
+`notarize: true` line, at the same indentation level as the other `mac:` keys:
+
+```yaml
+  # Custom file types for .cook / .menu. Conformance to public.plain-text lets
+  # macOS Quick Look render the source on spacebar with no native extension.
+  # The CFBundleDocumentTypes entries register Cook Editor as an Editor for them.
+  extendInfo:
+    CFBundleDocumentTypes:
+      - CFBundleTypeName: Cooklang Recipe
+        CFBundleTypeRole: Editor
+        LSHandlerRank: Owner
+        LSItemContentTypes:
+          - md.cook.editor.cook
+      - CFBundleTypeName: Cooklang Menu
+        CFBundleTypeRole: Editor
+        LSHandlerRank: Owner
+        LSItemContentTypes:
+          - md.cook.editor.menu
+    UTExportedTypeDeclarations:
+      - UTTypeIdentifier: md.cook.editor.cook
+        UTTypeDescription: Cooklang Recipe
+        UTTypeConformsTo:
+          - public.plain-text
+        UTTypeTagSpecification:
+          public.filename-extension:
+            - cook
+      - UTTypeIdentifier: md.cook.editor.menu
+        UTTypeDescription: Cooklang Menu
+        UTTypeConformsTo:
+          - public.plain-text
+        UTTypeTagSpecification:
+          public.filename-extension:
+            - menu
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run: `cd app && npx js-yaml electron-builder.yml > /dev/null && echo "YAML OK"`
+Expected: prints `YAML OK` (no parse error). If `js-yaml` CLI is unavailable, use:
+`node -e "require('js-yaml').load(require('fs').readFileSync('electron-builder.yml','utf8')); console.log('YAML OK')"`
+Expected: prints `YAML OK`.
+
+- [ ] **Step 3: Build an unsigned app bundle**
+
+Run: `cd app && CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --dir`
+Expected: completes and produces `app/dist/mac*/Cook Editor.app` (arch-dependent
+directory name, e.g. `dist/mac-arm64`). This skips signing/notarization.
+
+> Note: this step requires the app to have been bundled first (`npm run bundle`). If
+> `src-gen`/`lib` are stale or missing, run `cd app && npm run bundle` before this step.
+
+- [ ] **Step 4: Verify the Info.plist contains the UTI declarations**
+
+Run:
+```bash
+cd app
+APP=$(ls -d dist/mac*/*.app | head -1)
+plutil -extract UTExportedTypeDeclarations xml1 -o - "$APP/Contents/Info.plist" | grep -E "md.cook.editor.(cook|menu)|public.plain-text"
+plutil -extract CFBundleDocumentTypes xml1 -o - "$APP/Contents/Info.plist" | grep -E "md.cook.editor.(cook|menu)|Cooklang"
+```
+Expected: the first command prints lines containing `md.cook.editor.cook`,
+`md.cook.editor.menu`, and `public.plain-text`. The second prints the document type
+names/UTIs. If either `plutil -extract` errors with "does not exist", the `extendInfo`
+keys were not merged — recheck indentation in Step 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/electron-builder.yml
+git commit -m "feat(macos): declare .cook/.menu UTIs for Quick Look + file association"
+```
+
+---
+
+## Task 2: Handle macOS `open-file` so double-click opens the file
+
+Theia core's `hookApplicationEvents()` registers `will-quit`, `second-instance`, and
+`open-url` listeners but never `open-file`, so a double-clicked document does nothing.
+We override the method in the existing `CooklangElectronMainApplication` subclass, call
+`super` to keep all existing listeners, then add an `open-file` listener that forwards to
+the same `handleMainCommand` path Theia uses for CLI/second-instance file arguments.
+
+Electron main-process code is not practically unit-testable here; verification is a
+TypeScript compile + lint, plus the manual checks in Task 3.
+
+**Files:**
+- Modify: `packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts`
+
+- [ ] **Step 1: Add the `app` import**
+
+The file already imports from `@theia/core/electron-shared/electron`. Change that import
+line (currently `import { BrowserWindowConstructorOptions } from '@theia/core/electron-shared/electron';`)
+to also import `app`:
+
+```ts
+import { app, BrowserWindowConstructorOptions } from '@theia/core/electron-shared/electron';
+```
+
+(`path` is already imported as `import * as path from 'path';` — no change needed.)
+
+- [ ] **Step 2: Add the `hookApplicationEvents` override**
+
+Inside the `CooklangElectronMainApplication` class body (e.g. after the existing
+`getDefaultOptions()` override), add:
+
+```ts
+    /**
+     * Theia core does not register a macOS `open-file` handler, so double-clicking a
+     * `.cook` / `.menu` file in Finder (or "Open With → Cook Editor") would otherwise do
+     * nothing. Route the file through the same flow Theia uses for CLI/second-instance
+     * file arguments, so double-click behaves like launching the app with the file path.
+     */
+    protected override hookApplicationEvents(): void {
+        super.hookApplicationEvents();
+        if (process.platform === 'darwin') {
+            app.on('open-file', (event, filePath) => {
+                event.preventDefault();
+                this.handleMainCommand({
+                    file: filePath,
+                    cwd: path.dirname(filePath),
+                    secondInstance: true
+                }).catch(error => console.error('Failed to open file from Finder:', error));
+            });
+        }
+    }
+```
+
+- [ ] **Step 3: Compile the package**
+
+Run: `npx lerna run compile --scope @theia/cooklang-branding`
+Expected: completes with no TypeScript errors. If it errors that `handleMainCommand` /
+`hookApplicationEvents` are not assignable or have wrong visibility, re-check the method
+signatures against `node_modules/@theia/core/lib/electron-main/electron-main-application.d.ts`
+(both are `protected`; `handleMainCommand(options: ElectronMainCommandOptions)` accepts
+`{ file?, cwd, secondInstance }`).
+
+- [ ] **Step 4: Lint**
+
+Run: `npx lerna run lint --scope @theia/cooklang-branding`
+Expected: passes with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
+git commit -m "feat(macos): open .cook/.menu files on Finder double-click (open-file event)"
+```
+
+---
+
+## Task 3: Manual end-to-end verification on a packaged build
+
+No code changes — this task confirms the feature actually works, since the behavior lives
+in macOS LaunchServices/Quick Look and cannot be exercised by automated tests.
+
+**Files:** none.
+
+- [ ] **Step 1: Build and bundle the app**
+
+Run: `cd app && npm run bundle`
+Expected: completes; `src-gen/` and `lib/` are regenerated.
+
+- [ ] **Step 2: Produce a local app bundle**
+
+Run: `cd app && CSC_IDENTITY_AUTO_DISCOVERY=false npx electron-builder --dir`
+Expected: `app/dist/mac*/Cook Editor.app` exists.
+
+- [ ] **Step 3: Register the bundle with LaunchServices**
+
+Run:
+```bash
+cd app
+APP=$(ls -d dist/mac*/*.app | head -1)
+/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister -f "$APP"
+```
+Expected: no output (success). This forces macOS to pick up the new UTIs/associations
+without a re-login.
+
+- [ ] **Step 4: Verify Quick Look preview**
+
+Create a test file and preview it in Finder:
+```bash
+printf -- '---\ntitle: Test Recipe\n---\nAdd @eggs{2} to the #bowl{} and mix.\n' > ~/Desktop/quicklook-test.cook
+```
+In Finder, select `~/Desktop/quicklook-test.cook` and press Space.
+Expected: the Quick Look panel shows the file's source text (YAML frontmatter + the
+Cooklang line). Repeat with a `.menu` file:
+```bash
+printf -- '---\ntitle: Test Menu\n---\n[Starter]\n@@Soup\n' > ~/Desktop/quicklook-test.menu
+```
+Expected: source text shown on Space.
+
+> If "No preview available" still shows, LaunchServices may not have refreshed — re-run
+> Step 3, or log out/in. This is an OS cache issue, not a code defect (see spec caveats).
+
+- [ ] **Step 5: Verify double-click opens the file**
+
+While Cook Editor is NOT running, double-click `~/Desktop/quicklook-test.cook` in Finder.
+Expected: Cook Editor launches and opens the file (cold-launch `open-file`).
+Then, with Cook Editor already running, double-click `~/Desktop/quicklook-test.menu`.
+Expected: the file opens in the already-running instance.
+
+- [ ] **Step 6: Clean up test files**
+
+Run: `rm -f ~/Desktop/quicklook-test.cook ~/Desktop/quicklook-test.menu`
+Expected: files removed.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Part 1 (Quick Look UTIs) → Task 1 Steps 1-4. Part 2a (document
+  types) → Task 1 (CFBundleDocumentTypes). Part 2b (`open-file` handler) → Task 2.
+  Testing/verification + LaunchServices and cold-launch caveats → Task 3. All spec
+  sections are covered.
+- **Types:** `handleMainCommand({ file, cwd, secondInstance })` and the `protected`
+  `hookApplicationEvents()` override match the signatures in
+  `@theia/core/lib/electron-main/electron-main-application.d.ts` (verified during design).
+- **No placeholders:** every step has concrete YAML/TS/commands and expected output.

--- a/docs/superpowers/specs/2026-06-06-quicklook-cook-menu-preview-design.md
+++ b/docs/superpowers/specs/2026-06-06-quicklook-cook-menu-preview-design.md
@@ -1,0 +1,145 @@
+# macOS Quick Look preview + file association for `.cook` / `.menu`
+
+**Date:** 2026-06-06
+**Status:** Approved design — pending implementation plan
+
+## Goal
+
+When a user presses Space on a `.cook` or `.menu` file in macOS Finder (Quick Look),
+show the file's contents instead of the generic "no preview available" panel. As part
+of the same UTI registration, make Cook Editor the default application that opens these
+files on double-click.
+
+## Scope decisions
+
+- **Preview fidelity: raw source text only.** The Quick Look panel renders the `.cook` /
+  `.menu` source as plain text, exactly like previewing a `.txt` file. A fully *rendered*
+  recipe preview (formatted ingredients, steps, etc.) would require a native Quick Look
+  Preview Extension (`.appex`) built in Xcode, embedded in `Contents/PlugIns/`, and
+  separately code-signed/notarized. That is explicitly **out of scope** here and may be a
+  future phase.
+- **Platform: macOS only.** Windows/Linux are unaffected.
+- **No native code.** Part 1 is pure Info.plist metadata; Part 2 is TypeScript in the
+  existing Electron main-process subclass.
+
+## How macOS Quick Look works (why this approach)
+
+Finder's spacebar preview is **not** rendered by the Electron app at runtime. macOS
+decides how to preview a file from its UTI (Uniform Type Identifier). If a custom file
+type's UTI is declared to **conform to `public.plain-text`**, macOS's built-in text
+Quick Look generator renders it for free — no extension required.
+
+`electron-builder`'s `fileAssociations` field generates `CFBundleDocumentTypes` but does
+**not** let us control UTI *conformance*, so it cannot by itself make Quick Look show
+text. The reliable path is to declare the exported UTIs ourselves via `mac.extendInfo`,
+which merges arbitrary keys into the packaged `Info.plist`.
+
+## Part 1 — Quick Look preview (the core ask)
+
+Add to the `mac:` section of `app/electron-builder.yml` an `extendInfo` block declaring
+two exported UTIs and their document types.
+
+**Exported UTIs** (`UTExportedTypeDeclarations`):
+
+| UTI                   | Extension | Conforms to          | Description     |
+| --------------------- | --------- | -------------------- | --------------- |
+| `md.cook.editor.cook` | `cook`    | `public.plain-text`  | Cooklang Recipe |
+| `md.cook.editor.menu` | `menu`    | `public.plain-text`  | Cooklang Menu   |
+
+Each declaration includes `UTTypeTagSpecification` with
+`public.filename-extension: [<ext>]`. Conformance to `public.plain-text` is what unlocks
+the built-in text preview.
+
+> Note on `.menu`: this is a fairly generic extension. We declare an *exported* type we
+> own (`md.cook.editor.menu`); if another installed app also claims `.menu`,
+> LaunchServices resolves the handler by rank/recency. This is acceptable and not a
+> blocker — we are not trying to seize `.menu` system-wide, only to provide a preview and
+> a handler.
+
+## Part 2 — File association / default-open
+
+Declaring the UTIs alone makes the files show the Cook Editor icon and appear under
+"Open With → Cook Editor", but **double-click will not actually open the file**: Theia's
+Electron main process listens for `open-url` (the `cook://` scheme) and `second-instance`
+/ CLI args, but **not** for macOS's `open-file` event, which is what Finder fires on
+double-click.
+
+### 2a. Document type registration
+
+In the same `extendInfo` block, add `CFBundleDocumentTypes` entries that bind each UTI to
+the app as an editor:
+
+- `CFBundleTypeRole: Editor`
+- `LSItemContentTypes: [md.cook.editor.cook]` (and the menu UTI respectively)
+- `LSHandlerRank: Owner`
+
+### 2b. `open-file` handler
+
+The `cooklang-branding` package already subclasses `ElectronMainApplication` as
+`CooklangElectronMainApplication` and rebinds it (`packages/cooklang-branding/src/
+electron-main/`). Both `hookApplicationEvents()` and `handleMainCommand()` are
+`protected`, so the subclass is the access-correct, lowest-friction home for this — no
+new package and no cross-package coupling.
+
+Override `hookApplicationEvents()` in `CooklangElectronMainApplication`:
+
+1. Call `super.hookApplicationEvents()` to preserve all existing listeners
+   (`will-quit`, `second-instance`, `open-url`, etc.).
+2. Register `app.on('open-file', (event, filePath) => { ... })`:
+   - `event.preventDefault()`.
+   - Forward to the existing flow: `this.handleMainCommand({ file: filePath,
+     cwd: path.dirname(filePath), secondInstance: true })`.
+
+This routes a double-clicked file through the **exact same code path** Theia already uses
+for CLI file arguments (`cook-editor <path>`) and second-instance launches. We are not
+inventing new open behavior — double-click behaves identically to launching the app with
+the file as an argument. (How Theia then presents that path — as a single-file workspace
+vs. opening an editor — is existing, tested Theia behavior and is intentionally not
+redesigned here. A future refinement could open the file's parent folder as the workspace
+and reveal the file; that is out of scope.)
+
+`open-file` is registered only on non-Windows, consistent with how Theia gates `open-url`.
+
+## Files touched
+
+| File                                                                                  | Change                                                              |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `app/electron-builder.yml`                                                            | Add `mac.extendInfo` with `UTExportedTypeDeclarations` + `CFBundleDocumentTypes` |
+| `packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts`  | Override `hookApplicationEvents()` to handle `open-file`            |
+
+No new packages, no new entitlements, no native targets. Hardened runtime and
+notarization are unaffected because nothing is added to the signed binary set.
+
+## Testing & verification
+
+- **Unit-level:** the `open-file` override is thin glue over `handleMainCommand`; verify
+  by inspection and a focused test of the path-resolution call if practical (main-process
+  Electron code is awkward to unit test — primary verification is manual on a packaged
+  build).
+- **Manual (the real test):**
+  1. `cd app && npm run package` to produce a signed local `.app`/DMG.
+  2. Install/launch it once so LaunchServices registers the bundle.
+  3. In Finder, select a `.cook` file and press Space → the source text should appear in
+     the Quick Look panel. Repeat for a `.menu` file.
+  4. Double-click a `.cook` file → Cook Editor opens it (launching cold and while already
+     running).
+
+## Caveats / known risks
+
+- **LaunchServices cache:** associations and previews may not appear until the bundle is
+  registered. After install this usually happens automatically; if not, force it with
+  `/System/Library/Frameworks/CoreServices.framework/.../lsregister -f <App>.app` or a
+  re-login. Document this for testers; it is not a code issue.
+- **Cold-launch `open-file` timing:** when the app is launched *by* a Finder double-click
+  (not yet running), macOS buffers the `open-file` event until a listener attaches.
+  `hookApplicationEvents()` runs during startup, mirroring how the existing `open-url`
+  handler already works in this app, so this is expected to function — but it is the main
+  thing to verify in manual testing (step 4, cold launch).
+- **`.menu` extension collisions:** see the note in Part 1; not a blocker.
+
+## Out of scope (possible future phases)
+
+- Native Quick Look Preview Extension for a *rendered* (formatted) recipe/menu preview.
+- Quick Look thumbnails (file icons showing recipe content).
+- Custom document-type icons for `.cook` / `.menu` in Finder.
+- "Open parent folder + reveal file" double-click behavior.

--- a/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
@@ -12,7 +12,7 @@
 // *****************************************************************************
 
 import { injectable } from '@theia/core/shared/inversify';
-import { BrowserWindowConstructorOptions } from '@theia/core/electron-shared/electron';
+import { app, BrowserWindowConstructorOptions } from '@theia/core/electron-shared/electron';
 import { ElectronMainApplication } from '@theia/core/lib/electron-main/electron-main-application';
 import { TheiaBrowserWindowOptions } from '@theia/core/lib/electron-main/theia-electron-window';
 import * as path from 'path';
@@ -34,5 +34,25 @@ export class CooklangElectronMainApplication extends ElectronMainApplication {
             resolved.icon = path.resolve(this.globals.THEIA_APP_PROJECT_PATH, resolved.icon);
         }
         return resolved;
+    }
+
+    /**
+     * Theia core does not register a macOS `open-file` handler, so double-clicking a
+     * `.cook` / `.menu` file in Finder (or "Open With → Cook Editor") would otherwise do
+     * nothing. Route the file through the same flow Theia uses for CLI/second-instance
+     * file arguments, so double-click behaves like launching the app with the file path.
+     */
+    protected override hookApplicationEvents(): void {
+        super.hookApplicationEvents();
+        if (process.platform === 'darwin') {
+            app.on('open-file', (event, filePath) => {
+                event.preventDefault();
+                this.handleMainCommand({
+                    file: filePath,
+                    cwd: path.dirname(filePath),
+                    secondInstance: true
+                }).catch(error => console.error('Failed to open file from Finder:', error));
+            });
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Declare custom UTIs (`md.cook.editor.cook`, `md.cook.editor.menu`) conforming to `public.plain-text` via `mac.extendInfo` in `electron-builder.yml`, so macOS Finder renders the file source on **Quick Look** (spacebar) — no native extension needed.
- Register Cook Editor as an **Editor** handler for `.cook`/`.menu` (`CFBundleDocumentTypes`).
- Add a macOS `open-file` handler (override `hookApplicationEvents()` in `CooklangElectronMainApplication`), which Theia core lacks, so **double-clicking** a file in Finder opens it — routed through Theia's existing `handleMainCommand` flow.

No native code, no new packages, no entitlements changes; notarization unaffected.

Design: `docs/superpowers/specs/2026-06-06-quicklook-cook-menu-preview-design.md`
Plan: `docs/superpowers/plans/2026-06-06-quicklook-cook-menu-preview.md`

## Test Plan
- [x] `electron-builder --dir` Info.plist contains both UTIs (conforming to `public.plain-text`) + document types
- [x] `@theia/cooklang-branding` compiles + lints clean
- [x] Manual: Space on a `.cook`/`.menu` file shows source in Quick Look
- [x] Manual: double-click opens the file in Cook Editor (cold launch and while running)