### PR TITLE
fix(macos): pre-sign the Quick Look appex so electron-builder can seal the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,9 +203,50 @@ jobs:
           fi
           echo "All required frontend modules are registered."
 
-      - name: Build Quick Look extension (macOS)
+      - name: Build & sign Quick Look extension (macOS)
         if: runner.os == 'macOS'
-        run: ./macos/scripts/build-quicklook.sh
+        shell: bash
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/ql-signing.keychain-db"
+          KPW="$(uuidgen)"
+          CERT="$RUNNER_TEMP/ql-cert.p12"
+          trap 'rm -f "$CERT"' EXIT
+
+          # Import the Developer ID cert into a dedicated keychain so xcodebuild can sign
+          # the appex (and its embedded framework) inside-out before electron-builder runs.
+          printf '%s' "$MAC_CSC_LINK" | base64 --decode > "$CERT"
+          security create-keychain -p "$KPW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KPW" "$KEYCHAIN"
+          security import "$CERT" -k "$KEYCHAIN" -P "$MAC_CSC_KEY_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/xcodebuild
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KPW" "$KEYCHAIN" >/dev/null
+
+          # Add our keychain to the search list for the build, remembering the originals.
+          ORIG_KEYCHAINS=$(security list-keychains -d user | sed 's/[[:space:]"]//g')
+          security list-keychains -d user -s "$KEYCHAIN" $ORIG_KEYCHAINS
+
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | awk '/Developer ID Application/{print $2; exit}')
+          if [ -z "${IDENTITY:-}" ]; then echo "::error::No 'Developer ID Application' identity found in keychain"; exit 1; fi
+          echo "Signing Quick Look appex with identity ${IDENTITY}"
+
+          set +e
+          QUICKLOOK_SIGN_IDENTITY="$IDENTITY" \
+          QUICKLOOK_TEAM_ID="$APPLE_TEAM_ID" \
+          QUICKLOOK_KEYCHAIN="$KEYCHAIN" \
+            ./macos/scripts/build-quicklook.sh
+          rc=$?
+          set -e
+
+          # Restore the original search list so electron-builder's later signing isn't
+          # confused by two keychains holding the same identity (ambiguous match).
+          security list-keychains -d user -s $ORIG_KEYCHAINS
+          exit $rc
 
       - name: Package & Publish
         working-directory: app

--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -81,6 +81,13 @@ mac:
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
+  # The Quick Look extension is embedded by after-pack.js and PRE-SIGNED (inside-out,
+  # including its embedded CooklangParserFFI.framework, hardened runtime) by
+  # macos/scripts/build-quicklook.sh in CI. @electron/osx-sign cannot sign a nested
+  # .appex, so signIgnore tells electron-builder to leave it untouched; it still seals
+  # the outer app over the already-signed appex, and notarization covers it.
+  signIgnore:
+    - "Contents/PlugIns/CookQuickLook.appex"
   # Submit to Apple's notarytool after signing; uses APPLE_* env vars.
   notarize: true
   # Custom file types for .cook / .menu. Conformance to public.plain-text lets

--- a/macos/scripts/build-quicklook.sh
+++ b/macos/scripts/build-quicklook.sh
@@ -33,15 +33,23 @@ fi
 
 DERIVED="build/DerivedData"
 SIGN_ARGS=(CODE_SIGNING_ALLOWED=NO)
-# In CI, QUICKLOOK_SIGN_IDENTITY (a "Developer ID Application: ..." identity) is provided
-# so the appex is signed with hardened runtime + its sandbox entitlements.
+# In CI, QUICKLOOK_SIGN_IDENTITY (a "Developer ID Application" identity hash/name) is
+# provided so xcodebuild signs the appex AND its embedded CooklangParserFFI.framework
+# inside-out, with hardened runtime + a secure timestamp. electron-builder cannot sign a
+# nested .appex itself, so the appex must arrive pre-signed (then left alone via
+# `mac.signIgnore`). QUICKLOOK_KEYCHAIN, if set, points codesign at the keychain holding
+# the identity. The appex is not sandboxed, so no entitlements are applied.
 if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
+  CSFLAGS="--timestamp --options runtime"
+  if [[ -n "${QUICKLOOK_KEYCHAIN:-}" ]]; then
+    CSFLAGS="${CSFLAGS} --keychain ${QUICKLOOK_KEYCHAIN}"
+  fi
   SIGN_ARGS=(
     CODE_SIGNING_ALLOWED=YES
     CODE_SIGN_STYLE=Manual
     "CODE_SIGN_IDENTITY=${QUICKLOOK_SIGN_IDENTITY}"
     "DEVELOPMENT_TEAM=${QUICKLOOK_TEAM_ID:-}"
-    OTHER_CODE_SIGN_FLAGS=--timestamp
+    "OTHER_CODE_SIGN_FLAGS=${CSFLAGS}"
   )
 fi
 
@@ -61,3 +69,10 @@ rm -rf build/CookQuickLook.appex
 cp -R "$SRC" build/CookQuickLook.appex
 echo "Built: $(pwd)/build/CookQuickLook.appex"
 lipo -info "build/CookQuickLook.appex/Contents/MacOS/CookQuickLook" || true
+
+# When signed, fail fast if the appex (or its embedded framework) isn't validly signed —
+# electron-builder will refuse to seal the outer app over an unsigned nested component.
+if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
+  echo "Verifying appex signature (deep)..."
+  codesign --verify --deep --strict --verbose=2 "build/CookQuickLook.appex"
+fi


### PR DESCRIPTION
## Problem (alpha.17 release failed)

With the embed fix in place, alpha.17's macOS `Package & Publish` failed:
```
codesign --sign "Developer ID Application…" …/Contents/MacOS/Cook Editor
   …/Cook Editor: code object is not signed at all
   In subcomponent: …/Contents/PlugIns/CookQuickLook.appex
```
macOS signing is inside-out: electron-builder can't seal the outer app because the nested `CookQuickLook.appex` (which itself embeds `CooklangParserFFI.framework`) is **unsigned**, and `@electron/osx-sign` does not sign a nested `.appex`. (The embed itself worked — the log shows `after-pack: embedded Quick Look appex …`.)

## Fix

Pre-sign the appex inside-out in CI, then have electron-builder leave it alone:
- `release.yml`: import the Developer ID cert (`MAC_CSC_LINK`) into a keychain, run `build-quicklook.sh` with `QUICKLOOK_SIGN_IDENTITY`/`QUICKLOOK_KEYCHAIN`; restore the keychain search list afterward so electron-builder's later signing isn't ambiguous.
- `build-quicklook.sh`: sign via `xcodebuild` with hardened runtime + `--timestamp`, then `codesign --verify --deep --strict` to fail fast.
- `electron-builder.yml`: re-add `mac.signIgnore: [Contents/PlugIns/CookQuickLook.appex]` so electron-builder seals the outer app over the already-signed appex.

**No new secrets** — reuses `MAC_CSC_LINK` / `MAC_CSC_KEY_PASSWORD` / `APPLE_TEAM_ID`.

## Test Plan
- [x] YAML + `bash -n` + after-pack regression test pass locally
- [ ] alpha.18 release: macOS `Package & Publish` succeeds; CI guard confirms the appex is embedded + signed; notarization accepted; install + spacebar a `.cook` → rendered