### PR TITLE
fix(macos): add required bundle keys to Quick Look appex Info.plist

### DIFF
--- a/macos/QuickLookExtension/Sources/Info.plist
+++ b/macos/QuickLookExtension/Sources/Info.plist
@@ -2,8 +2,27 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!-- Standard bundle keys are REQUIRED: without CFBundleIdentifier/CFBundleExecutable
+         PluginKit refuses to register the extension, so Quick Look never invokes it.
+         Xcode substitutes the $(...) build settings when processing this Info.plist. -->
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
     <key>CFBundleDisplayName</key>
     <string>Cook Editor Quick Look</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/macos/scripts/build-quicklook.sh
+++ b/macos/scripts/build-quicklook.sh
@@ -75,6 +75,16 @@ cp -R "$SRC" build/CookQuickLook.appex
 echo "Built: $(pwd)/build/CookQuickLook.appex"
 lipo -info "build/CookQuickLook.appex/Contents/MacOS/CookQuickLook" || true
 
+# PluginKit refuses to register an app extension that lacks these standard bundle
+# keys, so Quick Look would never invoke it. Fail the build if they're missing.
+for _k in CFBundleIdentifier CFBundleExecutable CFBundlePackageType; do
+  _v=$(/usr/libexec/PlistBuddy -c "Print :${_k}" "build/CookQuickLook.appex/Contents/Info.plist" 2>/dev/null || true)
+  if [[ -z "${_v}" ]]; then
+    echo "error: appex Info.plist is missing ${_k} — PluginKit will not register the extension" >&2
+    exit 1
+  fi
+done
+
 # When signed, fail fast if the appex (or its embedded framework) isn't validly signed —
 # electron-builder will refuse to seal the outer app over an unsigned nested component.
 if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then


### PR DESCRIPTION
## Problem (why alpha.19 still showed text)

alpha.19 shipped the appex embedded, signed, and notarized — but Quick Look still rendered `.cook` as text. Root cause: the appex's `Info.plist` was **missing `CFBundleIdentifier`, `CFBundleExecutable`, `CFBundlePackageType`**. The hand-written `Sources/Info.plist` (used verbatim via `INFOPLIST_FILE` + `GENERATE_INFOPLIST_FILE: NO`) only had `CFBundleDisplayName` + `NSExtension`. **PluginKit silently refuses to register an extension with no bundle id / no executable**, so Quick Look never invokes it.

Verified on the installed build: `PlistBuddy Print :CFBundleIdentifier` → "Does Not Exist"; the appex structurally now matches Apple's own QL extensions after the fix.

## Fix
- `Sources/Info.plist`: add the standard `CFBundle*` keys (Xcode substitutes `$(PRODUCT_BUNDLE_IDENTIFIER)` etc. at build time, as it already does for `$(PRODUCT_MODULE_NAME)`), `CFBundlePackageType=XPC!`.
- `build-quicklook.sh`: fail the build if the appex Info.plist lacks those keys (regression guard).

## Test Plan
- [x] Local build: appex Info.plist now has `CFBundleIdentifier=md.cook.editor.quicklook`, `CFBundleExecutable=CookQuickLook`, `CFBundlePackageType=XPC!`; structure matches Apple's Notes QL extension
- [ ] alpha.20 (notarized): install fresh, spacebar a `.cook` → rendered preview; `pluginkit -m -i md.cook.editor.quicklook` lists it