### PR TITLE
feat(win,linux): file association + Linux spacebar text preview for .cook/.menu

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -122,6 +122,15 @@ win:
   target:
     - nsis
     - zip
+  fileAssociations:
+    - ext: cook
+      name: Cooklang Recipe
+      description: Cooklang Recipe
+      icon: resources/icon.ico
+    - ext: menu
+      name: Cooklang Menu
+      description: Cooklang Menu
+      icon: resources/icon.ico
 
 nsis:
   oneClick: false
@@ -144,6 +153,15 @@ linux:
     - AppImage
     - deb
     - tar.gz
+  fileAssociations:
+    - ext: cook
+      name: Cooklang Recipe
+      description: Cooklang Recipe
+      mimeType: text/x-cooklang
+    - ext: menu
+      name: Cooklang Menu
+      description: Cooklang Menu
+      mimeType: text/x-cooklang-menu
 
 appImage:
   artifactName: Cook-Editor.${ext}

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -54,6 +54,8 @@ extraResources:
     to: licenses/LICENSE-vscode.txt
   - from: ../NOTICE.md
     to: licenses/NOTICE.md
+  - from: resources/cooklang-mime.xml
+    to: cooklang-mime.xml
 
 publish:
   provider: github
@@ -172,5 +174,7 @@ deb:
     - libnotify4
     - libxtst6
     - libnss3
+  afterInstall: scripts/linux/deb-after-install.sh
+  afterRemove: scripts/linux/deb-after-remove.sh
 
 afterPack: ./scripts/after-pack.js

--- a/app/resources/cooklang-mime.xml
+++ b/app/resources/cooklang-mime.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/x-cooklang">
+    <comment>Cooklang Recipe</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.cook"/>
+  </mime-type>
+  <mime-type type="text/x-cooklang-menu">
+    <comment>Cooklang Menu</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.menu"/>
+  </mime-type>
+</mime-info>

--- a/app/scripts/linux/deb-after-install.sh
+++ b/app/scripts/linux/deb-after-install.sh
@@ -1,13 +1,64 @@
-#!/bin/sh
-set -e
-# Locate the MIME definition shipped inside the installed app tree (under /opt).
-# Using `find` avoids hard-coding a path containing the space in the product name.
-SRC="$(find /opt -maxdepth 4 -name cooklang-mime.xml 2>/dev/null | head -1)"
-if [ -n "$SRC" ] && command -v update-mime-database >/dev/null 2>&1; then
-    install -Dm644 "$SRC" /usr/share/mime/packages/cooklang.xml
+#!/bin/bash
+
+if type update-alternatives >/dev/null 2>&1; then
+    # Remove previous link if it doesn't use update-alternatives
+    if [ -L '/usr/bin/${executable}' -a -e '/usr/bin/${executable}' -a "`readlink '/usr/bin/${executable}'`" != '/etc/alternatives/${executable}' ]; then
+        rm -f '/usr/bin/${executable}'
+    fi
+    update-alternatives --install '/usr/bin/${executable}' '${executable}' '/opt/${sanitizedProductName}/${executable}' 100 || ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+else
+    ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
+fi
+
+# Check if user namespaces are supported by the kernel and working with a quick test:
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+fi
+
+# Cooklang: install the text/plain-subclass MIME definition so .cook/.menu files
+# are recognized as text and previewed by GNOME Files (Sushi) on spacebar. This
+# must run before the update-mime-database call below so the new type is picked up.
+if [ -f '/opt/${sanitizedProductName}/resources/cooklang-mime.xml' ]; then
+    cp -f '/opt/${sanitizedProductName}/resources/cooklang-mime.xml' /usr/share/mime/packages/cooklang.xml || true
+fi
+
+if hash update-mime-database 2>/dev/null; then
     update-mime-database /usr/share/mime || true
 fi
-# Refresh the desktop application database so the file association is picked up.
-if command -v update-desktop-database >/dev/null 2>&1; then
+
+if hash update-desktop-database 2>/dev/null; then
     update-desktop-database /usr/share/applications || true
+fi
+
+# Install apparmor profile. (Ubuntu 24+)
+# First check if the version of AppArmor running on the device supports our profile.
+# This is in order to keep backwards compatibility with Ubuntu 22.04 which does not support abi/4.0.
+# In that case, we just skip installing the profile since the app runs fine without it on 22.04.
+#
+# Those apparmor_parser flags are akin to performing a dry run of loading a profile.
+# https://wiki.debian.org/AppArmor/HowToUse#Dumping_profiles
+#
+# Unfortunately, at the moment AppArmor doesn't have a good story for backwards compatibility.
+# https://askubuntu.com/questions/1517272/writing-a-backwards-compatible-apparmor-profile
+if apparmor_status --enabled > /dev/null 2>&1; then
+  APPARMOR_PROFILE_SOURCE='/opt/${sanitizedProductName}/resources/apparmor-profile'
+  APPARMOR_PROFILE_TARGET='/etc/apparmor.d/${executable}'
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
+
+    # Updating the current AppArmor profile is not possible and probably not meaningful in a chroot'ed environment.
+    # Use cases are for example environments where images for clients are maintained.
+    # There, AppArmor might correctly be installed, but live updating makes no sense.
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      # Extra flags taken from dh_apparmor:
+      # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
+      # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET"
+    fi
+  else
+    echo "Skipping the installation of the AppArmor profile as this version of AppArmor does not seem to support the bundled profile"
+  fi
 fi

--- a/app/scripts/linux/deb-after-install.sh
+++ b/app/scripts/linux/deb-after-install.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+# Locate the MIME definition shipped inside the installed app tree (under /opt).
+# Using `find` avoids hard-coding a path containing the space in the product name.
+SRC="$(find /opt -maxdepth 4 -name cooklang-mime.xml 2>/dev/null | head -1)"
+if [ -n "$SRC" ] && command -v update-mime-database >/dev/null 2>&1; then
+    install -Dm644 "$SRC" /usr/share/mime/packages/cooklang.xml
+    update-mime-database /usr/share/mime || true
+fi
+# Refresh the desktop application database so the file association is picked up.
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database /usr/share/applications || true
+fi

--- a/app/scripts/linux/deb-after-remove.sh
+++ b/app/scripts/linux/deb-after-remove.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+if [ -f /usr/share/mime/packages/cooklang.xml ]; then
+    rm -f /usr/share/mime/packages/cooklang.xml
+    if command -v update-mime-database >/dev/null 2>&1; then
+        update-mime-database /usr/share/mime || true
+    fi
+fi

--- a/app/scripts/linux/deb-after-remove.sh
+++ b/app/scripts/linux/deb-after-remove.sh
@@ -1,8 +1,24 @@
-#!/bin/sh
-set -e
+#!/bin/bash
+
+# Delete the link to the binary
+if type update-alternatives >/dev/null 2>&1; then
+    update-alternatives --remove '${executable}' '/usr/bin/${executable}'
+else
+    rm -f '/usr/bin/${executable}'
+fi
+
+APPARMOR_PROFILE_DEST='/etc/apparmor.d/${executable}'
+
+# Remove apparmor profile.
+if [ -f "$APPARMOR_PROFILE_DEST" ]; then
+  rm -f "$APPARMOR_PROFILE_DEST"
+fi
+
+# Cooklang: remove the MIME definition installed by the after-install script,
+# then refresh the MIME database.
 if [ -f /usr/share/mime/packages/cooklang.xml ]; then
     rm -f /usr/share/mime/packages/cooklang.xml
-    if command -v update-mime-database >/dev/null 2>&1; then
+    if hash update-mime-database 2>/dev/null; then
         update-mime-database /usr/share/mime || true
     fi
 fi

--- a/docs/superpowers/plans/2026-06-07-cross-platform-file-association.md
+++ b/docs/superpowers/plans/2026-06-07-cross-platform-file-association.md
@@ -1,0 +1,369 @@
+# Windows + Linux File Association (and Linux Text Preview) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Cook Editor the default app that opens `.cook`/`.menu` files on Windows and Linux (double-click), and let GNOME Files (Sushi) preview their source on spacebar.
+
+**Architecture:** Pure packaging config — no application code. Windows/Linux pass a double-clicked file to the app as `argv`, which Theia already opens via `handleMainCommand`. Add `fileAssociations` scoped under the `win:` and `linux:` blocks of `app/electron-builder.yml` (scoped per-platform so macOS's existing `extendInfo` is untouched). For Linux spacebar preview, ship a shared-mime-info XML declaring the types as `sub-class-of text/plain` and register it on `.deb` install via `afterInstall`/`afterRemove` scripts running `update-mime-database`.
+
+**Tech Stack:** electron-builder (YAML), freedesktop shared-mime-info XML, POSIX sh maintainer scripts.
+
+**Design spec:** `docs/superpowers/specs/2026-06-07-cross-platform-file-association-design.md`
+
+> **Environment note:** This is a macOS dev box. Building the actual Windows NSIS and Linux `.deb` artifacts requires Windows / Linux environments and is done in **Task 3 (manual)**. Tasks 1-2 are config/file creation verified by static checks (YAML parse, `sh -n`, XML well-formedness).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `app/electron-builder.yml` | Packaging config: per-platform `fileAssociations`, `extraResources` entry, `deb.afterInstall`/`afterRemove` | Modify |
+| `app/resources/cooklang-mime.xml` | freedesktop MIME definition marking `.cook`/`.menu` as `sub-class-of text/plain` | Create |
+| `build/linux/deb-after-install.sh` | Install MIME XML into `/usr/share/mime/packages/` and refresh databases | Create |
+| `build/linux/deb-after-remove.sh` | Remove MIME XML and refresh the MIME database | Create |
+
+No application/runtime code, no new packages, no macOS changes.
+
+---
+
+## Task 1: Windows + Linux file associations
+
+Add `fileAssociations` under both the `win:` and `linux:` blocks. This is the
+default-open half — portable with no code because Theia opens files passed on `argv`.
+
+**Files:**
+- Modify: `app/electron-builder.yml` (`win:` block ~lines 120-124, `linux:` block ~lines 140-146)
+
+- [ ] **Step 1: Add `fileAssociations` to the `win:` block**
+
+The `win:` block currently is:
+
+```yaml
+win:
+  icon: resources/icon.ico
+  target:
+    - nsis
+    - zip
+```
+
+Change it to (append `fileAssociations`, keep existing keys):
+
+```yaml
+win:
+  icon: resources/icon.ico
+  target:
+    - nsis
+    - zip
+  fileAssociations:
+    - ext: cook
+      name: Cooklang Recipe
+      description: Cooklang Recipe
+      icon: resources/icon.ico
+    - ext: menu
+      name: Cooklang Menu
+      description: Cooklang Menu
+      icon: resources/icon.ico
+```
+
+- [ ] **Step 2: Add `fileAssociations` to the `linux:` block**
+
+The `linux:` block currently is:
+
+```yaml
+linux:
+  icon: resources/icon-256.png
+  category: Utility
+  target:
+    - AppImage
+    - deb
+    - tar.gz
+```
+
+Change it to (append `fileAssociations`, keep existing keys):
+
+```yaml
+linux:
+  icon: resources/icon-256.png
+  category: Utility
+  target:
+    - AppImage
+    - deb
+    - tar.gz
+  fileAssociations:
+    - ext: cook
+      name: Cooklang Recipe
+      description: Cooklang Recipe
+      mimeType: text/x-cooklang
+    - ext: menu
+      name: Cooklang Menu
+      description: Cooklang Menu
+      mimeType: text/x-cooklang-menu
+```
+
+- [ ] **Step 3: Verify the YAML parses and associations are scoped per-platform**
+
+Run from `/Users/alexeydubovskoy/Cooklang/editor`:
+
+```bash
+cd app && node -e "
+const y=require('js-yaml');
+const o=y.load(require('fs').readFileSync('electron-builder.yml','utf8'));
+const win=(o.win.fileAssociations||[]).map(f=>f.ext+':'+(f.mimeType||'(no mime)'));
+const lin=(o.linux.fileAssociations||[]).map(f=>f.ext+':'+f.mimeType);
+if(o.mac && o.mac.fileAssociations){throw new Error('mac.fileAssociations must NOT be set')};
+if(!o.mac || !o.mac.extendInfo){throw new Error('mac.extendInfo missing — did not preserve macOS work')};
+console.log('win:', win.join(', '));
+console.log('linux:', lin.join(', '));
+console.log('mac.extendInfo preserved:', !!o.mac.extendInfo);
+"
+```
+
+Expected output:
+```
+win: cook:(no mime), menu:(no mime)
+linux: cook:text/x-cooklang, menu:text/x-cooklang-menu
+mac.extendInfo preserved: true
+```
+
+(If the node command can't resolve `js-yaml` from `app/`, run it from the repo root — `js-yaml` is a transitive dependency of electron-builder.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/electron-builder.yml
+git commit -m "feat(win,linux): register .cook/.menu file associations"
+```
+
+---
+
+## Task 2: Linux spacebar preview (MIME subclass + deb scripts)
+
+Make the Linux MIME types subclasses of `text/plain` so GNOME Sushi previews the source.
+Ship the XML inside the app, and register it on `.deb` install via maintainer scripts.
+
+**Files:**
+- Create: `app/resources/cooklang-mime.xml`
+- Create: `build/linux/deb-after-install.sh`
+- Create: `build/linux/deb-after-remove.sh`
+- Modify: `app/electron-builder.yml` (`extraResources` list ~lines 40-62, `deb:` block ~lines 151-156)
+
+- [ ] **Step 1: Create the MIME definition**
+
+Create `app/resources/cooklang-mime.xml` with exactly:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/x-cooklang">
+    <comment>Cooklang Recipe</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.cook"/>
+  </mime-type>
+  <mime-type type="text/x-cooklang-menu">
+    <comment>Cooklang Menu</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.menu"/>
+  </mime-type>
+</mime-info>
+```
+
+- [ ] **Step 2: Verify the XML is well-formed**
+
+Run: `xmllint --noout app/resources/cooklang-mime.xml && echo "XML OK"`
+Expected: prints `XML OK` (no error). `xmllint` ships with macOS. If it is unavailable,
+use: `python3 -c "import xml.dom.minidom,sys; xml.dom.minidom.parse('app/resources/cooklang-mime.xml'); print('XML OK')"`
+Expected: prints `XML OK`.
+
+- [ ] **Step 3: Create the deb after-install script**
+
+Create `build/linux/deb-after-install.sh` with exactly:
+
+```sh
+#!/bin/sh
+set -e
+# Locate the MIME definition shipped inside the installed app tree (under /opt).
+# Using `find` avoids hard-coding a path containing the space in the product name.
+SRC="$(find /opt -maxdepth 4 -name cooklang-mime.xml 2>/dev/null | head -1)"
+if [ -n "$SRC" ] && command -v update-mime-database >/dev/null 2>&1; then
+    install -Dm644 "$SRC" /usr/share/mime/packages/cooklang.xml
+    update-mime-database /usr/share/mime || true
+fi
+# Refresh the desktop application database so the file association is picked up.
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database /usr/share/applications || true
+fi
+```
+
+- [ ] **Step 4: Create the deb after-remove script**
+
+Create `build/linux/deb-after-remove.sh` with exactly:
+
+```sh
+#!/bin/sh
+set -e
+if [ -f /usr/share/mime/packages/cooklang.xml ]; then
+    rm -f /usr/share/mime/packages/cooklang.xml
+    if command -v update-mime-database >/dev/null 2>&1; then
+        update-mime-database /usr/share/mime || true
+    fi
+fi
+```
+
+- [ ] **Step 5: Make both scripts executable and verify their syntax**
+
+Run from `/Users/alexeydubovskoy/Cooklang/editor`:
+
+```bash
+chmod +x build/linux/deb-after-install.sh build/linux/deb-after-remove.sh
+sh -n build/linux/deb-after-install.sh && sh -n build/linux/deb-after-remove.sh && echo "SH SYNTAX OK"
+test -x build/linux/deb-after-install.sh && test -x build/linux/deb-after-remove.sh && echo "EXECUTABLE OK"
+```
+
+Expected: prints `SH SYNTAX OK` then `EXECUTABLE OK`.
+
+- [ ] **Step 6: Ship the XML as an extra resource**
+
+In `app/electron-builder.yml`, the `extraResources:` list currently ends with:
+
+```yaml
+  - from: ../NOTICE.md
+    to: licenses/NOTICE.md
+```
+
+Add a new entry immediately after it (same indentation, still inside `extraResources:`):
+
+```yaml
+  - from: resources/cooklang-mime.xml
+    to: cooklang-mime.xml
+```
+
+- [ ] **Step 7: Wire the maintainer scripts into the `deb:` block**
+
+The `deb:` block currently is:
+
+```yaml
+deb:
+  artifactName: Cook-Editor.${ext}
+  depends:
+    - libnotify4
+    - libxtst6
+    - libnss3
+```
+
+Change it to (append the two script keys, keep existing keys):
+
+```yaml
+deb:
+  artifactName: Cook-Editor.${ext}
+  depends:
+    - libnotify4
+    - libxtst6
+    - libnss3
+  afterInstall: build/linux/deb-after-install.sh
+  afterRemove: build/linux/deb-after-remove.sh
+```
+
+- [ ] **Step 8: Verify the YAML still parses with the new keys**
+
+Run from `/Users/alexeydubovskoy/Cooklang/editor`:
+
+```bash
+cd app && node -e "
+const y=require('js-yaml');
+const o=y.load(require('fs').readFileSync('electron-builder.yml','utf8'));
+const hasRes=(o.extraResources||[]).some(r=>r.from==='resources/cooklang-mime.xml');
+if(!hasRes){throw new Error('extraResources entry for cooklang-mime.xml missing')};
+if(o.deb.afterInstall!=='build/linux/deb-after-install.sh'){throw new Error('deb.afterInstall not set')};
+if(o.deb.afterRemove!=='build/linux/deb-after-remove.sh'){throw new Error('deb.afterRemove not set')};
+console.log('extraResources + deb scripts wired OK');
+"
+```
+
+Expected output: `extraResources + deb scripts wired OK`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/electron-builder.yml app/resources/cooklang-mime.xml build/linux/deb-after-install.sh build/linux/deb-after-remove.sh
+git commit -m "feat(linux): enable GNOME spacebar text preview for .cook/.menu via MIME subclass"
+```
+
+---
+
+## Task 3: Manual cross-platform verification
+
+No code changes — confirms behavior on real OSes (cannot be tested on the macOS dev box).
+
+**Files:** none.
+
+- [ ] **Step 1: Windows — build the installer**
+
+On a Windows machine (or Windows VM) with the repo checked out and deps installed:
+Run: `cd app && npm run bundle && npx electron-builder --win nsis`
+Expected: produces `app/dist/Cook-Editor-Setup.exe`.
+
+- [ ] **Step 2: Windows — install and test association**
+
+Install the produced `.exe`. In File Explorer, create a test file `test.cook` containing
+a couple of lines of text, then double-click it.
+Expected: Cook Editor launches and opens `test.cook`. Repeat with a `test.menu` file.
+Expected: the files show the Cook Editor icon in Explorer.
+
+- [ ] **Step 3: Linux — build the deb**
+
+On a Linux machine (or VM) with GNOME, repo checked out and deps installed:
+Run: `cd app && npm run bundle && npx electron-builder --linux deb`
+Expected: produces `app/dist/Cook-Editor.deb`.
+
+- [ ] **Step 4: Linux — install and verify MIME registration**
+
+```bash
+sudo apt install ./app/dist/Cook-Editor.deb
+gio mime text/x-cooklang
+test -f /usr/share/mime/packages/cooklang.xml && echo "mime xml installed"
+```
+Expected: `/usr/share/mime/packages/cooklang.xml` exists; `gio mime text/x-cooklang`
+reports Cook Editor as the default handler.
+
+- [ ] **Step 5: Linux — verify content-type and text inheritance**
+
+```bash
+printf -- '---\ntitle: Test\n---\nAdd @eggs{2} to the #bowl{}.\n' > ~/test.cook
+gio info ~/test.cook | grep content-type
+```
+Expected: `standard::content-type: text/x-cooklang`. (The type inherits `text/plain` per
+the shipped MIME XML, which is what enables text preview.)
+
+- [ ] **Step 6: Linux — verify association and spacebar preview in GNOME Files**
+
+Open `~` in GNOME Files (Nautilus). Double-click `test.cook`.
+Expected: Cook Editor opens it. Then select `test.cook` and press Space.
+Expected: GNOME Sushi shows the file's source text.
+
+- [ ] **Step 7: Linux — verify clean removal**
+
+```bash
+sudo apt remove cook-editor   # or the package name reported by: dpkg -l | grep -i cook
+test -f /usr/share/mime/packages/cooklang.xml && echo "STILL PRESENT (bug)" || echo "removed OK"
+```
+Expected: prints `removed OK` (the after-remove script deleted the MIME XML).
+
+- [ ] **Step 8: Clean up test files**
+
+Run (on each platform used): remove the `test.cook` / `test.menu` files created above.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Part W (Windows association) → Task 1 Steps 1,3-4 + Task 3 Steps 1-2.
+  Part L1 (Linux association) → Task 1 Steps 2-4 + Task 3 Steps 3-4,6. Part L2 (Linux
+  preview) → Task 2 (XML + scripts + wiring) + Task 3 Steps 5-7. Testing/verification →
+  Task 3. Scope limitations are inherent (deb/GNOME only) and surfaced in Task 3’s targets.
+- **MIME type consistency:** `text/x-cooklang` (`.cook`) and `text/x-cooklang-menu`
+  (`.menu`) are identical across the `linux.fileAssociations` mimeType (Task 1 Step 2),
+  the shipped XML (Task 2 Step 1), and the verification commands (Task 3 Steps 4-5).
+- **No placeholders:** every step has concrete YAML/XML/sh content and expected output.
+- **macOS safety:** Task 1 Step 3 asserts `mac.extendInfo` is preserved and
+  `mac.fileAssociations` is absent, guarding against regressing the merged macOS work.

--- a/docs/superpowers/plans/2026-06-07-cross-platform-file-association.md
+++ b/docs/superpowers/plans/2026-06-07-cross-platform-file-association.md
@@ -326,6 +326,19 @@ test -f /usr/share/mime/packages/cooklang.xml && echo "mime xml installed"
 Expected: `/usr/share/mime/packages/cooklang.xml` exists; `gio mime text/x-cooklang`
 reports Cook Editor as the default handler.
 
+- [ ] **Step 4b: Linux — verify the app is on PATH and launches**
+
+The deb maintainer scripts override electron-builder's defaults, so confirm the default
+behavior they incorporate still works (PATH symlink, chrome-sandbox, AppArmor):
+
+```bash
+which cook-editor   # or the executable name from: dpkg -L <pkg> | grep /usr/bin
+cook-editor &       # should launch the app window, then close it
+```
+Expected: `which` prints `/usr/bin/cook-editor` (the `update-alternatives`/symlink from
+the after-install script), and launching from the terminal opens the app without a
+chrome-sandbox or AppArmor error.
+
 - [ ] **Step 5: Linux — verify content-type and text inheritance**
 
 ```bash

--- a/docs/superpowers/specs/2026-06-07-cross-platform-file-association-design.md
+++ b/docs/superpowers/specs/2026-06-07-cross-platform-file-association-design.md
@@ -1,0 +1,234 @@
+# Windows + Linux file association (and Linux text preview) for `.cook` / `.menu`
+
+**Date:** 2026-06-07
+**Status:** Approved design — pending implementation plan
+
+## Goal
+
+Extend the macOS Quick Look / file-association work (see
+`2026-06-06-quicklook-cook-menu-preview-design.md`) to the other desktop platforms:
+
+- **Windows:** Cook Editor is the default app that opens `.cook` / `.menu` on
+  double-click.
+- **Linux:** same default-open association, plus a source-text preview on spacebar in
+  GNOME Files (Sushi).
+
+The macOS implementation is already merged/open separately and is **not** modified here.
+
+## Why "the same" is only partially portable
+
+The macOS feature had two halves: file association (double-click opens) and Quick Look
+preview (spacebar). Their portability differs:
+
+- **File association** is portable and cheap. Windows passes a double-clicked file to the
+  app as an `argv` argument; Linux file managers do the same. Theia's Electron main
+  process already opens a file given on `argv` — `start()` parses a `[file]` positional and
+  calls `handleMainCommand({ file, cwd, secondInstance: false })`
+  (`@theia/core/lib/electron-main/electron-main-application.js:156`), and
+  `onSecondInstance` does the same when the app is already running. So **no application
+  code is needed** for double-click-open on Windows or Linux — only packaging metadata.
+- **Spacebar preview** is macOS-specific UX:
+  - **Windows** has no spacebar preview in Explorer. The nearest analog is the Preview
+    Pane (Alt+P), which requires a native `IPreviewHandler` COM shell extension (C++/.NET,
+    registry-registered) — out of scope: heavy, non-Electron, low payoff.
+  - **Linux** has spacebar preview only in GNOME Files via **Sushi** (and varies by
+    desktop environment). Sushi picks a previewer by MIME type; declaring our type a
+    **subclass of `text/plain`** makes it use the text previewer — the Linux analog of
+    macOS's `public.plain-text` conformance.
+
+## electron-builder behavior (verified in `app-builder-lib`)
+
+- `fileAssociations` is read **per platform**: the effective list is
+  `config.fileAssociations` concatenated with `platformSpecificBuildOptions.fileAssociations`
+  (`platformPackager.js:578`). So putting `fileAssociations` under `win:` / `linux:` keeps
+  them off macOS. macOS only merges `mac.extendInfo` into its plist
+  (`macPackager.js:473`), so the existing macOS work is untouched.
+- For Linux, electron-builder auto-generates a MIME XML
+  (`LinuxTargetHelper.computeMimeTypeFiles`) containing only `<glob>`, `<comment>`, and
+  `<icon>` — **no `<sub-class-of>`** — and installs it (for `deb`/fpm targets) to
+  `/usr/share/mime/packages/<executableName>.xml` (`FpmTarget.js:196`). It also adds each
+  association's `mimeType` to the generated `.desktop` `MimeType=` key
+  (`LinuxTargetHelper.js:139`).
+- `update-mime-database` **unions** all definitions across files in
+  `/usr/share/mime/packages/`. So an additional XML that declares only
+  `<sub-class-of type="text/plain"/>` for the same MIME type augments (does not replace)
+  electron-builder's generated glob definition. This is the mechanism Part L2 relies on.
+
+## MIME types
+
+- `.cook` → `text/x-cooklang`
+- `.menu` → `text/x-cooklang-menu`
+
+Both declared `<sub-class-of type="text/plain"/>` (Part L2).
+
+## Part W — Windows file association
+
+Add a `fileAssociations` array under the **`win:`** block in `app/electron-builder.yml`:
+
+```yaml
+win:
+  # ...existing keys...
+  fileAssociations:
+    - ext: cook
+      name: Cooklang Recipe
+      description: Cooklang Recipe
+      icon: resources/icon.ico
+    - ext: menu
+      name: Cooklang Menu
+      description: Cooklang Menu
+      icon: resources/icon.ico
+```
+
+The NSIS installer registers the extensions to the app. On double-click, Windows launches
+Cook Editor with the file path as `argv`, which Theia already opens. **No code changes.**
+
+Note: registration is per-user (HKCU) under the current assisted NSIS config
+(`oneClick: false`), which is fine. The existing `cook://` protocol registration is
+independent and unaffected.
+
+## Part L1 — Linux file association
+
+Add a `fileAssociations` array under the **`linux:`** block, with MIME types:
+
+```yaml
+linux:
+  # ...existing keys...
+  fileAssociations:
+    - ext: cook
+      name: Cooklang Recipe
+      description: Cooklang Recipe
+      mimeType: text/x-cooklang
+    - ext: menu
+      name: Cooklang Menu
+      description: Cooklang Menu
+      mimeType: text/x-cooklang-menu
+```
+
+electron-builder writes `text/x-cooklang;text/x-cooklang-menu;` into the generated
+`.desktop` `MimeType=` key and ships a glob MIME definition. On the **`.deb`** package this
+gives full desktop integration (default-open via `argv`). **AppImage and tar.gz do not
+install system files, so they will not auto-register** — documented limitation.
+
+## Part L2 — Linux spacebar preview (GNOME)
+
+Make the MIME types subclasses of `text/plain` so GNOME Sushi previews the source.
+
+1. **Add `app/resources/cooklang-mime.xml`:**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="text/x-cooklang">
+    <comment>Cooklang Recipe</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.cook"/>
+  </mime-type>
+  <mime-type type="text/x-cooklang-menu">
+    <comment>Cooklang Menu</comment>
+    <sub-class-of type="text/plain"/>
+    <glob pattern="*.menu"/>
+  </mime-type>
+</mime-info>
+```
+
+2. **Ship it as an extra resource** so it lands inside the installed app tree
+   (`/opt/<productName>/resources/cooklang-mime.xml`). Add to `extraResources` in
+   `app/electron-builder.yml`:
+
+```yaml
+extraResources:
+  # ...existing entries...
+  - from: resources/cooklang-mime.xml
+    to: cooklang-mime.xml
+```
+
+   (Installed location resolves under the app's `resources/` directory; the exact absolute
+   path is computed in the post-install script — see step 3.)
+
+3. **Register it on install via deb scripts.** Add to the `deb:` block:
+
+```yaml
+deb:
+  # ...existing keys...
+  afterInstall: build/linux/deb-after-install.sh
+  afterRemove: build/linux/deb-after-remove.sh
+```
+
+   `build/linux/deb-after-install.sh`:
+
+```sh
+#!/bin/sh
+set -e
+# Locate the shipped MIME definition within the installed app tree.
+SRC="$(find /opt -maxdepth 4 -name cooklang-mime.xml 2>/dev/null | head -1)"
+if [ -n "$SRC" ] && command -v update-mime-database >/dev/null 2>&1; then
+    install -Dm644 "$SRC" /usr/share/mime/packages/cooklang.xml
+    update-mime-database /usr/share/mime || true
+fi
+# Refresh the desktop application database so the association is picked up.
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database /usr/share/applications || true
+fi
+```
+
+   `build/linux/deb-after-remove.sh`:
+
+```sh
+#!/bin/sh
+set -e
+if [ -f /usr/share/mime/packages/cooklang.xml ]; then
+    rm -f /usr/share/mime/packages/cooklang.xml
+    if command -v update-mime-database >/dev/null 2>&1; then
+        update-mime-database /usr/share/mime || true
+    fi
+fi
+```
+
+   After `update-mime-database` runs, the merged definition for each type has both the
+   glob (from electron-builder's generated XML) and `<sub-class-of type="text/plain"/>`
+   (from ours). GNOME Sushi then previews `.cook` / `.menu` as text on spacebar.
+
+## Files touched
+
+| File | Change |
+| --- | --- |
+| `app/electron-builder.yml` | `win.fileAssociations`, `linux.fileAssociations`, `extraResources` entry, `deb.afterInstall` / `deb.afterRemove` |
+| `app/resources/cooklang-mime.xml` | New — MIME definition with `sub-class-of text/plain` |
+| `build/linux/deb-after-install.sh` | New — install MIME XML + refresh databases |
+| `build/linux/deb-after-remove.sh` | New — remove MIME XML + refresh database |
+
+No application/runtime code changes. No new packages. No macOS changes. Entitlements and
+notarization unaffected.
+
+## Testing & verification
+
+- **Static:** YAML still parses; the two shell scripts pass `sh -n` (syntax check) and are
+  executable; the XML is well-formed (`xmllint --noout` if available).
+- **Windows (manual, on a Windows box/VM):** build NSIS (`electron-builder --win nsis`),
+  install, double-click a `.cook` and a `.menu` file → Cook Editor opens each. Confirm the
+  files show the app icon in Explorer.
+- **Linux (manual, GNOME VM/container):** build `.deb` (`electron-builder --linux deb`),
+  install with `apt install ./<pkg>.deb`, then:
+  - double-click a `.cook`/`.menu` in Files → Cook Editor opens it;
+  - select the file and press Space → Sushi shows the source text.
+  - `gio info quicklook-test.cook` should report `standard::content-type: text/x-cooklang`
+    and the type should inherit `text/plain` (`gio mime text/x-cooklang`).
+
+## Caveats / known risks
+
+- **deb-only desktop integration:** AppImage and tar.gz neither register the association
+  nor enable preview automatically (no system-file install). Accepted.
+- **GNOME-only preview:** spacebar preview depends on GNOME Sushi. KDE Dolphin and other
+  file managers may show the association but preview behavior varies; not targeted.
+- **`/opt` discovery in the post-install script:** the script `find`s `cooklang-mime.xml`
+  under `/opt` rather than hard-coding `/opt/Cook Editor/resources/...`, avoiding fragility
+  from the space in the product name and any install-dir differences.
+- **Mime cache timing:** as on macOS, the file manager may need a restart (or
+  `update-mime-database` to finish) before the new type/preview is recognized.
+
+## Out of scope (possible future phases)
+
+- Native Windows `IPreviewHandler` (Preview Pane) and `IThumbnailProvider` (thumbnails).
+- Dedicated `.cook` / `.menu` document icons (this pass reuses the app icon).
+- KDE/other-DE preview integration.
+- Rendered (formatted) previews on any platform — these remain raw-source only.


### PR DESCRIPTION
## Summary
Extends the macOS Quick Look / file-association work (#33) to Windows and Linux. **No application code** — purely packaging config plus freedesktop MIME metadata.

- **Windows** — `win.fileAssociations` for `.cook`/`.menu`; NSIS registers the extensions. Double-click opens the file (Theia already opens files passed on `argv`; verified at `electron-main-application.js:156`).
- **Linux association** — `linux.fileAssociations` with MIME types `text/x-cooklang` / `text/x-cooklang-menu`; full desktop integration on `.deb`.
- **Linux spacebar preview** — ships `cooklang-mime.xml` declaring the types `sub-class-of text/plain`, installed into `/usr/share/mime/packages/` by the deb `afterInstall`/`afterRemove` scripts so GNOME Files (Sushi) previews the source on Space.
- File associations are scoped under `win:`/`linux:` only, so the merged macOS `mac.extendInfo` is untouched.

### Note on the deb maintainer scripts
electron-builder **replaces** (does not append to) its default deb scripts when `deb.afterInstall`/`afterRemove` are set. The scripts here are therefore **supersets** of electron-builder's default templates (preserving the `/usr/bin` symlink, chrome-sandbox SUID, and AppArmor profile setup) with the Cooklang MIME registration added. Caught in code review; verified by diffing against the default templates.

### Scope / limitations (by design)
- Windows: association only — Explorer has no spacebar preview (a native `IPreviewHandler` is out of scope).
- Linux preview: **deb + GNOME** only; AppImage/tar.gz install no system files; other DEs vary.

Spec: `docs/superpowers/specs/2026-06-07-cross-platform-file-association-design.md`
Plan: `docs/superpowers/plans/2026-06-07-cross-platform-file-association.md`

## Test Plan
Static checks done (YAML parse, `bash -n`, XML well-formed, scripts diff-verified vs electron-builder defaults, `mac.extendInfo` preserved). **Real-OS verification still required** (no Win/Linux env available to the author):
- [ ] Windows: build NSIS, install, double-click `.cook`/`.menu` → Cook Editor opens
- [ ] Linux (GNOME): build `.deb`, install, `which cook-editor` resolves + app launches (PATH/sandbox/AppArmor intact)
- [ ] Linux: double-click opens; Space shows source preview (Sushi); `gio info` reports `text/x-cooklang`
- [ ] Linux: uninstall removes `/usr/share/mime/packages/cooklang.xml`