### PR TITLE
fix(macos): sandbox the Quick Look appex so PluginKit registers it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 .DS_Store
 node_modules
 build
+# Track only this one file under the otherwise-ignored repo-root build/ dir.
+# Anchored to root so nested build/ dirs (packages/*/build, etc.) stay ignored.
+!/build/
+/build/*
+!/build/entitlements.quicklook.plist
 lib
 tmp
 *.log

--- a/build/entitlements.quicklook.plist
+++ b/build/entitlements.quicklook.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- REQUIRED: PlugInKit silently refuses to register a non-sandboxed Quick Look
+         preview extension, so Quick Look never loads it. This entitlement is what
+         makes the extension register. The read-only file access lets the preview
+         read the file the system hands it. -->
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/macos/QuickLookExtension/Sources/Info.plist
+++ b/macos/QuickLookExtension/Sources/Info.plist
@@ -19,10 +19,13 @@
     <string>$(PRODUCT_NAME)</string>
     <key>CFBundlePackageType</key>
     <string>XPC!</string>
+    <!-- Must match the host app's version (build-quicklook.sh passes the app version
+         via MARKETING_VERSION / CURRENT_PROJECT_VERSION). A mismatched extension
+         version is a documented cause of the system rejecting the extension. -->
     <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
+    <string>$(MARKETING_VERSION)</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>NSExtension</key>
     <dict>
         <key>NSExtensionPointIdentifier</key>

--- a/macos/QuickLookExtension/Sources/RecipePreviewView.swift
+++ b/macos/QuickLookExtension/Sources/RecipePreviewView.swift
@@ -31,6 +31,11 @@ struct RecipePreviewView: View {
             .padding(24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        // Quick Look hosts the view in a translucent panel; give it an opaque
+        // document background (adapts to light/dark) so the text is readable
+        // instead of showing through to the desktop/panel behind it.
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .textBackgroundColor))
     }
 
     private var header: some View {

--- a/macos/QuickLookExtension/project.yml
+++ b/macos/QuickLookExtension/project.yml
@@ -22,6 +22,8 @@ targets:
         PRODUCT_NAME: CookQuickLook
         GENERATE_INFOPLIST_FILE: NO
         INFOPLIST_FILE: Sources/Info.plist
+        # REQUIRED for PlugInKit to register the QL preview extension (sandbox).
+        CODE_SIGN_ENTITLEMENTS: ../../build/entitlements.quicklook.plist
         ENABLE_HARDENED_RUNTIME: YES
         SWIFT_VERSION: "5.9"
     dependencies:

--- a/macos/scripts/build-quicklook.sh
+++ b/macos/scripts/build-quicklook.sh
@@ -3,7 +3,11 @@
 # Output: macos/QuickLookExtension/build/CookQuickLook.appex
 set -euo pipefail
 
-cd "$(dirname "$0")/../QuickLookExtension"
+# Resolve paths BEFORE cd-ing (so $0-relative lookups don't break afterwards).
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$SCRIPT_DIR/../QuickLookExtension"
 
 # --- Acquire xcodegen (prefer PATH; else pinned prebuilt binary; brew is unreliable on older Xcode) ---
 XCODEGEN_VERSION="2.43.0"
@@ -30,6 +34,12 @@ if [[ -z "${XCODEGEN:-}" || ! -x "$XCODEGEN" ]]; then
 fi
 
 "$XCODEGEN" generate
+
+# Match the appex version to the host app's (PlugInKit/LaunchServices reject an
+# extension whose CFBundleVersion differs from its containing app). Read it from
+# app/package.json; fall back to 1/1.0 for standalone local builds.
+APP_VERSION=$(node -p "require('$REPO_ROOT/app/package.json').version" 2>/dev/null || echo "1.0")
+VERSION_ARGS=("MARKETING_VERSION=${APP_VERSION}" "CURRENT_PROJECT_VERSION=${APP_VERSION}")
 
 DERIVED="build/DerivedData"
 SIGN_ARGS=(CODE_SIGNING_ALLOWED=NO)
@@ -65,6 +75,7 @@ xcodebuild \
   -derivedDataPath "$DERIVED" \
   -destination 'generic/platform=macOS' \
   ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
+  "${VERSION_ARGS[@]}" \
   "${SIGN_ARGS[@]}" \
   build
 
@@ -96,5 +107,11 @@ if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
     echo "error: appex executable still has com.apple.security.get-task-allow (would fail notarization)" >&2
     exit 1
   fi
-  echo "Signature OK, no get-task-allow."
+  # PlugInKit silently refuses to register a NON-sandboxed Quick Look preview extension.
+  # This is the entitlement whose absence cost alpha.16–20; fail loudly if it's gone.
+  if ! codesign -d --entitlements :- "build/CookQuickLook.appex" 2>/dev/null | grep -q "com.apple.security.app-sandbox"; then
+    echo "error: appex is not sandboxed (missing com.apple.security.app-sandbox) — PluginKit will not register it" >&2
+    exit 1
+  fi
+  echo "Signature OK: sandboxed, no get-task-allow."
 fi


### PR DESCRIPTION
## THE fix — why the preview never appeared (alpha.16–20)

**PlugInKit silently refuses to register a non-sandboxed Quick Look preview extension.** No log, no error — the extension is simply absent from `pluginkit -mAv -p com.apple.quicklook.preview`, so Quick Look falls back to plain text. We dropped `com.apple.security.app-sandbox` back when we simplified to "electron-builder signs it" (which deleted `entitlements.quicklook.plist`).

Confirmed on the user's Mac: adding the sandbox entitlement → extension registers in 1s and renders the formatted recipe. (Found via the Transmission project + Eclectic Light's PlugInKit writeups after exhausting every other hypothesis — conformance, bundle id, sealing, Info.plist keys, notarization were all ruled out.)

## Changes
- Restore `build/entitlements.quicklook.plist` (`app-sandbox` + `files.user-selected.read-only`), wired via `CODE_SIGN_ENTITLEMENTS` in `project.yml`. Build guard fails if the signed appex isn't sandboxed.
- Match the appex `CFBundleVersion`/`CFBundleShortVersionString` to the host app's (documented requirement; `build-quicklook.sh` reads `app/package.json`). Fixed a path bug where the version lookup ran after the script `cd`'d.
- Opaque document background on the SwiftUI preview (`Color(nsColor: .textBackgroundColor)`) — it was transparent over Quick Look's translucent panel and hard to read.

## Test Plan
- [x] Local signed build: appex sandboxed, version matches app, registers in 1s, renders
- [ ] alpha.21 notarized release: install via DMG, spacebar a `.cook` → readable rendered recipe