### PR TITLE
fix(macos): embed Quick Look appex (after-pack early-return skipped it)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,24 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+      # Guard against silently shipping a macOS build without the Quick Look
+      # extension (regression: after-pack early-returned before the embed block,
+      # so no build contained Contents/PlugIns/CookQuickLook.appex).
+      - name: Verify Quick Look extension embedded (macOS)
+        if: runner.os == 'macOS'
+        working-directory: app
+        shell: bash
+        run: |
+          APP=$(find dist -maxdepth 2 -name 'Cook Editor.app' -type d | head -1)
+          if [ -z "$APP" ]; then
+            echo "::error::packaged 'Cook Editor.app' not found under app/dist"; exit 1
+          fi
+          APPEX="$APP/Contents/PlugIns/CookQuickLook.appex"
+          if [ ! -x "$APPEX/Contents/MacOS/CookQuickLook" ]; then
+            echo "::error::Quick Look extension missing at $APPEX — after-pack embed did not run"; exit 1
+          fi
+          echo "Quick Look extension embedded: $APPEX"
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/app/scripts/after-pack.js
+++ b/app/scripts/after-pack.js
@@ -11,6 +11,14 @@ const fs = require('fs');
  * @param {import('electron-builder').AfterPackContext} context
  */
 exports.default = async function afterPack(context) {
+    // Embed the macOS Quick Look extension FIRST — it must run independently of the
+    // source-map cleanup below, which early-returns when the asar `resources/app`
+    // layout is absent (it is, for this app). Gating the embed behind that guard is
+    // what previously shipped builds with no extension.
+    if (context.electronPlatformName === 'darwin') {
+        embedQuickLookAppex(context);
+    }
+
     const appDir = path.join(context.appOutDir, 'resources', 'app');
     if (!fs.existsSync(appDir)) {
         console.log('after-pack: app directory not found, skipping cleanup');
@@ -23,31 +31,36 @@ exports.default = async function afterPack(context) {
         removeFilesRecursively(libDir, f => f.endsWith('.js.map'));
     }
 
-    // macOS only: embed the Quick Look preview extension into Contents/PlugIns
-    // so electron-builder's mac signing step seals it and notarization covers it.
-    // NOTE: this electron-builder version's AfterPackContext has no `appDir`; the
-    // packager's `projectDir` is the electron-builder project root (this `app/`
-    // directory), so `..` reaches the repo root where `macos/` lives.
-    if (context.electronPlatformName === 'darwin') {
-        const projectDir = context.packager.projectDir;
-        const appexSrc = path.resolve(
-            projectDir, '..', 'macos', 'QuickLookExtension', 'build', 'CookQuickLook.appex'
-        );
-        if (fs.existsSync(appexSrc)) {
-            const appName = `${context.packager.appInfo.productFilename}.app`;
-            const plugins = path.join(context.appOutDir, appName, 'Contents', 'PlugIns');
-            fs.mkdirSync(plugins, { recursive: true });
-            const dest = path.join(plugins, 'CookQuickLook.appex');
-            fs.rmSync(dest, { recursive: true, force: true });
-            fs.cpSync(appexSrc, dest, { recursive: true });
-            console.log(`after-pack: embedded Quick Look appex at ${dest}`);
-        } else {
-            console.warn(`after-pack: CookQuickLook.appex not found at ${appexSrc}; skipping (run macos/scripts/build-quicklook.sh first)`);
-        }
-    }
-
     console.log('after-pack: cleanup complete');
 };
+
+/**
+ * Embed the Quick Look preview extension into the packaged `<App>.app/Contents/PlugIns`
+ * so electron-builder's mac signing step seals it and notarization covers it.
+ *
+ * NOTE: this electron-builder version's AfterPackContext has no `appDir`; the packager's
+ * `projectDir` is the electron-builder project root (this `app/` directory), so `..`
+ * reaches the repo root where `macos/` lives.
+ *
+ * @param {import('electron-builder').AfterPackContext} context
+ */
+function embedQuickLookAppex(context) {
+    const projectDir = context.packager.projectDir;
+    const appexSrc = path.resolve(
+        projectDir, '..', 'macos', 'QuickLookExtension', 'build', 'CookQuickLook.appex'
+    );
+    if (!fs.existsSync(appexSrc)) {
+        console.warn(`after-pack: CookQuickLook.appex not found at ${appexSrc}; skipping (run macos/scripts/build-quicklook.sh first)`);
+        return;
+    }
+    const appName = `${context.packager.appInfo.productFilename}.app`;
+    const plugins = path.join(context.appOutDir, appName, 'Contents', 'PlugIns');
+    fs.mkdirSync(plugins, { recursive: true });
+    const dest = path.join(plugins, 'CookQuickLook.appex');
+    fs.rmSync(dest, { recursive: true, force: true });
+    fs.cpSync(appexSrc, dest, { recursive: true });
+    console.log(`after-pack: embedded Quick Look appex at ${dest}`);
+}
 
 /**
  * @param {string} dir

--- a/app/scripts/after-pack.spec.js
+++ b/app/scripts/after-pack.spec.js
@@ -1,0 +1,61 @@
+// @ts-check
+'use strict';
+
+// Regression test for the macOS Quick Look appex embedding in after-pack.
+//
+// Bug: the appex-embed block was placed AFTER the source-map-cleanup guard,
+// which early-`return`s when `<appOutDir>/resources/app` is absent. That path
+// does not exist in this app's packaged layout, so the embed never ran and no
+// build shipped the extension. This test pins the embed running INDEPENDENTLY
+// of that guard. Run: `node app/scripts/after-pack.spec.js`
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const afterPack = require('./after-pack').default;
+
+async function run() {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'afterpack-spec-'));
+    try {
+        const projectDir = path.join(tmp, 'repo', 'app'); // electron-builder project dir
+        const appOutDir = path.join(tmp, 'out');
+        const appName = 'Cook Editor.app';
+
+        // Packaged .app exists; `resources/app` deliberately does NOT (mirrors real layout).
+        fs.mkdirSync(path.join(appOutDir, appName, 'Contents'), { recursive: true });
+
+        // Fake built appex at the path after-pack resolves from projectDir/../macos.
+        const appexSrc = path.join(tmp, 'repo', 'macos', 'QuickLookExtension', 'build', 'CookQuickLook.appex');
+        fs.mkdirSync(path.join(appexSrc, 'Contents'), { recursive: true });
+        fs.writeFileSync(path.join(appexSrc, 'Contents', 'Info.plist'), '<plist/>');
+
+        const context = {
+            appOutDir,
+            electronPlatformName: 'darwin',
+            packager: {
+                projectDir,
+                appInfo: { productFilename: 'Cook Editor' }
+            }
+        };
+
+        await afterPack(context);
+
+        const embedded = path.join(
+            appOutDir, appName, 'Contents', 'PlugIns', 'CookQuickLook.appex', 'Contents', 'Info.plist'
+        );
+        assert.ok(
+            fs.existsSync(embedded),
+            'appex must be embedded into Contents/PlugIns even when resources/app is absent'
+        );
+        console.log('PASS: appex embedded regardless of the resources/app cleanup guard');
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+}
+
+run().catch(e => {
+    console.error('FAIL:', e.message);
+    process.exit(1);
+});


### PR DESCRIPTION
## Problem

The macOS Quick Look extension never shipped in any build — alpha.16's published `Cook-Editor-*.zip`/`.dmg` (and the installed app) have **no `Contents/PlugIns/CookQuickLook.appex`**, so spacebar still shows the raw text fallback.

**Root cause:** `app/scripts/after-pack.js` early-`return`s when `<appOutDir>/resources/app` doesn't exist (it never does in this app's packaged layout — the source-map cleanup had silently been a no-op all along). The appex-embed block was placed *after* that return, so it was dead code. CI confirms it: every macOS job logged `after-pack: app directory not found, skipping cleanup`, and the `Build Quick Look extension` step built the appex but it was never embedded.

The `.cook`-shows-as-text / `dyn.*` UTI was a **red herring** (stale `mdls`/Spotlight cache); `UTType(filenameExtension:"cook")` resolves to `md.cook.editor.cook` correctly, so the appex will match once present.

## Fix

- Run the macOS embed (`embedQuickLookAppex`) **before** the cleanup guard, independent of `resources/app`.
- Add `app/scripts/after-pack.spec.js` — a regression test that fails on the old code, passes on the new (`node app/scripts/after-pack.spec.js`).
- Add a release-CI guard that **fails the macOS build** if the packaged app lacks `Contents/PlugIns/CookQuickLook.appex`.

## Test Plan
- [x] `node app/scripts/after-pack.spec.js` passes (failed before the fix)
- [x] `node --check app/scripts/after-pack.js`
- [ ] Next release (alpha.17): CI guard confirms the appex is embedded; install + spacebar a `.cook` → rendered preview