### PR TITLE
fix(macos): suppress get-task-allow on Quick Look appex (notarization)

### DIFF
--- a/macos/scripts/build-quicklook.sh
+++ b/macos/scripts/build-quicklook.sh
@@ -49,6 +49,11 @@ if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
     CODE_SIGN_STYLE=Manual
     "CODE_SIGN_IDENTITY=${QUICKLOOK_SIGN_IDENTITY}"
     "DEVELOPMENT_TEAM=${QUICKLOOK_TEAM_ID:-}"
+    # Do NOT inject com.apple.security.get-task-allow — Xcode adds that debug
+    # entitlement by default, and notarization rejects it ("The executable
+    # requests the com.apple.security.get-task-allow entitlement"). This appex
+    # needs no entitlements (not sandboxed), so suppress the base set entirely.
+    CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
     "OTHER_CODE_SIGN_FLAGS=${CSFLAGS}"
   )
 fi
@@ -75,4 +80,11 @@ lipo -info "build/CookQuickLook.appex/Contents/MacOS/CookQuickLook" || true
 if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
   echo "Verifying appex signature (deep)..."
   codesign --verify --deep --strict --verbose=2 "build/CookQuickLook.appex"
+  # Fail fast on the debug entitlement that notarization rejects, rather than
+  # discovering it after a slow notarytool round-trip.
+  if codesign -d --entitlements :- "build/CookQuickLook.appex/Contents/MacOS/CookQuickLook" 2>/dev/null | grep -q "get-task-allow"; then
+    echo "error: appex executable still has com.apple.security.get-task-allow (would fail notarization)" >&2
+    exit 1
+  fi
+  echo "Signature OK, no get-task-allow."
 fi


### PR DESCRIPTION
## Problem (alpha.18 failed at notarization)

alpha.18 signed and sealed correctly but notarytool rejected it:
> "The executable requests the com.apple.security.get-task-allow entitlement." — on `CookQuickLook.appex/Contents/MacOS/CookQuickLook`

Xcode injects the `get-task-allow` debug entitlement by default; notarization forbids it for distribution.

## Fix
- `build-quicklook.sh`: sign with `CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO` (the appex is not sandboxed and needs no entitlements), and **fail fast** if `get-task-allow` is still present (catches it in the fast Build&sign step, not after a slow notarytool round-trip).

## Validation
Verified via a **dry-run** (`workflow_dispatch publish=false`) on this branch — run 27213024069: both macOS jobs passed `Build & sign`, `Package & Publish` (**notarization included**), and the embed guard. This is the exact gate that failed in alpha.18.

## Test Plan
- [x] Dry-run: arm64 + x64 sign + **notarize** successfully; appex embedded + signed
- [ ] alpha.19 (real release): publish, then install + spacebar a `.cook` → rendered preview