### PR TITLE
feat(branding): default VSX registry to plugins.cook.md

### DIFF
--- a/packages/cooklang-branding/src/electron-main/cooklang-branding-electron-main-module.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-branding-electron-main-module.ts
@@ -16,6 +16,11 @@ import { ElectronMainApplication, ElectronMainApplicationContribution } from '@t
 import { CooklangElectronMainApplication } from './cooklang-electron-main-application';
 import { CooklangBrandingElectronMainContribution } from './cooklang-branding-electron-main-contribution';
 
+// Cook Editor installs plugins from the self-hosted marketplace. The backend
+// process inherits this env var (read by @theia/vsx-registry's VSXEnvironment);
+// an explicitly set VSX_REGISTRY_URL still wins for dev overrides.
+process.env.VSX_REGISTRY_URL ??= 'https://plugins.cook.md';
+
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(CooklangElectronMainApplication).toSelf().inSingletonScope();
     rebind(ElectronMainApplication).toService(CooklangElectronMainApplication);


### PR DESCRIPTION
## Summary

- Sets `VSX_REGISTRY_URL` (only if unset) in the cooklang-branding electron-main module, so the backend's `@theia/vsx-registry` talks to the self-hosted marketplace at https://plugins.cook.md instead of open-vsx.org
- Explicit env var still wins — dev overrides unaffected
- Follows the established pattern of customizing via `cooklang-branding` rather than patching upstream files

## Test plan

- [x] `npx lerna run compile --scope @theia/cooklang-branding`
- [x] Rebuilt app bundle; Extensions view search served by plugins.cook.md (backend log shows the registry URL, no open-vsx.org calls)
- [x] Installed `cooklang.meal-journal@0.1.0` from the marketplace in-app; plugin activates (status bar button appears)