### PR TITLE
feat(macos): editor-style Quick Look preview

### DIFF
--- a/macos/QuickLookExtension/Sources/PreviewViewController.swift
+++ b/macos/QuickLookExtension/Sources/PreviewViewController.swift
@@ -19,7 +19,8 @@ final class PreviewViewController: NSViewController, QLPreviewingController {
                 source: source,
                 fallbackTitle: url.deletingPathExtension().lastPathComponent
             )
-            host = NSHostingView(rootView: RecipePreviewView(model: model))
+            let isMenu = url.pathExtension.lowercased() == "menu"
+            host = NSHostingView(rootView: RecipePreviewView(model: model, isMenu: isMenu))
         }
         embed(host)
     }

--- a/macos/QuickLookExtension/Sources/RecipePreviewModel.swift
+++ b/macos/QuickLookExtension/Sources/RecipePreviewModel.swift
@@ -1,16 +1,30 @@
 import Foundation
 import CooklangParser
 
+/// One inline run of rendered step text.
 enum StepSegment: Equatable {
     case text(String)
     case ingredient(String)
     case cookware(String)
     case timer(String)
+    case recipeRef(String)
+}
+
+/// An ingredient referenced by a single step (for the per-step summary line).
+struct StepIngredient: Equatable {
+    let name: String
+    let amount: String?
 }
 
 enum StepModel: Equatable {
-    case step([StepSegment])
+    case step(segments: [StepSegment], ingredients: [StepIngredient])
     case note(String)
+}
+
+/// A "label: value" metadata pill (servings, time, and any custom keys).
+struct MetadataPill: Equatable {
+    let label: String
+    let value: String
 }
 
 struct IngredientLine: Equatable {
@@ -27,8 +41,7 @@ struct SectionModel: Equatable {
 struct RecipePreviewModel: Equatable {
     let title: String
     let description: String?
-    let servings: String?
-    let time: String?
+    let metadata: [MetadataPill]
     let tags: [String]
     let ingredients: [IngredientLine]
     let cookware: [String]
@@ -55,18 +68,32 @@ struct RecipePreviewModel: Equatable {
                 steps: section.blocks.map { block in
                     switch block {
                     case .stepBlock(let step):
-                        return .step(step.items.map { item in
+                        var segments: [StepSegment] = []
+                        var stepIngredients: [StepIngredient] = []
+                        for item in step.items {
                             switch item {
                             case .text(let value):
-                                return .text(value)
+                                segments.append(.text(value))
                             case .ingredientRef(let index):
-                                return .ingredient(name(at: index, in: ingredients) ?? "")
+                                if let ing = element(at: index, in: ingredients) {
+                                    if ing.reference != nil {
+                                        // A recipe reference (@./other{}) — link, not a quantified ingredient.
+                                        segments.append(.recipeRef(ing.name))
+                                    } else {
+                                        segments.append(.ingredient(ing.name))
+                                        stepIngredients.append(StepIngredient(
+                                            name: ing.name,
+                                            amount: ing.amount.flatMap(Formatting.amount)
+                                        ))
+                                    }
+                                }
                             case .cookwareRef(let index):
-                                return .cookware(cookwareName(at: index, in: cookware) ?? "")
+                                segments.append(.cookware(element(at: index, in: cookware)?.name ?? ""))
                             case .timerRef(let index):
-                                return .timer(timerLabel(at: index, in: timers) ?? "")
+                                segments.append(.timer(timerLabel(at: index, in: timers) ?? ""))
                             }
-                        })
+                        }
+                        return .step(segments: segments, ingredients: stepIngredients)
                     case .noteBlock(let note):
                         return .note(note.text)
                     }
@@ -77,8 +104,7 @@ struct RecipePreviewModel: Equatable {
         return RecipePreviewModel(
             title: metadataTitle(recipe: recipe) ?? fallbackTitle,
             description: metadataDescription(recipe: recipe),
-            servings: metadataServings(recipe: recipe).map(Formatting.servings),
-            time: metadataTime(recipe: recipe).map(Formatting.time),
+            metadata: metadataPills(recipe: recipe),
             tags: metadataTags(recipe: recipe) ?? [],
             ingredients: ingredientLines,
             cookware: cookware.map { $0.name },
@@ -86,13 +112,30 @@ struct RecipePreviewModel: Equatable {
         )
     }
 
-    private static func name(at index: UInt32, in list: [Ingredient]) -> String? {
-        let i = Int(index)
-        return list.indices.contains(i) ? list[i].name : nil
+    /// Servings + time + any custom metadata keys, as "label: value" pills (matches the editor).
+    private static func metadataPills(recipe: CooklangRecipe) -> [MetadataPill] {
+        var pills: [MetadataPill] = []
+        if let servings = metadataServings(recipe: recipe) {
+            pills.append(MetadataPill(label: "Servings", value: Formatting.servings(servings)))
+        }
+        if let time = metadataTime(recipe: recipe) {
+            pills.append(MetadataPill(label: "Time", value: Formatting.time(time)))
+        }
+        for key in metadataCustomKeys(recipe: recipe) {
+            if let value = metadataGet(recipe: recipe, key: key), !value.isEmpty {
+                pills.append(MetadataPill(label: key, value: value))
+            }
+        }
+        return pills
     }
-    private static func cookwareName(at index: UInt32, in list: [Cookware]) -> String? {
+
+    private static func element(at index: UInt32, in list: [Ingredient]) -> Ingredient? {
         let i = Int(index)
-        return list.indices.contains(i) ? list[i].name : nil
+        return list.indices.contains(i) ? list[i] : nil
+    }
+    private static func element(at index: UInt32, in list: [Cookware]) -> Cookware? {
+        let i = Int(index)
+        return list.indices.contains(i) ? list[i] : nil
     }
     private static func timerLabel(at index: UInt32, in list: [CooklangParser.Timer]) -> String? {
         let i = Int(index)

--- a/macos/QuickLookExtension/Sources/RecipePreviewView.swift
+++ b/macos/QuickLookExtension/Sources/RecipePreviewView.swift
@@ -1,124 +1,342 @@
 import SwiftUI
 
+// MARK: - Palette (mirrors the editor's recipe-preview.css)
+
+private extension Color {
+    /// Cook Editor brand orange — the `badge.background` (#e15a29) used for step
+    /// numbers, tags, and menu day-headers.
+    static let cookBrand = Color(red: 0xE1 / 255, green: 0x5A / 255, blue: 0x29 / 255)
+    /// Subtle inline-code style fill for ingredient/cookware tags.
+    static let cookChipFill = Color.primary.opacity(0.06)
+    static let cookChipStroke = Color.primary.opacity(0.18)
+}
+
+private extension NSColor {
+    static let cookBrand = NSColor(srgbRed: 0xE1 / 255, green: 0x5A / 255, blue: 0x29 / 255, alpha: 1)
+    static let cookTagFill = NSColor(white: 0.5, alpha: 0.16)
+    static let cookTimerFill = NSColor(srgbRed: 0xE1 / 255, green: 0x5A / 255, blue: 0x29 / 255, alpha: 0.16)
+}
+
 struct RecipePreviewView: View {
     let model: RecipePreviewModel
+    var isMenu: Bool = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 header
-                if !metadataChips.isEmpty {
-                    chips(metadataChips)
+                if !model.tags.isEmpty {
+                    WrapHStack(model.tags.map { AnyView(tagPill($0)) })
                 }
                 if let description = model.description, !description.isEmpty {
-                    Text(description).font(.body).foregroundStyle(.secondary)
+                    blockquote(description)
                 }
-                if !model.ingredients.isEmpty {
-                    section("Ingredients") {
-                        ForEach(Array(model.ingredients.enumerated()), id: \.offset) { _, line in
-                            ingredientRow(line)
-                        }
-                    }
+                if !model.metadata.isEmpty {
+                    WrapHStack(model.metadata.map { AnyView(metadataPill($0)) })
                 }
-                if !model.cookware.isEmpty {
-                    section("Cookware") {
-                        Text(model.cookware.joined(separator: ", "))
-                            .font(.body).foregroundStyle(.secondary)
-                    }
+                if isMenu {
+                    menuBody
+                } else {
+                    recipeBody
                 }
-                stepsView
             }
-            .padding(24)
+            .padding(.horizontal, 32)
+            .padding(.vertical, 24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
-        // Quick Look hosts the view in a translucent panel; give it an opaque
-        // document background (adapts to light/dark) so the text is readable
-        // instead of showing through to the desktop/panel behind it.
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color(nsColor: .textBackgroundColor))
     }
 
+    // MARK: Header
+
     private var header: some View {
-        Text(model.title).font(.largeTitle.bold())
+        VStack(alignment: .leading, spacing: 8) {
+            Text(model.title).font(.system(size: 30, weight: .semibold))
+            Divider()
+        }
     }
 
-    private var metadataChips: [String] {
-        var chips: [String] = []
-        if let s = model.servings { chips.append("Serves \(s)") }
-        if let t = model.time { chips.append(t) }
-        chips.append(contentsOf: model.tags.map { "#\($0)" })
-        return chips
-    }
+    // MARK: Recipe layout (two columns: ingredients | instructions)
 
-    private func chips(_ values: [String]) -> some View {
-        HStack(spacing: 8) {
-            ForEach(Array(values.enumerated()), id: \.offset) { _, value in
-                Text(value)
-                    .font(.caption).padding(.horizontal, 10).padding(.vertical, 4)
-                    .background(Color.accentColor.opacity(0.15))
-                    .clipShape(Capsule())
+    private var recipeBody: some View {
+        HStack(alignment: .top, spacing: 24) {
+            VStack(alignment: .leading, spacing: 0) {
+                sidebarTitle("Ingredients")
+                ForEach(Array(model.ingredients.enumerated()), id: \.offset) { _, line in
+                    ingredientRow(line)
+                }
+                if !model.cookware.isEmpty {
+                    sidebarTitle("Cookware")
+                        .padding(.top, 16)
+                    ForEach(Array(model.cookware.enumerated()), id: \.offset) { _, name in
+                        Text(name).fontWeight(.medium).padding(.vertical, 4)
+                    }
+                }
             }
+            .frame(width: 220, alignment: .leading)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 0) {
+                sidebarTitle("Instructions")
+                    .padding(.bottom, 8)
+                stepsView(model.sections)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
     private func ingredientRow(_ line: IngredientLine) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            Image(systemName: line.isRecipeReference ? "arrow.right.circle" : "circle.fill")
-                .font(.system(size: line.isRecipeReference ? 11 : 5))
-                .foregroundStyle(line.isRecipeReference ? Color.accentColor : .secondary)
-            Text(line.name).fontWeight(line.isRecipeReference ? .semibold : .regular)
+            if line.isRecipeReference {
+                Image(systemName: "arrow.right.circle").font(.system(size: 11)).foregroundColor(.cookBrand)
+            }
+            Text(line.name)
+                .foregroundColor(line.isRecipeReference ? .cookBrand : .primary)
+                .fontWeight(line.isRecipeReference ? .semibold : .regular)
             if let amount = line.amount {
                 Spacer(minLength: 8)
-                Text(amount).foregroundStyle(.secondary)
+                Text(amount).foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    @ViewBuilder
+    private func stepsView(_ sections: [SectionModel]) -> some View {
+        ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
+            if let title = section.title, !title.isEmpty {
+                Text(title).font(.system(size: 17, weight: .semibold))
+                    .padding(.top, 16).padding(.bottom, 4)
+            }
+            ForEach(Array(numberedSteps(section.steps).enumerated()), id: \.offset) { _, entry in
+                stepRow(number: entry.number, step: entry.step)
             }
         }
     }
 
     @ViewBuilder
-    private var stepsView: some View {
-        ForEach(Array(model.sections.enumerated()), id: \.offset) { _, section in
-            VStack(alignment: .leading, spacing: 10) {
-                if let title = section.title, !title.isEmpty {
-                    Text(title).font(.title3.bold())
-                }
-                ForEach(Array(section.steps.enumerated()), id: \.offset) { index, step in
-                    stepRow(index: index, step: step)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func stepRow(index: Int, step: StepModel) -> some View {
+    private func stepRow(number: Int?, step: StepModel) -> some View {
         switch step {
         case .note(let text):
-            Text(text).italic().foregroundStyle(.secondary)
-                .padding(.leading, 8).overlay(alignment: .leading) {
-                    Rectangle().frame(width: 3).foregroundStyle(Color.accentColor.opacity(0.4))
+            blockquote(text)
+                .padding(.vertical, 4)
+        case .step(let segments, let ingredients):
+            HStack(alignment: .top, spacing: 12) {
+                stepBadge(number ?? 0)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(stepAttributed(segments)).lineSpacing(4)
+                    if !ingredients.isEmpty {
+                        stepIngredientsSummary(ingredients)
+                    }
                 }
-        case .step(let segments):
-            HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text("\(index + 1).").font(.body.monospacedDigit()).foregroundStyle(.secondary)
-                stepText(segments)
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    private func stepBadge(_ n: Int) -> some View {
+        Text("\(n)")
+            .font(.system(size: 12, weight: .bold))
+            .foregroundColor(.white)
+            .frame(width: 24, height: 24)
+            .background(RoundedRectangle(cornerRadius: 3).fill(Color.cookBrand))
+    }
+
+    private func stepIngredientsSummary(_ ingredients: [StepIngredient]) -> some View {
+        let parts = ingredients.map { ing -> String in
+            if let a = ing.amount { return "\(ing.name): \(a)" }
+            return ing.name
+        }
+        return Text(parts.joined(separator: " · "))
+            .font(.system(size: 11))
+            .foregroundColor(.secondary)
+            .padding(.leading, 10)
+            .overlay(alignment: .leading) {
+                Rectangle().frame(width: 2).foregroundColor(.primary.opacity(0.2))
+            }
+    }
+
+    // MARK: Menu layout (day cards)
+
+    @ViewBuilder
+    private var menuBody: some View {
+        ForEach(Array(model.sections.enumerated()), id: \.offset) { _, section in
+            VStack(alignment: .leading, spacing: 0) {
+                Text(section.title?.isEmpty == false ? section.title! : "Menu")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16).padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.cookBrand)
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(Array(section.steps.enumerated()), id: \.offset) { _, step in
+                        menuLine(step)
+                    }
+                }
+                .padding(16)
+            }
+            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.primary.opacity(0.15)))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+    }
+
+    @ViewBuilder
+    private func menuLine(_ step: StepModel) -> some View {
+        switch step {
+        case .note(let text):
+            blockquote(text)
+        case .step(let segments, _):
+            // A lone "Breakfast:" text line is a meal header.
+            if segments.count == 1, case .text(let t) = segments[0], t.trimmingCharacters(in: .whitespaces).hasSuffix(":") {
+                Text(t.trimmingCharacters(in: .whitespaces))
+                    .font(.system(size: 14, weight: .semibold))
+                    .padding(.top, 4)
+            } else {
+                Text(stepAttributed(segments)).lineSpacing(3)
             }
         }
     }
 
-    private func stepText(_ segments: [StepSegment]) -> Text {
-        segments.reduce(Text("")) { acc, segment in
+    // MARK: Shared pieces
+
+    private func sidebarTitle(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(.system(size: 11, weight: .semibold))
+            .tracking(0.6)
+            .foregroundColor(.secondary)
+            .padding(.bottom, 8)
+    }
+
+    private func tagPill(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(.white)
+            .padding(.horizontal, 8).padding(.vertical, 1)
+            .background(RoundedRectangle(cornerRadius: 3).fill(Color.cookBrand))
+    }
+
+    private func metadataPill(_ pill: MetadataPill) -> some View {
+        HStack(spacing: 4) {
+            Text("\(pill.label):").fontWeight(.semibold)
+            Text(pill.value)
+        }
+        .font(.system(size: 12))
+        .padding(.horizontal, 10).padding(.vertical, 2)
+        .background(RoundedRectangle(cornerRadius: 3).fill(Color.cookChipFill))
+        .overlay(RoundedRectangle(cornerRadius: 3).stroke(Color.cookChipStroke))
+    }
+
+    private func blockquote(_ text: String) -> some View {
+        Text(text)
+            .italic()
+            .foregroundColor(.primary)
+            .padding(.leading, 12).padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .overlay(alignment: .leading) {
+                Rectangle().frame(width: 3).foregroundColor(.cookBrand.opacity(0.6))
+            }
+    }
+
+    /// Inline step text with ingredient/cookware/timer/recipe-ref runs highlighted
+    /// (AttributedString background runs, the closest wrapping-inline analogue of the
+    /// editor's bordered chips).
+    private func stepAttributed(_ segments: [StepSegment]) -> AttributedString {
+        var result = AttributedString()
+        for segment in segments {
             switch segment {
-            case .text(let s): return acc + Text(s)
-            case .ingredient(let s): return acc + Text(s).foregroundColor(.accentColor).bold()
-            case .cookware(let s): return acc + Text(s).bold()
-            case .timer(let s): return acc + Text(s).foregroundColor(.orange).bold()
+            case .text(let s):
+                result += AttributedString(s)
+            case .ingredient(let s):
+                result += chip(s, fill: .cookTagFill)
+            case .cookware(let s):
+                var a = chip(s, fill: .cookTagFill)
+                a.font = .system(size: NSFont.systemFontSize).italic()
+                result += a
+            case .timer(let s):
+                var a = chip(s, fill: .cookTimerFill)
+                a.foregroundColor = .cookBrand
+                a.font = .system(size: NSFont.systemFontSize, weight: .semibold)
+                result += a
+            case .recipeRef(let s):
+                var a = AttributedString(s)
+                a.foregroundColor = .cookBrand
+                a.font = .system(size: NSFont.systemFontSize, weight: .semibold)
+                result += a
             }
         }
+        return result
     }
 
-    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title).font(.title3.bold())
-            content()
+    private func chip(_ s: String, fill: NSColor) -> AttributedString {
+        var a = AttributedString("\u{2009}\(s)\u{2009}") // thin spaces give the highlight a little padding
+        a.backgroundColor = fill
+        return a
+    }
+
+    /// Number steps within a section (notes don't consume a number).
+    private func numberedSteps(_ steps: [StepModel]) -> [(number: Int?, step: StepModel)] {
+        var n = 0
+        return steps.map { step in
+            if case .step = step { n += 1; return (n, step) }
+            return (nil, step)
+        }
+    }
+}
+
+// MARK: - Wrapping horizontal stack (macOS 12 has no Layout/Grid flow)
+
+/// Lays the given views left-to-right, wrapping to new rows by available width.
+struct WrapHStack: View {
+    let views: [AnyView]
+    var hSpacing: CGFloat = 8
+    var vSpacing: CGFloat = 8
+
+    @State private var totalHeight: CGFloat = .zero
+
+    init(_ views: [AnyView], hSpacing: CGFloat = 8, vSpacing: CGFloat = 8) {
+        self.views = views
+        self.hSpacing = hSpacing
+        self.vSpacing = vSpacing
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            content(in: geo)
+        }
+        .frame(height: totalHeight)
+    }
+
+    private func content(in geo: GeometryProxy) -> some View {
+        var x = CGFloat.zero
+        var y = CGFloat.zero
+        return ZStack(alignment: .topLeading) {
+            ForEach(views.indices, id: \.self) { i in
+                views[i]
+                    .alignmentGuide(.leading) { d in
+                        if abs(x - d.width) > geo.size.width {
+                            x = 0
+                            y -= d.height + vSpacing
+                        }
+                        let result = x
+                        if i == views.count - 1 { x = 0 } else { x -= d.width + hSpacing }
+                        return result
+                    }
+                    .alignmentGuide(.top) { _ in
+                        let result = y
+                        if i == views.count - 1 { y = 0 }
+                        return result
+                    }
+            }
+        }
+        .background(heightReader($totalHeight))
+    }
+
+    private func heightReader(_ binding: Binding<CGFloat>) -> some View {
+        GeometryReader { geo -> Color in
+            DispatchQueue.main.async { binding.wrappedValue = geo.size.height }
+            return Color.clear
         }
     }
 }

--- a/macos/QuickLookExtension/Tests/RecipePreviewModelTests.swift
+++ b/macos/QuickLookExtension/Tests/RecipePreviewModelTests.swift
@@ -11,19 +11,21 @@ final class RecipePreviewModelTests: XCTestCase {
         let source = try loadFixture("simple.cook")
         let model = RecipePreviewModel.from(source: source, fallbackTitle: "simple")
         XCTAssertEqual(model.title, "Pancakes")
-        XCTAssertEqual(model.servings, "4")
+        XCTAssertTrue(model.metadata.contains { $0.label == "Servings" && $0.value == "4" })
         XCTAssertTrue(model.tags.contains("breakfast"))
         XCTAssertTrue(model.ingredients.contains { $0.name == "flour" && $0.amount == "200 g" })
         XCTAssertTrue(model.cookware.contains("bowl"))
     }
 
-    func testStepsResolveIngredientSegments() throws {
+    func testStepsResolveIngredientSegmentsAndSummary() throws {
         let source = try loadFixture("simple.cook")
         let model = RecipePreviewModel.from(source: source, fallbackTitle: "simple")
         let firstStep = model.sections.first!.steps.first!
-        guard case .step(let segments) = firstStep else { return XCTFail("expected a step") }
+        guard case .step(let segments, let ingredients) = firstStep else { return XCTFail("expected a step") }
         XCTAssertTrue(segments.contains(.ingredient("flour")))
         XCTAssertTrue(segments.contains(.cookware("bowl")))
+        // The per-step ingredient summary carries the resolved amount.
+        XCTAssertTrue(ingredients.contains { $0.name == "flour" && $0.amount == "200 g" })
     }
 
     func testMenuReferenceFlagged() throws {


### PR DESCRIPTION
## Summary
Rebuilds the Quick Look preview to match the editor's recipe/menu rendering (mirrors `recipe-preview.css` / `menu-preview.css`):
- Two-column **Ingredients | Instructions** layout
- **Metadata pills** (Servings + custom keys like calories/protein)
- Orange (#e15a29) **step-number badges** + section headers
- Inline highlighted **ingredient / cookware / timer / recipe-ref** runs in step text
- **Per-step ingredient summary** lines; **Cookware** section
- `.menu` files → **day cards** with orange headers, meal subheaders, recipe-ref links
- Tags as orange pills; description/notes as orange-bordered blockquotes

Model gains metadata pills, per-step ingredients, and a `.recipeRef` segment. Tests updated (10/10 pass).

Note: inline tags use background highlights rather than bordered boxes (no inline flow layout on the macOS 12 target); can switch to bordered chips if we bump to macOS 13.

## Test Plan
- [x] Unit tests 10/10
- [x] Built signed + installed locally; recipe + menu render confirmed by user
- [ ] alpha.21 release