### PR TITLE
feat(cooklang): Render Report command — Jinja2 reports for recipes

### DIFF
--- a/docs/superpowers/plans/2026-06-10-cooklang-report-rendering.md
+++ b/docs/superpowers/plans/2026-06-10-cooklang-report-rendering.md
@@ -1,0 +1,987 @@
+# Cooklang Report Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A "Cooklang: Render Report…" command that applies a Jinja2 report template (cookcli-compatible, via the `cooklang-reports` crate) to the open `.cook` recipe and shows the rendered markdown in a new main-area tab.
+
+**Architecture:** Rendering happens in Rust (`cooklang-reports` 0.5.0, minijinja) exposed through a new `renderReport` NAPI function in `packages/cooklang-native`, surfaced over the existing `CooklangLanguageService` RPC. The frontend adds a command contribution (QuickPick of workspace + built-in templates) and a per-(recipe, template) `ReportWidget` that renders output with Theia's `MarkdownRenderer` and live-refreshes on document change.
+
+**Tech Stack:** Rust + NAPI-RS, Theia RPC (`ServiceConnectionProvider`), React `ReactWidget`, `@theia/core` `Markdown` component, mocha/chai specs, cargo tests.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-cooklang-report-design.md`
+
+**Reference repos (read-only):**
+- `/Users/alexeydubovskoy/Cooklang/cooklang-reports` — local checkout of the crate (v0.5.0, same as crates.io)
+- `/Users/alexeydubovskoy/Cooklang/CookCLI/src/report.rs` — cookcli's report command
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/cooklang-native/Cargo.toml` | Modify | add `cooklang-reports = "0.5"` |
+| `packages/cooklang-native/src/lib.rs` | Modify | new `render_report` NAPI fn + cargo tests |
+| `packages/cooklang/src/common/cooklang-language-service.ts` | Modify | RPC interface: `renderReport` |
+| `packages/cooklang/src/common/report-templates.ts` | Create | built-in templates + filename helpers (monaco-free) |
+| `packages/cooklang/src/common/report-templates.spec.ts` | Create | unit tests for helpers |
+| `packages/cooklang/src/common/index.ts` | Modify | re-export report-templates |
+| `packages/cooklang/src/node/cooklang-language-service-impl.ts` | Modify | backend impl: URI→fsPath conversion + native call |
+| `packages/cooklang/src/node/cooklang-language-service-impl.spec.ts` | Create | tests for URI→fsPath config conversion |
+| `packages/cooklang/src/browser/report-widget.tsx` | Create | per-(recipe, template) rendered-markdown tab |
+| `packages/cooklang/src/browser/report-contribution.ts` | Create | command, QuickPick, menus |
+| `packages/cooklang/src/browser/style/report.css` | Create | widget styling |
+| `packages/cooklang/src/browser/cooklang-frontend-module.ts` | Modify | DI bindings |
+
+Every new TS file starts with the same 12-line license header used by every existing file in `packages/cooklang/src/` (copy it verbatim from `packages/cooklang/src/common/cooklang-language-service.ts:1-12`).
+
+---
+
+### Task 1: Rust — `render_report` in cooklang-native
+
+**Files:**
+- Modify: `packages/cooklang-native/Cargo.toml`
+- Modify: `packages/cooklang-native/src/lib.rs` (append at end of file)
+
+- [ ] **Step 1: Add the dependency**
+
+In `packages/cooklang-native/Cargo.toml`, after the `cooklang-find = "0.5.8"` line, add:
+
+```toml
+cooklang-reports = "0.5"
+```
+
+(crates.io has 0.5.0; it depends on `cooklang 0.18` which unifies with our `0.18.5`.)
+
+- [ ] **Step 2: Write the failing cargo tests**
+
+Append at the very end of `packages/cooklang-native/src/lib.rs`:
+
+```rust
+#[cfg(test)]
+mod render_report_tests {
+    #[test]
+    fn renders_ingredients_template() {
+        let recipe = "Mix @eggs{3} with @flour{125%g}.";
+        let template = "{% for i in ingredients %}{{ i.name }};{% endfor %}";
+        let result = super::render_report(recipe.into(), template.into(), "{}".into());
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let output = v["output"].as_str().expect("expected output, not error");
+        assert!(output.contains("eggs;"), "output was: {output}");
+        assert!(output.contains("flour;"), "output was: {output}");
+    }
+
+    #[test]
+    fn applies_scale_from_config() {
+        let recipe = "Mix @eggs{2}.";
+        let template = "{{ scale }}";
+        let result = super::render_report(recipe.into(), template.into(), r#"{"scale": 2}"#.into());
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["output"].as_str().unwrap(), "2.0");
+    }
+
+    #[test]
+    fn returns_error_for_bad_template() {
+        let result = super::render_report("Mix @eggs{1}.".into(), "{% for %}".into(), "{}".into());
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(!v["error"].as_str().unwrap().is_empty());
+    }
+}
+```
+
+Note for the `applies_scale_from_config` assertion: minijinja renders the f64 `2.0` as `2.0`. If the test fails with output `2`, relax the assertion to `assert!(["2", "2.0"].contains(&v["output"].as_str().unwrap()))` — the point is that the config was parsed, not the float formatting.
+
+- [ ] **Step 3: Run tests to verify they fail to compile**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor/packages/cooklang-native && cargo test render_report`
+Expected: compile error — `render_report` not found.
+
+- [ ] **Step 4: Implement `render_report`**
+
+In `packages/cooklang-native/src/lib.rs`, immediately above the test module you just added, append:
+
+```rust
+/// Configuration accepted by `render_report`, mirroring cooklang_reports::Config.
+/// All path fields are OS filesystem paths (the Theia backend converts URIs
+/// before calling into the addon).
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+struct ReportConfig {
+    scale: Option<f64>,
+    base_path: Option<String>,
+    aisle_path: Option<String>,
+    pantry_path: Option<String>,
+    datastore_path: Option<String>,
+}
+
+/// Render a Jinja2 report template against a recipe via cooklang-reports
+/// (the same engine cookcli's `cook report` uses).
+///
+/// Returns JSON: `{"output": "..."}` on success or `{"error": "..."}` on failure.
+#[napi]
+pub fn render_report(recipe: String, template: String, config_json: String) -> String {
+    let cfg: ReportConfig = serde_json::from_str(&config_json).unwrap_or_default();
+    let mut builder = cooklang_reports::config::Config::builder();
+    builder.scale(cfg.scale.unwrap_or(1.0));
+    if let Some(p) = cfg.base_path {
+        builder.base_path(p);
+    }
+    if let Some(p) = cfg.aisle_path {
+        builder.aisle_path(p);
+    }
+    if let Some(p) = cfg.pantry_path {
+        builder.pantry_path(p);
+    }
+    if let Some(p) = cfg.datastore_path {
+        builder.datastore_path(p);
+    }
+    let config = builder.build();
+    match cooklang_reports::render_template_with_config(&recipe, &template, &config) {
+        Ok(output) => serde_json::json!({ "output": output }).to_string(),
+        Err(err) => serde_json::json!({ "error": err.to_string() }).to_string(),
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor/packages/cooklang-native && cargo test render_report`
+Expected: `test result: ok. 3 passed`
+
+- [ ] **Step 6: Rebuild the Node addon (regenerates index.d.ts / index.js)**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor/packages/cooklang-native && npm run build`
+Expected: success; `grep renderReport index.d.ts` shows
+`export declare function renderReport(recipe: string, template: string, configJson: string): string`
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor
+git add packages/cooklang-native/Cargo.toml packages/cooklang-native/Cargo.lock packages/cooklang-native/src/lib.rs packages/cooklang-native/index.d.ts packages/cooklang-native/index.js
+git commit -m "feat(cooklang-native): add renderReport via cooklang-reports crate"
+```
+
+---
+
+### Task 2: Backend RPC — `renderReport` on CooklangLanguageService
+
+**Files:**
+- Modify: `packages/cooklang/src/common/cooklang-language-service.ts:67` (after `findRecipe`)
+- Modify: `packages/cooklang/src/node/cooklang-language-service-impl.ts` (after `findRecipe`, line ~275)
+- Create: `packages/cooklang/src/node/cooklang-language-service-impl.spec.ts`
+
+- [ ] **Step 1: Extend the common interface**
+
+In `packages/cooklang/src/common/cooklang-language-service.ts`, inside `interface CooklangLanguageService`, after the `findRecipe` method, add:
+
+```ts
+    /**
+     * Render a Jinja2 report template against a recipe (cookcli-compatible,
+     * via the cooklang-reports crate).
+     *
+     * `configJson` is a JSON object with optional `scale` (number) and
+     * optional `basePath`, `aislePath`, `pantryPath`, `datastorePath` given
+     * as **URI strings** — the backend converts them to filesystem paths.
+     *
+     * Returns JSON: `{"output": "..."}` on success or `{"error": "..."}`.
+     */
+    renderReport(recipeContent: string, templateContent: string, configJson: string): Promise<string>;
+```
+
+- [ ] **Step 2: Write the failing backend spec**
+
+Create `packages/cooklang/src/node/cooklang-language-service-impl.spec.ts` (license header first, then):
+
+```ts
+import { expect } from 'chai';
+import { CooklangLanguageServiceImpl } from './cooklang-language-service-impl';
+
+describe('CooklangLanguageServiceImpl report config conversion', () => {
+
+    it('converts URI entries to filesystem paths', () => {
+        const impl = new CooklangLanguageServiceImpl();
+        const result = impl['convertReportConfigPaths'](JSON.stringify({
+            scale: 1,
+            basePath: 'file:///tmp/workspace',
+            aislePath: 'file:///tmp/workspace/config/aisle.conf'
+        }));
+        const config = JSON.parse(result);
+        expect(config.scale).to.equal(1);
+        expect(config.basePath).to.equal('/tmp/workspace');
+        expect(config.aislePath).to.equal('/tmp/workspace/config/aisle.conf');
+    });
+
+    it('leaves absent path entries absent', () => {
+        const impl = new CooklangLanguageServiceImpl();
+        const config = JSON.parse(impl['convertReportConfigPaths']('{"scale":2}'));
+        expect(config).to.deep.equal({ scale: 2 });
+    });
+});
+```
+
+(`impl['convertReportConfigPaths']` is the standard bracket-access trick for testing a protected method; the constructor is safe to call directly — DI `@postConstruct` does not run outside a container.)
+
+- [ ] **Step 3: Compile and run the spec to verify it fails**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang`
+Expected: TS error — `convertReportConfigPaths` / `renderReport` missing on the impl (interface not satisfied).
+
+- [ ] **Step 4: Implement in the backend service**
+
+In `packages/cooklang/src/node/cooklang-language-service-impl.ts`:
+
+Add the import at the top, next to the other `@theia/core` imports:
+
+```ts
+import { FileUri } from '@theia/core/lib/common/file-uri';
+```
+
+After the `findRecipe` method, add:
+
+```ts
+    async renderReport(recipeContent: string, templateContent: string, configJson: string): Promise<string> {
+        try {
+            const native = require('@theia/cooklang-native');
+            return native.renderReport(recipeContent, templateContent, this.convertReportConfigPaths(configJson));
+        } catch (error) {
+            console.error('[cooklang] Failed to render report:', error);
+            return JSON.stringify({ error: String(error) });
+        }
+    }
+
+    /**
+     * The frontend sends path-like config entries as URI strings (URIs cross
+     * the wire, never raw paths); the native addon needs OS filesystem paths.
+     */
+    protected convertReportConfigPaths(configJson: string): string {
+        const config = JSON.parse(configJson) as Record<string, unknown>;
+        for (const key of ['basePath', 'aislePath', 'pantryPath', 'datastorePath']) {
+            const value = config[key];
+            if (typeof value === 'string') {
+                config[key] = FileUri.fsPath(value);
+            }
+        }
+        return JSON.stringify(config);
+    }
+```
+
+- [ ] **Step 5: Compile and run tests to verify they pass**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang && npx lerna run test --scope @theia/cooklang`
+Expected: compile OK; the two new specs pass (existing `shopping-list-service.spec.ts` still passes).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cooklang/src/common/cooklang-language-service.ts packages/cooklang/src/node/cooklang-language-service-impl.ts packages/cooklang/src/node/cooklang-language-service-impl.spec.ts
+git commit -m "feat(cooklang): add renderReport RPC to CooklangLanguageService"
+```
+
+---
+
+### Task 3: Built-in templates + filename helpers (common, monaco-free)
+
+**Files:**
+- Create: `packages/cooklang/src/common/report-templates.ts`
+- Create: `packages/cooklang/src/common/report-templates.spec.ts`
+- Modify: `packages/cooklang/src/common/index.ts`
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `packages/cooklang/src/common/report-templates.spec.ts` (license header, then):
+
+```ts
+import { expect } from 'chai';
+import { ReportTemplates } from './report-templates';
+
+describe('ReportTemplates', () => {
+
+    it('recognizes template files by extension, case-insensitively', () => {
+        expect(ReportTemplates.isTemplateFile('cost.jinja')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.md.jinja')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.J2')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.jinja2')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.txt')).to.equal(false);
+        expect(ReportTemplates.isTemplateFile('recipe.cook')).to.equal(false);
+    });
+
+    it('resolves built-in templates by id', () => {
+        for (const template of ReportTemplates.BUILT_IN) {
+            expect(ReportTemplates.byId(template.id)).to.equal(template);
+            expect(template.content.length).to.be.greaterThan(0);
+        }
+        expect(ReportTemplates.byId('nope')).to.equal(undefined);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang`
+Expected: TS error — module `./report-templates` not found.
+
+- [ ] **Step 3: Implement**
+
+Create `packages/cooklang/src/common/report-templates.ts` (license header, then):
+
+```ts
+/**
+ * A report template bundled with the editor, available even when the
+ * workspace has no `config/reports/` directory.
+ */
+export interface BuiltInReportTemplate {
+    id: string;
+    label: string;
+    content: string;
+}
+
+export namespace ReportTemplates {
+
+    /** File extensions recognized as Jinja2 report templates. */
+    export const FILE_EXTENSIONS: ReadonlyArray<string> = ['.jinja', '.j2', '.jinja2'];
+
+    /** Workspace directory scanned for report templates. */
+    export const WORKSPACE_TEMPLATE_DIR = 'config/reports';
+
+    export function isTemplateFile(fileName: string): boolean {
+        const lower = fileName.toLowerCase();
+        return FILE_EXTENSIONS.some(ext => lower.endsWith(ext));
+    }
+
+    export const BUILT_IN: ReadonlyArray<BuiltInReportTemplate> = [
+        {
+            id: 'builtin:ingredients',
+            label: 'Ingredients List (built-in)',
+            content: `# {{ metadata.title | default("Ingredients") }}
+
+{% for ingredient in ingredients | sort(attribute='name') -%}
+- {{ ingredient.name }}{% if ingredient.quantity %}: {{ ingredient.quantity }}{% endif %}
+{% endfor %}`
+        },
+        {
+            id: 'builtin:shopping-list',
+            label: 'Shopping List (built-in)',
+            content: `# Shopping List
+
+{% for (aisle, items) in aisled(ingredients) | items -%}
+## {{ aisle | titleize }}
+
+{% for ingredient in items -%}
+- [ ] {{ ingredient.name }}{% if ingredient.quantity %}: {{ ingredient.quantity }}{% endif %}
+{% endfor %}
+{% endfor %}`
+        }
+    ];
+
+    export function byId(id: string): BuiltInReportTemplate | undefined {
+        return BUILT_IN.find(template => template.id === id);
+    }
+}
+```
+
+In `packages/cooklang/src/common/index.ts`, add alongside the existing exports:
+
+```ts
+export * from './report-templates';
+```
+
+- [ ] **Step 4: Compile and run tests to verify they pass**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang && npx lerna run test --scope @theia/cooklang`
+Expected: PASS (all specs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang/src/common/report-templates.ts packages/cooklang/src/common/report-templates.spec.ts packages/cooklang/src/common/index.ts
+git commit -m "feat(cooklang): add built-in report templates and template-file helpers"
+```
+
+---
+
+### Task 4: ReportWidget — rendered-markdown tab
+
+**Files:**
+- Create: `packages/cooklang/src/browser/report-widget.tsx`
+- Create: `packages/cooklang/src/browser/style/report.css`
+
+No unit spec for this file: it imports `MonacoWorkspace`, which kills the browser spec harness (known monaco-css pitfall). Behavior is covered by the manual verification in Task 6; the testable logic (template constants/helpers, config conversion) already lives in monaco-free files.
+
+- [ ] **Step 1: Create the CSS**
+
+Create `packages/cooklang/src/browser/style/report.css`:
+
+```css
+.cooklang-report {
+    padding: 0 20px 20px 20px;
+    color: var(--theia-editor-foreground);
+    background: var(--theia-editor-background);
+}
+
+.cooklang-report-error pre {
+    color: var(--theia-errorForeground);
+    white-space: pre-wrap;
+    font-family: var(--theia-code-font-family);
+}
+
+.cooklang-report-loading {
+    padding: 20px;
+    color: var(--theia-descriptionForeground);
+}
+```
+
+- [ ] **Step 2: Create the widget**
+
+Create `packages/cooklang/src/browser/report-widget.tsx` (license header, then):
+
+```tsx
+import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { Markdown } from '@theia/core/lib/browser/markdown-rendering/markdown';
+import { nls } from '@theia/core/lib/common/nls';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import URI from '@theia/core/lib/common/uri';
+import * as React from '@theia/core/shared/react';
+import { CooklangLanguageService, COOKLANG_LANGUAGE_ID, ReportTemplates } from '../common';
+
+import '../../src/browser/style/report.css';
+
+// ---------------------------------------------------------------------------
+// Public constants and helpers
+// ---------------------------------------------------------------------------
+
+export const REPORT_WIDGET_ID = 'cooklang-report-widget';
+
+export interface ReportWidgetOptions {
+    /** URI string of the source `.cook` file. */
+    uri: string;
+    /** Template id: `builtin:*` or `workspace:<template uri>`. */
+    templateId: string;
+    /** Human-readable template name for the tab title. */
+    templateLabel: string;
+    /** URI string of a workspace template file; unset for built-ins. */
+    templateUri?: string;
+    /** Render config (scale + URI-string paths), passed through to the RPC. */
+    configJson: string;
+}
+
+/**
+ * Constructs a unique widget ID for a report tab tied to a recipe + template.
+ */
+export function createReportWidgetId(uri: URI, templateId: string): string {
+    return `${REPORT_WIDGET_ID}:${templateId}:${uri.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// ReportWidget
+// ---------------------------------------------------------------------------
+
+@injectable()
+export class ReportWidget extends ReactWidget implements Navigatable {
+
+    @inject(CooklangLanguageService)
+    protected readonly service: CooklangLanguageService;
+
+    @inject(MonacoWorkspace)
+    protected readonly monacoWorkspace: MonacoWorkspace;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(MarkdownRenderer)
+    protected readonly markdownRenderer: MarkdownRenderer;
+
+    protected uri: URI;
+    protected options: ReportWidgetOptions;
+    protected output: string | undefined;
+    protected errorMessage: string | undefined;
+    protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        this.addClass('cooklang-report');
+        this.scrollOptions = {
+            suppressScrollX: true,
+            minScrollbarLength: 35,
+        };
+        this.toDispose.push(
+            this.monacoWorkspace.onDidChangeTextDocument(event => {
+                if (
+                    event.model.languageId !== COOKLANG_LANGUAGE_ID ||
+                    event.model.uri !== this.uri?.toString()
+                ) {
+                    return;
+                }
+                this.debouncedRender();
+            })
+        );
+    }
+
+    /**
+     * Bind this widget to a recipe + template and trigger the first render.
+     */
+    setOptions(options: ReportWidgetOptions): void {
+        this.options = options;
+        this.uri = new URI(options.uri);
+        this.id = createReportWidgetId(this.uri, options.templateId);
+        this.title.label = nls.localize('theia/cooklang/reportTabTitle', 'Report: {0} ({1})', this.uri.path.base, options.templateLabel);
+        this.title.caption = this.title.label;
+        this.title.closable = true;
+        this.title.iconClass = 'codicon codicon-output';
+        this.renderReport();
+    }
+
+    // --- Navigatable ---
+
+    getResourceUri(): URI | undefined {
+        return this.uri;
+    }
+
+    createMoveToUri(resourceUri: URI): URI | undefined {
+        return resourceUri;
+    }
+
+    // --- Report rendering ---
+
+    protected debouncedRender(): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+        }
+        this.debounceTimer = setTimeout(() => {
+            this.debounceTimer = undefined;
+            this.renderReport();
+        }, 300);
+    }
+
+    protected async renderReport(): Promise<void> {
+        try {
+            const recipe = await this.readRecipeContent();
+            const template = await this.readTemplateContent();
+            const resultJson = await this.service.renderReport(recipe, template, this.options.configJson);
+            const result = JSON.parse(resultJson) as { output?: string; error?: string };
+            this.output = result.output;
+            this.errorMessage = result.error;
+        } catch (error) {
+            this.output = undefined;
+            this.errorMessage = String(error);
+        }
+        this.update();
+    }
+
+    protected async readRecipeContent(): Promise<string> {
+        const model = this.monacoWorkspace.getTextDocument(this.uri.toString());
+        if (model) {
+            return model.getText();
+        }
+        const content = await this.fileService.read(this.uri);
+        return content.value;
+    }
+
+    protected async readTemplateContent(): Promise<string> {
+        if (this.options.templateUri) {
+            const content = await this.fileService.read(new URI(this.options.templateUri));
+            return content.value;
+        }
+        const builtIn = ReportTemplates.byId(this.options.templateId);
+        if (!builtIn) {
+            throw new Error(`Unknown built-in report template: ${this.options.templateId}`);
+        }
+        return builtIn.content;
+    }
+
+    // --- Rendering ---
+
+    protected render(): React.ReactNode {
+        if (this.errorMessage) {
+            return (
+                <div className='cooklang-report-error'>
+                    <strong>{nls.localize('theia/cooklang/reportError', 'Report rendering failed:')}</strong>
+                    <pre>{this.errorMessage}</pre>
+                </div>
+            );
+        }
+        if (this.output === undefined) {
+            return <div className='cooklang-report-loading'>{nls.localizeByDefault('Loading...')}</div>;
+        }
+        return (
+            <Markdown
+                markdown={this.output}
+                markdownRenderer={this.markdownRenderer}
+                className='cooklang-report-content'
+            />
+        );
+    }
+
+    // --- Disposal ---
+
+    override dispose(): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = undefined;
+        }
+        super.dispose();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fully initialised {@link ReportWidget} bound to `options`.
+ *
+ * Uses a child container so each report tab gets its own widget instance
+ * while inheriting all parent bindings.
+ */
+export function createReportWidget(
+    container: interfaces.Container,
+    options: ReportWidgetOptions
+): ReportWidget {
+    const child = container.createChild();
+    child.bind(ReportWidget).toSelf().inTransientScope();
+    const widget = child.get(ReportWidget);
+    widget.setOptions(options);
+    return widget;
+}
+```
+
+Note: `Markdown` is exported from `@theia/core/lib/browser/markdown-rendering/markdown` (`export const Markdown = React.memo(MarkdownComponent)` at `packages/core/src/browser/markdown-rendering/markdown.tsx:124`); `MarkdownRenderer` is a DI symbol bound in `frontend-application-module.ts:321`.
+
+- [ ] **Step 3: Compile**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang`
+Expected: success. (The widget isn't bound yet — that's Task 6.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang/src/browser/report-widget.tsx packages/cooklang/src/browser/style/report.css
+git commit -m "feat(cooklang): add ReportWidget rendering report output as markdown"
+```
+
+---
+
+### Task 5: ReportContribution — command, QuickPick, menus
+
+**Files:**
+- Create: `packages/cooklang/src/browser/report-contribution.ts`
+
+- [ ] **Step 1: Create the contribution**
+
+Create `packages/cooklang/src/browser/report-contribution.ts` (license header, then):
+
+```ts
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common/command';
+import { MenuModelRegistry, MenuContribution } from '@theia/core/lib/common/menu';
+import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
+import { QuickPickService, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { nls } from '@theia/core/lib/common/nls';
+import { EditorManager, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import URI from '@theia/core/lib/common/uri';
+import { COOKLANG_LANGUAGE_ID, ReportTemplates } from '../common';
+import { ReportWidget, ReportWidgetOptions, REPORT_WIDGET_ID, createReportWidgetId } from './report-widget';
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+export namespace CooklangReportCommands {
+    export const RENDER_REPORT: Command = Command.toLocalizedCommand({
+        id: 'cooklang.renderReport',
+        label: 'Cooklang: Render Report...',
+        iconClass: 'codicon codicon-output'
+    }, 'theia/cooklang/renderReport');
+}
+
+/** A template choice offered in the QuickPick. */
+interface ReportTemplatePick {
+    id: string;
+    label: string;
+    uri?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ReportContribution
+// ---------------------------------------------------------------------------
+
+@injectable()
+export class ReportContribution implements CommandContribution, MenuContribution {
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
+
+    @inject(QuickPickService)
+    protected readonly quickPickService: QuickPickService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    // --- CommandContribution ---
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(CooklangReportCommands.RENDER_REPORT, {
+            execute: () => this.renderReport(),
+            isEnabled: () => this.getActiveCooklangEditorUri() !== undefined,
+        });
+    }
+
+    // --- MenuContribution ---
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction([...EDITOR_CONTEXT_MENU, 'navigation'], {
+            commandId: CooklangReportCommands.RENDER_REPORT.id,
+            when: 'resourceExtname == .cook',
+        });
+    }
+
+    // --- Command execution ---
+
+    protected async renderReport(): Promise<void> {
+        const uri = this.getActiveCooklangEditorUri();
+        if (!uri) {
+            return;
+        }
+        if (uri.path.ext === '.menu') {
+            this.messageService.info(
+                nls.localize('theia/cooklang/reportMenuUnsupported', 'Reports are not supported for menu files yet.')
+            );
+            return;
+        }
+        const template = await this.pickTemplate();
+        if (!template) {
+            return;
+        }
+        const options: ReportWidgetOptions = {
+            uri: uri.toString(),
+            templateId: template.id,
+            templateLabel: template.label,
+            templateUri: template.uri,
+            configJson: await this.buildConfigJson(),
+        };
+        const widget = await this.getOrCreateReport(options);
+        if (!widget.isAttached) {
+            await this.shell.addWidget(widget, { area: 'main' });
+        }
+        this.shell.activateWidget(widget.id);
+    }
+
+    /**
+     * Returns the URI of the active editor when its language is Cooklang,
+     * or `undefined` otherwise.
+     */
+    protected getActiveCooklangEditorUri(): URI | undefined {
+        const editorWidget = this.editorManager.currentEditor;
+        if (!editorWidget) {
+            return undefined;
+        }
+        const { languageId, uri } = editorWidget.editor.document;
+        if (languageId !== COOKLANG_LANGUAGE_ID) {
+            return undefined;
+        }
+        return new URI(uri);
+    }
+
+    /**
+     * Shows a QuickPick of workspace templates (config/reports/*.jinja|j2|jinja2)
+     * followed by the built-in templates.
+     */
+    protected async pickTemplate(): Promise<ReportTemplatePick | undefined> {
+        const workspaceTemplates = await this.findWorkspaceTemplates();
+        const items: Array<(QuickPickItem & { template: ReportTemplatePick }) | QuickPickSeparator> = [];
+        if (workspaceTemplates.length > 0) {
+            items.push({
+                type: 'separator',
+                label: nls.localize('theia/cooklang/workspaceTemplates', 'Workspace Templates'),
+            });
+            for (const template of workspaceTemplates) {
+                items.push({ label: template.label, description: ReportTemplates.WORKSPACE_TEMPLATE_DIR, template });
+            }
+        }
+        items.push({
+            type: 'separator',
+            label: nls.localize('theia/cooklang/builtInTemplates', 'Built-in Templates'),
+        });
+        for (const builtIn of ReportTemplates.BUILT_IN) {
+            items.push({ label: builtIn.label, template: { id: builtIn.id, label: builtIn.label } });
+        }
+        const picked = await this.quickPickService.show(items, {
+            placeholder: nls.localize('theia/cooklang/pickReportTemplate', 'Select a report template'),
+        });
+        return picked && 'template' in picked ? picked.template : undefined;
+    }
+
+    /**
+     * Lists template files in `config/reports/` of the first workspace root.
+     */
+    protected async findWorkspaceTemplates(): Promise<ReportTemplatePick[]> {
+        const root = this.workspaceService.tryGetRoots()[0];
+        if (!root) {
+            return [];
+        }
+        const dir = root.resource.resolve(ReportTemplates.WORKSPACE_TEMPLATE_DIR);
+        try {
+            const stat = await this.fileService.resolve(dir);
+            if (!stat.isDirectory || !stat.children) {
+                return [];
+            }
+            return stat.children
+                .filter(child => !child.isDirectory && ReportTemplates.isTemplateFile(child.name))
+                .map(child => ({
+                    id: `workspace:${child.resource.toString()}`,
+                    label: child.name,
+                    uri: child.resource.toString(),
+                }))
+                .sort((a, b) => a.label.localeCompare(b.label));
+        } catch {
+            // Directory does not exist — no workspace templates.
+            return [];
+        }
+    }
+
+    /**
+     * Builds the render config from workspace conventions. Paths are sent as
+     * URI strings; the backend converts them to filesystem paths.
+     */
+    protected async buildConfigJson(): Promise<string> {
+        const config: {
+            scale: number;
+            basePath?: string;
+            aislePath?: string;
+            pantryPath?: string;
+            datastorePath?: string;
+        } = { scale: 1 };
+        const root = this.workspaceService.tryGetRoots()[0];
+        if (root) {
+            config.basePath = root.resource.toString();
+            const aisle = root.resource.resolve('config/aisle.conf');
+            if (await this.fileService.exists(aisle)) {
+                config.aislePath = aisle.toString();
+            }
+            const pantry = root.resource.resolve('config/pantry.conf');
+            if (await this.fileService.exists(pantry)) {
+                config.pantryPath = pantry.toString();
+            }
+            const datastore = root.resource.resolve('db');
+            if (await this.fileService.exists(datastore)) {
+                config.datastorePath = datastore.toString();
+            }
+        }
+        return JSON.stringify(config);
+    }
+
+    /**
+     * Returns an existing report widget for (uri, template) if open, otherwise
+     * creates one via the widget factory. A fresh `setOptions` re-render is
+     * triggered on reuse so the report reflects the latest config.
+     */
+    protected async getOrCreateReport(options: ReportWidgetOptions): Promise<ReportWidget> {
+        const widgetId = createReportWidgetId(new URI(options.uri), options.templateId);
+        const existing = this.widgetManager.tryGetWidget<ReportWidget>(widgetId);
+        if (existing) {
+            existing.setOptions(options);
+            return existing;
+        }
+        return this.widgetManager.getOrCreateWidget<ReportWidget>(REPORT_WIDGET_ID, options);
+    }
+}
+```
+
+- [ ] **Step 2: Compile**
+
+Run: `cd /Users/alexeydubovskoy/Cooklang/editor && npx lerna run compile --scope @theia/cooklang`
+Expected: success. If `EDITOR_CONTEXT_MENU` is not exported from `@theia/editor/lib/browser`, import it from `@theia/editor/lib/browser/editor-menu` instead.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang/src/browser/report-contribution.ts
+git commit -m "feat(cooklang): add Render Report command with template QuickPick"
+```
+
+---
+
+### Task 6: Wire up DI, lint, bundle, verify
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/cooklang-frontend-module.ts`
+
+- [ ] **Step 1: Add bindings**
+
+In `packages/cooklang/src/browser/cooklang-frontend-module.ts`, add imports:
+
+```ts
+import { REPORT_WIDGET_ID, ReportWidgetOptions, createReportWidget } from './report-widget';
+import { ReportContribution } from './report-contribution';
+```
+
+Inside the `ContainerModule`, after the menu-preview bindings (line ~82), add:
+
+```ts
+    // Report widget factory
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: REPORT_WIDGET_ID,
+        createWidget: (options: ReportWidgetOptions) =>
+            createReportWidget(ctx.container, options),
+    })).inSingletonScope();
+
+    // Report command and context menu
+    bind(ReportContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ReportContribution);
+    bind(MenuContribution).toService(ReportContribution);
+```
+
+- [ ] **Step 2: Compile, lint, test**
+
+Run:
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+npx lerna run test --scope @theia/cooklang
+```
+Expected: all pass. Fix any lint complaints (4-space indent, single quotes, explicit return types).
+
+- [ ] **Step 3: Bundle and launch the app**
+
+Run:
+```bash
+cd /Users/alexeydubovskoy/Cooklang/editor/app && npm run bundle
+npm run start:electron
+```
+
+- [ ] **Step 4: Manual verification**
+
+1. Open a `.cook` file from the workspace (e.g. one under `app/`).
+2. Run "Cooklang: Render Report..." from the command palette → QuickPick shows the two built-in templates (plus any `config/reports/*.jinja` files if present).
+3. Pick "Ingredients List (built-in)" → a new tab "Report: <file> (Ingredients List (built-in))" opens with a rendered markdown heading + ingredient bullets.
+4. Edit the recipe (add `@butter{10%g}` to a step) → the report tab updates within ~a second without re-running the command.
+5. Create `config/reports/bad.jinja` containing `{% for %}` in the workspace, re-run the command, pick it → the tab shows the minijinja error in the preformatted error block (no popup, no crash).
+6. Open a `.menu` file, run the command → info toast "Reports are not supported for menu files yet."
+7. Right-click inside a `.cook` editor → "Cooklang: Render Report..." appears in the context menu.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang/src/browser/cooklang-frontend-module.ts
+git commit -m "feat(cooklang): wire up report widget factory and contribution"
+```

--- a/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
+++ b/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
@@ -71,10 +71,10 @@ New `report-contribution.ts` registering `cooklang.renderReport`
   the active editor is a `.cook` file. For `.menu` files the command shows an
   info message that menu reports are not yet supported.
 - Flow on invocation:
-  1. **Template discovery:** scan directories named `reports` or `templates`
-     (case-insensitive) at the workspace root and under `config/` for
-     `*.jinja`, `*.j2`, `*.jinja2` via `FileService`; show a QuickPick of
-     found templates (with their source directory as description) plus
+  1. **Template discovery:** search the whole workspace for `*.jinja`,
+     `*.j2`, `*.jinja2` via the ripgrep-backed `FileSearchService`
+     (respects `.gitignore`, capped at 200 results); show a QuickPick of
+     found templates (with their parent directory as description) plus
      built-in templates ("Ingredients List", "Shopping List") bundled with
      the package as string constants.
   2. **Config wiring:** if present in the workspace, pass
@@ -93,8 +93,11 @@ New `report-contribution.ts` registering `cooklang.renderReport`
 - Widget id derived from recipe URI + template identifier, so re-running the
   same combination reuses the existing tab; a different template for the
   same recipe opens a separate tab.
-- Renders the report output as markdown → HTML via Theia's
-  `MarkdownRenderer` (sanitized).
+- Renders the report output according to the template's inner file
+  extension: `*.md.jinja` or no inner extension → markdown via Theia's
+  `MarkdownRenderer` (sanitized); `*.html.jinja` → DOMPurify-sanitized
+  HTML; anything else (`*.yaml.jinja`, `*.json.jinja`, …) → preformatted
+  text.
 - Subscribes to the source document and re-renders on change, debounced
   (same approach as the recipe preview).
 - Render/template errors are displayed inside the widget as a preformatted

--- a/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
+++ b/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
@@ -71,13 +71,16 @@ New `report-contribution.ts` registering `cooklang.renderReport`
   the active editor is a `.cook` file. For `.menu` files the command shows an
   info message that menu reports are not yet supported.
 - Flow on invocation:
-  1. **Template discovery:** scan `config/reports/` in the workspace for
+  1. **Template discovery:** scan directories named `reports` or `templates`
+     (case-insensitive) at the workspace root and under `config/` for
      `*.jinja`, `*.j2`, `*.jinja2` via `FileService`; show a QuickPick of
-     found templates plus built-in templates ("Ingredients List",
-     "Shopping List") bundled with the package as string constants.
+     found templates (with their source directory as description) plus
+     built-in templates ("Ingredients List", "Shopping List") bundled with
+     the package as string constants.
   2. **Config wiring:** if present in the workspace, pass
-     `config/aisle.conf`, `config/pantry.conf`, `db/` (datastore) and the
-     workspace root as base path. Missing files are simply omitted.
+     `config/aisle.conf`, `config/pantry.conf`, the first of `db/` or
+     `config/db/` (datastore), and the workspace root as base path. Missing
+     files are simply omitted.
   3. **Content:** recipe content is read from the open editor document (so
      unsaved changes render); the template is read via `FileService` (or
      taken from the built-in constant).

--- a/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
+++ b/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
@@ -1,0 +1,126 @@
+# Cooklang Report Rendering — Design
+
+**Date:** 2026-06-10
+**Status:** Approved
+
+## Goal
+
+Add a "Cooklang: Render Report…" command to the editor that renders a
+[Cooklang report](https://cooklang.org/docs/use-cases/reports/) (a Jinja2
+template applied to a recipe) for the currently open `.cook` file and shows
+the result in a new main-area tab. Feature parity target is `cook report`
+from cookcli, which delegates to the `cooklang-reports` crate (minijinja).
+
+## Scope
+
+- **In:** single recipes (`.cook`), template discovery from the workspace,
+  built-in fallback templates, rendered-markdown output tab with live
+  re-render, workspace-convention config wiring (aisle/pantry/datastore).
+- **Out (v1):** `.menu` files (upstream `cooklang-reports` does not support
+  menus; the command shows a friendly "not supported for menus yet" message),
+  recipe scaling UI (scale fixed at 1), template editing aids.
+
+## Architecture
+
+Rendering happens in Rust via the `cooklang-reports` crate, exposed through
+the existing NAPI-RS addon and `CooklangLanguageService` RPC — the same
+pipeline used by `parse` and `generateShoppingList`. This guarantees the
+same template engine, filters (`db()`, `aisled()`, `excluding_pantry()`,
+number formatters, …) and behavior as cookcli.
+
+### 1. cooklang-native (Rust)
+
+- Add `cooklang-reports` to `packages/cooklang-native/Cargo.toml`. Use the
+  latest published crates.io version; if crates.io lags behind 0.5.x, use a
+  git dependency on `cooklang/cooklang-reports`.
+- New NAPI function:
+
+  ```rust
+  #[napi]
+  pub fn render_report(recipe: String, template: String, config_json: String) -> String
+  ```
+
+  `config_json` carries optional `scale`, `basePath`, `aislePath`,
+  `pantryPath`, `datastorePath` (all filesystem paths, already converted by
+  the backend). Maps onto `cooklang_reports::Config` and calls
+  `render_template_with_config(&recipe, &template, &config)`.
+- Returns JSON: `{ "output": "..." }` on success, `{ "error": "..." }` on
+  failure (minijinja errors formatted with source context where available).
+
+### 2. Backend RPC (packages/cooklang/src/node)
+
+- New method on `CooklangLanguageService` (common interface +
+  `CooklangLanguageServiceImpl`):
+
+  ```ts
+  renderReport(recipeContent: string, templateContent: string, configJson: string): Promise<string>;
+  ```
+
+- The frontend sends path-like config entries as URI strings; the backend
+  converts them with `FileUri.fsPath` before building the native config
+  (URIs cross the wire, never raw paths).
+- Errors from the native call are caught and returned as `{ error }` JSON,
+  mirroring the `parse` error-handling pattern.
+
+### 3. Frontend command (packages/cooklang/src/browser)
+
+New `report-contribution.ts` registering `cooklang.renderReport`
+("Cooklang: Render Report…"):
+
+- Available in the command palette and the editor context menu; enabled when
+  the active editor is a `.cook` file. For `.menu` files the command shows an
+  info message that menu reports are not yet supported.
+- Flow on invocation:
+  1. **Template discovery:** scan `config/reports/` in the workspace for
+     `*.jinja`, `*.j2`, `*.jinja2` via `FileService`; show a QuickPick of
+     found templates plus built-in templates ("Ingredients List",
+     "Shopping List") bundled with the package as string constants.
+  2. **Config wiring:** if present in the workspace, pass
+     `config/aisle.conf`, `config/pantry.conf`, `db/` (datastore) and the
+     workspace root as base path. Missing files are simply omitted.
+  3. **Content:** recipe content is read from the open editor document (so
+     unsaved changes render); the template is read via `FileService` (or
+     taken from the built-in constant).
+  4. Open/reveal the `ReportWidget` for (recipe URI, template) in the main
+     area.
+
+### 4. ReportWidget (packages/cooklang/src/browser)
+
+- `ReactWidget` + `Navigatable`, modeled on `RecipePreviewWidget`.
+- Widget id derived from recipe URI + template identifier, so re-running the
+  same combination reuses the existing tab; a different template for the
+  same recipe opens a separate tab.
+- Renders the report output as markdown → HTML via Theia's
+  `MarkdownRenderer` (sanitized).
+- Subscribes to the source document and re-renders on change, debounced
+  (same approach as the recipe preview).
+- Render/template errors are displayed inside the widget as a preformatted
+  error block — no popups.
+- Styling via CSS classes in `style/` (no inline styles); colors via
+  `--theia-*` variables only.
+
+## Error handling
+
+- Native panic safety: `render_report` catches errors from
+  `cooklang-reports` and returns them as `{ error }` — no process crashes.
+- Backend catches `require`/invocation failures and returns `{ error }`.
+- Widget displays `{ error }` content in-place; the QuickPick step surfaces
+  filesystem problems (unreadable template) via `MessageService`.
+
+## Testing
+
+- **Rust:** unit test for `render_report` with a small recipe fixture and an
+  ingredients template; one test for the error path (bad template syntax).
+- **Backend:** `cooklang-language-service-impl.spec.ts` addition with the
+  native module stubbed.
+- **Frontend:** template-discovery logic extracted into a monaco-free file
+  with its own spec (avoids the known monaco-css spec-harness failure).
+- Manual: render built-in template on a sample recipe; verify live
+  re-render and error display.
+
+## Conventions
+
+- All user-facing strings localized with `nls.localize`
+  (`theia/cooklang/...` keys).
+- Property injection, `@postConstruct` (sync), `inSingletonScope` bindings.
+- 4-space indent, single quotes, explicit return types.

--- a/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
+++ b/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
@@ -13,12 +13,12 @@ from cookcli, which delegates to the `cooklang-reports` crate (minijinja).
 
 ## Scope
 
-- **In:** single recipes (`.cook`), template discovery from the workspace,
-  built-in fallback templates, rendered-markdown output tab with live
-  re-render, workspace-convention config wiring (aisle/pantry/datastore).
-- **Out (v1):** `.menu` files (upstream `cooklang-reports` does not support
-  menus; the command shows a friendly "not supported for menus yet" message),
-  recipe scaling UI (scale fixed at 1), template editing aids.
+- **In:** recipes (`.cook`) and menus (`.menu` — same Cooklang syntax,
+  different extension, rendered through the same engine), template discovery
+  from the workspace, built-in fallback templates, rendered output tab with
+  live re-render, workspace-convention config wiring
+  (aisle/pantry/datastore).
+- **Out (v1):** recipe scaling UI (scale fixed at 1), template editing aids.
 
 ## Architecture
 
@@ -68,8 +68,8 @@ New `report-contribution.ts` registering `cooklang.renderReport`
 ("Cooklang: Render Report…"):
 
 - Available in the command palette and the editor context menu; enabled when
-  the active editor is a `.cook` file. For `.menu` files the command shows an
-  info message that menu reports are not yet supported.
+  the current view (preview tab, report tab, or text editor) shows a `.cook`
+  or `.menu` resource.
 - Flow on invocation:
   1. **Template discovery:** search the whole workspace for `*.jinja`,
      `*.j2`, `*.jinja2` via the ripgrep-backed `FileSearchService`

--- a/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
+++ b/docs/superpowers/specs/2026-06-10-cooklang-report-design.md
@@ -104,8 +104,9 @@ New `report-contribution.ts` registering `cooklang.renderReport`
 - Native panic safety: `render_report` catches errors from
   `cooklang-reports` and returns them as `{ error }` — no process crashes.
 - Backend catches `require`/invocation failures and returns `{ error }`.
-- Widget displays `{ error }` content in-place; the QuickPick step surfaces
-  filesystem problems (unreadable template) via `MessageService`.
+- Widget displays `{ error }` content in-place; filesystem problems
+  (unreadable template) also surface in the widget's error block, keeping a
+  single error surface with no popups.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,8 +69,8 @@
     },
     "app": {
       "name": "@cook-md/editor-app",
-      "version": "0.1.0-alpha.9",
-      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "version": "0.1.0-alpha.21",
+      "license": "(EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/ai-chat": "1.70.0",
         "@theia/ai-chat-ui": "1.70.0",
@@ -28022,11 +28022,12 @@
     "packages/cooklang": {
       "name": "@theia/cooklang",
       "version": "1.70.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/cooklang-native": "0.1.0",
         "@theia/core": "1.70.0",
         "@theia/editor": "1.70.0",
+        "@theia/file-search": "1.70.0",
         "@theia/filesystem": "1.70.0",
         "@theia/monaco": "1.70.0",
         "@theia/monaco-editor-core": "1.108.201",
@@ -28041,7 +28042,7 @@
     "packages/cooklang-account": {
       "name": "@theia/cooklang-account",
       "version": "1.70.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/cooklang-native": "0.1.0",
         "@theia/core": "1.70.0",
@@ -28055,7 +28056,7 @@
     "packages/cooklang-ai": {
       "name": "@theia/cooklang-ai",
       "version": "1.70.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception AND (EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0)",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
         "@grpc/proto-loader": "^0.7.0",
@@ -28099,7 +28100,7 @@
     "packages/cooklang-branding": {
       "name": "@theia/cooklang-branding",
       "version": "1.70.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/ai-chat": "1.70.0",
         "@theia/ai-chat-ui": "1.70.0",
@@ -28116,7 +28117,7 @@
     "packages/cooklang-native": {
       "name": "@theia/cooklang-native",
       "version": "0.1.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.0"
       }

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "cooklang",
  "cooklang-find",
  "cooklang-language-server",
+ "cooklang-reports",
  "cooklang-sync-client",
  "napi",
  "napi-build",
@@ -449,6 +450,23 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower-lsp",
+]
+
+[[package]]
+name = "cooklang-reports"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48868cbf385ded5773999ef7137db8246571c5aed3915d9898934954fa1b4339"
+dependencies = [
+ "anyhow",
+ "cooklang",
+ "cooklang-find",
+ "minijinja",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "yaml-datastore",
 ]
 
 [[package]]
@@ -1466,6 +1484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "migrations_internals"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1524,17 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
+dependencies = [
+ "indexmap",
+ "memo-map",
+ "serde",
 ]
 
 [[package]]
@@ -3633,6 +3668,17 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yaml-datastore"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8af6117f4d2157a2cd2221234e3f92c526601dfbac22e466a493f36bd4d2901f"
+dependencies = [
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "yansi"

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -11,6 +11,7 @@ napi = { version = "2", features = ["napi6", "serde-json", "tokio_rt"] }
 napi-derive = "2"
 cooklang = { version = "0.18.5", features = ["aisle", "pantry", "shopping_list"] }
 cooklang-find = "0.5.8"
+cooklang-reports = "0.5"
 camino = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/packages/cooklang-native/index.d.ts
+++ b/packages/cooklang-native/index.d.ts
@@ -62,6 +62,13 @@ export declare function checkedSet(entriesJson: string): Array<string>
  */
 export declare function findRecipe(baseDir: string, name: string): string | null
 export declare function compactChecked(entriesJson: string, currentIngredients: Array<string>): string
+/**
+ * Render a Jinja2 report template against a recipe via cooklang-reports
+ * (the same engine cookcli's `cook report` uses).
+ *
+ * Returns JSON: `{"output": "..."}` on success or `{"error": "..."}` on failure.
+ */
+export declare function renderReport(recipe: string, template: string, configJson: string): string
 export declare class LspServer {
   constructor()
   sendMessage(message: string): void

--- a/packages/cooklang-native/index.js
+++ b/packages/cooklang-native/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, compactChecked } = nativeBinding
+const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, compactChecked, renderReport } = nativeBinding
 
 module.exports.parse = parse
 module.exports.generateShoppingList = generateShoppingList
@@ -327,3 +327,4 @@ module.exports.writeCheckEntry = writeCheckEntry
 module.exports.checkedSet = checkedSet
 module.exports.findRecipe = findRecipe
 module.exports.compactChecked = compactChecked
+module.exports.renderReport = renderReport

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -969,4 +969,12 @@ mod render_report_tests {
         let v: serde_json::Value = serde_json::from_str(&result).unwrap();
         assert!(!v["error"].as_str().unwrap().is_empty());
     }
+
+    #[test]
+    fn returns_json_for_unparsable_recipe() {
+        let garbage = "@{unclosed [- broken >> nonsense";
+        let result = super::render_report(garbage.into(), "{{ scale }}".into(), "{}".into());
+        let v: serde_json::Value = serde_json::from_str(&result).expect("must return valid JSON");
+        assert!(v.get("output").is_some() || v.get("error").is_some());
+    }
 }

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -899,3 +899,74 @@ pub fn napi_compact_checked(
     serde_json::to_string(&compacted)
         .map_err(|e| napi::Error::from_reason(e.to_string()))
 }
+
+/// Configuration accepted by `render_report`, mirroring cooklang_reports::Config.
+/// All path fields are OS filesystem paths (the Theia backend converts URIs
+/// before calling into the addon).
+#[derive(serde::Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+struct ReportConfig {
+    scale: Option<f64>,
+    base_path: Option<String>,
+    aisle_path: Option<String>,
+    pantry_path: Option<String>,
+    datastore_path: Option<String>,
+}
+
+/// Render a Jinja2 report template against a recipe via cooklang-reports
+/// (the same engine cookcli's `cook report` uses).
+///
+/// Returns JSON: `{"output": "..."}` on success or `{"error": "..."}` on failure.
+#[napi]
+pub fn render_report(recipe: String, template: String, config_json: String) -> String {
+    let cfg: ReportConfig = serde_json::from_str(&config_json).unwrap_or_default();
+    let mut builder = cooklang_reports::config::Config::builder();
+    builder.scale(cfg.scale.unwrap_or(1.0));
+    if let Some(p) = cfg.base_path {
+        builder.base_path(p);
+    }
+    if let Some(p) = cfg.aisle_path {
+        builder.aisle_path(p);
+    }
+    if let Some(p) = cfg.pantry_path {
+        builder.pantry_path(p);
+    }
+    if let Some(p) = cfg.datastore_path {
+        builder.datastore_path(p);
+    }
+    let config = builder.build();
+    match cooklang_reports::render_template_with_config(&recipe, &template, &config) {
+        Ok(output) => serde_json::json!({ "output": output }).to_string(),
+        Err(err) => serde_json::json!({ "error": err.to_string() }).to_string(),
+    }
+}
+
+#[cfg(test)]
+mod render_report_tests {
+    #[test]
+    fn renders_ingredients_template() {
+        let recipe = "Mix @eggs{3} with @flour{125%g}.";
+        let template = "{% for i in ingredients %}{{ i.name }};{% endfor %}";
+        let result = super::render_report(recipe.into(), template.into(), "{}".into());
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let output = v["output"].as_str().expect("expected output, not error");
+        assert!(output.contains("eggs;"), "output was: {output}");
+        assert!(output.contains("flour;"), "output was: {output}");
+    }
+
+    #[test]
+    fn applies_scale_from_config() {
+        let recipe = "Mix @eggs{2}.";
+        let template = "{{ scale }}";
+        let result = super::render_report(recipe.into(), template.into(), r#"{"scale": 2}"#.into());
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(v["output"].as_str().unwrap(), "2.0");
+    }
+
+    #[test]
+    fn returns_error_for_bad_template() {
+        let result = super::render_report("Mix @eggs{1}.".into(), "{% for %}".into(), "{}".into());
+        let v: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert!(!v["error"].as_str().unwrap().is_empty());
+    }
+}

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -937,7 +937,7 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
     let config = builder.build();
     match cooklang_reports::render_template_with_config(&recipe, &template, &config) {
         Ok(output) => serde_json::json!({ "output": output }).to_string(),
-        Err(err) => serde_json::json!({ "error": err.to_string() }).to_string(),
+        Err(err) => serde_json::json!({ "error": err.format_with_source() }).to_string(),
     }
 }
 

--- a/packages/cooklang/package.json
+++ b/packages/cooklang/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "1.70.0",
     "@theia/editor": "1.70.0",
+    "@theia/file-search": "1.70.0",
     "@theia/filesystem": "1.70.0",
     "@theia/monaco": "1.70.0",
     "@theia/monaco-editor-core": "1.108.201",

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -35,6 +35,8 @@ import { ShoppingListService } from './shopping-list-service';
 import { ShoppingListContribution } from './shopping-list-contribution';
 import { MENU_PREVIEW_WIDGET_ID, createMenuPreviewWidget } from './menu-preview-widget';
 import { MenuPreviewContribution } from './menu-preview-contribution';
+import { REPORT_WIDGET_ID, ReportWidgetOptions, createReportWidget } from './report-widget';
+import { ReportContribution } from './report-contribution';
 import { bindCooklangPreferences } from '../common';
 
 export default new ContainerModule(bind => {
@@ -80,6 +82,18 @@ export default new ContainerModule(bind => {
     bind(OpenHandler).toService(MenuPreviewContribution);
     bind(TabBarToolbarContribution).toService(MenuPreviewContribution);
     bind(MenuContribution).toService(MenuPreviewContribution);
+
+    // Report widget factory
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: REPORT_WIDGET_ID,
+        createWidget: (options: ReportWidgetOptions) =>
+            createReportWidget(ctx.container, options),
+    })).inSingletonScope();
+
+    // Report command and context menu
+    bind(ReportContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ReportContribution);
+    bind(MenuContribution).toService(ReportContribution);
 
     // Cooklang preferences
     bindCooklangPreferences(bind);

--- a/packages/cooklang/src/browser/menu-preview-widget.tsx
+++ b/packages/cooklang/src/browser/menu-preview-widget.tsx
@@ -12,6 +12,7 @@
 // *****************************************************************************
 
 import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { Message } from '@theia/core/shared/@lumino/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { CommandRegistry } from '@theia/core/lib/common/command';
@@ -74,15 +75,22 @@ export class MenuPreviewWidget extends ReactWidget implements Navigatable {
     protected parseErrors: string[] = [];
     protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
     protected scale = 1;
+    protected parseSequence = 0;
 
     @postConstruct()
     protected init(): void {
         this.addClass('theia-menu-preview');
+        this.node.tabIndex = 0;
         this.scrollOptions = {
             suppressScrollX: true,
             minScrollbarLength: 35,
         };
         this.listenToDocumentChanges();
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.node.focus();
     }
 
     /**
@@ -167,7 +175,11 @@ export class MenuPreviewWidget extends ReactWidget implements Navigatable {
     }
 
     protected parseContent(content: string): void {
+        const sequence = ++this.parseSequence;
         this.service.parseMenu(content, this.scale).then(json => {
+            if (this.isDisposed || sequence !== this.parseSequence) {
+                return;
+            }
             try {
                 const result: MenuParseResult = JSON.parse(json);
                 this.menuResult = result;
@@ -181,6 +193,9 @@ export class MenuPreviewWidget extends ReactWidget implements Navigatable {
             }
             this.update();
         }).catch(e => {
+            if (this.isDisposed || sequence !== this.parseSequence) {
+                return;
+            }
             this.menuResult = undefined;
             this.parseErrors = [`Parse request failed: ${e}`];
             this.update();

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -12,6 +12,7 @@
 // *****************************************************************************
 
 import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { Message } from '@theia/core/shared/@lumino/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { CommandRegistry } from '@theia/core/lib/common/command';
@@ -73,15 +74,22 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     protected recipe: Recipe | undefined;
     protected parseErrors: string[] = [];
     protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    protected parseSequence = 0;
 
     @postConstruct()
     protected init(): void {
         this.addClass('theia-recipe-preview');
+        this.node.tabIndex = 0;
         this.scrollOptions = {
             suppressScrollX: true,
             minScrollbarLength: 35,
         };
         this.listenToDocumentChanges();
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.node.focus();
     }
 
     /**
@@ -166,7 +174,11 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     }
 
     protected parseContent(content: string): void {
+        const sequence = ++this.parseSequence;
         this.service.parse(content).then(json => {
+            if (this.isDisposed || sequence !== this.parseSequence) {
+                return;
+            }
             try {
                 const result = JSON.parse(json);
                 this.recipe = result.recipe ?? undefined;
@@ -180,6 +192,9 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
             }
             this.update();
         }).catch(e => {
+            if (this.isDisposed || sequence !== this.parseSequence) {
+                return;
+            }
             this.recipe = undefined;
             this.parseErrors = [`Parse request failed: ${e}`];
             this.update();

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -14,7 +14,7 @@
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common/command';
 import { MenuModelRegistry, MenuContribution } from '@theia/core/lib/common/menu';
-import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
+import { ApplicationShell, Widget, WidgetManager } from '@theia/core/lib/browser';
 import { QuickPickService, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { nls } from '@theia/core/lib/common/nls';
@@ -123,21 +123,30 @@ export class ReportContribution implements CommandContribution, MenuContribution
     }
 
     /**
-     * Resolves the recipe URI from the current widget when it is a navigatable
-     * showing a `.cook` or `.menu` resource (recipe preview, report tab), or
-     * falls back to the active Cooklang text editor. `.cook` files open in
-     * preview mode by default, so the preview widget — not an editor — is the
-     * common context for this command.
+     * Resolves the recipe URI from the focused widget, the current main-area
+     * tab, or the active Cooklang text editor — in that order. `.cook` files
+     * open in preview mode by default, and the preview widget never takes DOM
+     * focus, so it is reported by `getCurrentWidget('main')` (tab selection)
+     * but never by `shell.currentWidget` (focus tracker).
      */
     protected getActiveCooklangUri(): URI | undefined {
-        const current = this.shell.currentWidget;
-        if (NavigatableWidget.is(current)) {
-            const uri = current.getResourceUri();
+        return this.getCooklangResourceUri(this.shell.currentWidget)
+            ?? this.getCooklangResourceUri(this.shell.getCurrentWidget('main'))
+            ?? this.getActiveCooklangEditorUri();
+    }
+
+    /**
+     * Returns the widget's resource URI when it is a navigatable showing a
+     * `.cook` or `.menu` resource (text editor, recipe preview, report tab).
+     */
+    protected getCooklangResourceUri(widget: Widget | undefined): URI | undefined {
+        if (NavigatableWidget.is(widget)) {
+            const uri = widget.getResourceUri();
             if (uri && (uri.path.ext === '.cook' || uri.path.ext === '.menu')) {
                 return uri;
             }
         }
-        return this.getActiveCooklangEditorUri();
+        return undefined;
     }
 
     /**

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -172,14 +172,9 @@ export class ReportContribution implements CommandContribution, MenuContribution
      * point (the stored labels double as stable fallbacks).
      */
     protected localizeBuiltInLabel(template: BuiltInReportTemplate): string {
-        switch (template.id) {
-            case 'builtin:ingredients':
-                return nls.localize('theia/cooklang/templateIngredients', 'Ingredients List (built-in)');
-            case 'builtin:shopping-list':
-                return nls.localize('theia/cooklang/templateShoppingList', 'Shopping List (built-in)');
-            default:
-                return template.label;
-        }
+        return template.localizationKey
+            ? nls.localize(template.localizationKey, template.label)
+            : template.label;
     }
 
     /**
@@ -226,15 +221,20 @@ export class ReportContribution implements CommandContribution, MenuContribution
         if (root) {
             config.basePath = root.resource.toString();
             const aisle = root.resource.resolve('config/aisle.conf');
-            if (await this.fileService.exists(aisle)) {
+            const pantry = root.resource.resolve('config/pantry.conf');
+            const datastore = root.resource.resolve('db');
+            const [hasAisle, hasPantry, hasDatastore] = await Promise.all([
+                this.fileService.exists(aisle),
+                this.fileService.exists(pantry),
+                this.fileService.exists(datastore),
+            ]);
+            if (hasAisle) {
                 config.aislePath = aisle.toString();
             }
-            const pantry = root.resource.resolve('config/pantry.conf');
-            if (await this.fileService.exists(pantry)) {
+            if (hasPantry) {
                 config.pantryPath = pantry.toString();
             }
-            const datastore = root.resource.resolve('db');
-            if (await this.fileService.exists(datastore)) {
+            if (hasDatastore) {
                 config.datastorePath = datastore.toString();
             }
         }

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -242,13 +242,15 @@ export class ReportContribution implements CommandContribution, MenuContribution
     }
 
     /**
-     * Returns an existing report widget for (uri, template) if open, otherwise
+     * Returns an existing report widget for (uri, template) — looked up by its
+     * widget id among the widgets created by the report factory — otherwise
      * creates one via the widget factory. A fresh `setOptions` re-render is
      * triggered on reuse so the report reflects the latest config.
      */
     protected async getOrCreateReport(options: ReportWidgetOptions): Promise<ReportWidget> {
         const widgetId = createReportWidgetId(new URI(options.uri), options.templateId);
-        const existing = this.widgetManager.tryGetWidget<ReportWidget>(widgetId);
+        const existing = this.widgetManager.getWidgets(REPORT_WIDGET_ID)
+            .find((widget): widget is ReportWidget => widget.id === widgetId);
         if (existing) {
             existing.setOptions(options);
             return existing;

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -16,7 +16,6 @@ import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/c
 import { MenuModelRegistry, MenuContribution } from '@theia/core/lib/common/menu';
 import { ApplicationShell, Widget, WidgetManager } from '@theia/core/lib/browser';
 import { QuickPickService, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
-import { MessageService } from '@theia/core/lib/common/message-service';
 import { nls } from '@theia/core/lib/common/nls';
 import { NavigatableWidget } from '@theia/core/lib/browser/navigatable-types';
 import { EditorManager, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
@@ -67,9 +66,6 @@ export class ReportContribution implements CommandContribution, MenuContribution
     @inject(QuickPickService)
     protected readonly quickPickService: QuickPickService;
 
-    @inject(MessageService)
-    protected readonly messageService: MessageService;
-
     @inject(FileService)
     protected readonly fileService: FileService;
 
@@ -93,7 +89,7 @@ export class ReportContribution implements CommandContribution, MenuContribution
     registerMenus(menus: MenuModelRegistry): void {
         menus.registerMenuAction([...EDITOR_CONTEXT_MENU, 'navigation'], {
             commandId: CooklangReportCommands.RENDER_REPORT.id,
-            when: 'resourceExtname == .cook',
+            when: 'resourceExtname == .cook || resourceExtname == .menu',
         });
     }
 
@@ -102,12 +98,6 @@ export class ReportContribution implements CommandContribution, MenuContribution
     protected async renderReport(): Promise<void> {
         const uri = this.getActiveCooklangUri();
         if (!uri) {
-            return;
-        }
-        if (uri.path.ext === '.menu') {
-            this.messageService.info(
-                nls.localize('theia/cooklang/reportMenuUnsupported', 'Reports are not supported for menu files yet.')
-            );
             return;
         }
         const template = await this.pickTemplate();

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -43,6 +43,8 @@ interface ReportTemplatePick {
     id: string;
     label: string;
     uri?: string;
+    /** Workspace-relative directory the template came from, shown in the QuickPick. */
+    description?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -166,8 +168,8 @@ export class ReportContribution implements CommandContribution, MenuContribution
     }
 
     /**
-     * Shows a QuickPick of workspace templates (config/reports/*.jinja|j2|jinja2)
-     * followed by the built-in templates.
+     * Shows a QuickPick of workspace templates (*.jinja|j2|jinja2 in template
+     * directories) followed by the built-in templates.
      */
     protected async pickTemplate(): Promise<ReportTemplatePick | undefined> {
         const workspaceTemplates = await this.findWorkspaceTemplates();
@@ -178,7 +180,7 @@ export class ReportContribution implements CommandContribution, MenuContribution
                 label: nls.localize('theia/cooklang/workspaceTemplates', 'Workspace Templates'),
             });
             for (const template of workspaceTemplates) {
-                items.push({ label: template.label, description: ReportTemplates.WORKSPACE_TEMPLATE_DIR, template });
+                items.push({ label: template.label, description: template.description, template });
             }
         }
         items.push({
@@ -206,31 +208,57 @@ export class ReportContribution implements CommandContribution, MenuContribution
     }
 
     /**
-     * Lists template files in `config/reports/` of the first workspace root.
+     * Lists template files found in the workspace's template directories
+     * (`reports`/`templates` in any case, at the root and under `config/`).
      */
     protected async findWorkspaceTemplates(): Promise<ReportTemplatePick[]> {
         const root = this.workspaceService.tryGetRoots()[0];
         if (!root) {
             return [];
         }
-        const dir = root.resource.resolve(ReportTemplates.WORKSPACE_TEMPLATE_DIR);
-        try {
-            const stat = await this.fileService.resolve(dir);
-            if (!stat.isDirectory || !stat.children) {
-                return [];
+        const picks: ReportTemplatePick[] = [];
+        for (const dir of await this.resolveTemplateDirectories(root.resource)) {
+            const relative = root.resource.relative(dir)?.toString() ?? dir.path.base;
+            try {
+                const stat = await this.fileService.resolve(dir);
+                for (const child of stat.children ?? []) {
+                    if (!child.isDirectory && ReportTemplates.isTemplateFile(child.name)) {
+                        picks.push({
+                            id: `workspace:${child.resource.toString()}`,
+                            label: child.name,
+                            uri: child.resource.toString(),
+                            description: relative,
+                        });
+                    }
+                }
+            } catch {
+                // Unreadable directory — skip it.
             }
-            return stat.children
-                .filter(child => !child.isDirectory && ReportTemplates.isTemplateFile(child.name))
-                .map(child => ({
-                    id: `workspace:${child.resource.toString()}`,
-                    label: child.name,
-                    uri: child.resource.toString(),
-                }))
-                .sort((a, b) => a.label.localeCompare(b.label));
-        } catch {
-            // Directory does not exist — no workspace templates.
-            return [];
         }
+        return picks.sort((a, b) => a.label.localeCompare(b.label));
+    }
+
+    /**
+     * Resolves the directories scanned for templates: children of the
+     * workspace root and of `config/` whose name matches a template
+     * directory name (case-insensitive).
+     */
+    protected async resolveTemplateDirectories(root: URI): Promise<URI[]> {
+        const directories: URI[] = [];
+        const scan = async (parent: URI): Promise<void> => {
+            try {
+                const stat = await this.fileService.resolve(parent);
+                for (const child of stat.children ?? []) {
+                    if (child.isDirectory && ReportTemplates.isTemplateDirName(child.name)) {
+                        directories.push(child.resource);
+                    }
+                }
+            } catch {
+                // Missing directory — nothing to scan.
+            }
+        };
+        await Promise.all([scan(root), scan(root.resolve('config'))]);
+        return directories;
     }
 
     /**
@@ -250,11 +278,11 @@ export class ReportContribution implements CommandContribution, MenuContribution
             config.basePath = root.resource.toString();
             const aisle = root.resource.resolve('config/aisle.conf');
             const pantry = root.resource.resolve('config/pantry.conf');
-            const datastore = root.resource.resolve('db');
-            const [hasAisle, hasPantry, hasDatastore] = await Promise.all([
+            const datastores = [root.resource.resolve('db'), root.resource.resolve('config/db')];
+            const [hasAisle, hasPantry, ...hasDatastores] = await Promise.all([
                 this.fileService.exists(aisle),
                 this.fileService.exists(pantry),
-                this.fileService.exists(datastore),
+                ...datastores.map(candidate => this.fileService.exists(candidate)),
             ]);
             if (hasAisle) {
                 config.aislePath = aisle.toString();
@@ -262,7 +290,8 @@ export class ReportContribution implements CommandContribution, MenuContribution
             if (hasPantry) {
                 config.pantryPath = pantry.toString();
             }
-            if (hasDatastore) {
+            const datastore = datastores.find((candidate, index) => hasDatastores[index]);
+            if (datastore) {
                 config.datastorePath = datastore.toString();
             }
         }

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -1,0 +1,258 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { CommandContribution, CommandRegistry, Command } from '@theia/core/lib/common/command';
+import { MenuModelRegistry, MenuContribution } from '@theia/core/lib/common/menu';
+import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
+import { QuickPickService, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { nls } from '@theia/core/lib/common/nls';
+import { EditorManager, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import URI from '@theia/core/lib/common/uri';
+import { COOKLANG_LANGUAGE_ID, ReportTemplates, BuiltInReportTemplate } from '../common';
+import { ReportWidget, ReportWidgetOptions, REPORT_WIDGET_ID, createReportWidgetId } from './report-widget';
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+export namespace CooklangReportCommands {
+    export const RENDER_REPORT: Command = Command.toLocalizedCommand({
+        id: 'cooklang.renderReport',
+        label: 'Cooklang: Render Report...',
+        iconClass: 'codicon codicon-output'
+    }, 'theia/cooklang/renderReport');
+}
+
+/** A template choice offered in the QuickPick. */
+interface ReportTemplatePick {
+    id: string;
+    label: string;
+    uri?: string;
+}
+
+// ---------------------------------------------------------------------------
+// ReportContribution
+// ---------------------------------------------------------------------------
+
+@injectable()
+export class ReportContribution implements CommandContribution, MenuContribution {
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
+
+    @inject(QuickPickService)
+    protected readonly quickPickService: QuickPickService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    // --- CommandContribution ---
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(CooklangReportCommands.RENDER_REPORT, {
+            execute: () => this.renderReport(),
+            isEnabled: () => this.getActiveCooklangEditorUri() !== undefined,
+        });
+    }
+
+    // --- MenuContribution ---
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerMenuAction([...EDITOR_CONTEXT_MENU, 'navigation'], {
+            commandId: CooklangReportCommands.RENDER_REPORT.id,
+            when: 'resourceExtname == .cook',
+        });
+    }
+
+    // --- Command execution ---
+
+    protected async renderReport(): Promise<void> {
+        const uri = this.getActiveCooklangEditorUri();
+        if (!uri) {
+            return;
+        }
+        if (uri.path.ext === '.menu') {
+            this.messageService.info(
+                nls.localize('theia/cooklang/reportMenuUnsupported', 'Reports are not supported for menu files yet.')
+            );
+            return;
+        }
+        const template = await this.pickTemplate();
+        if (!template) {
+            return;
+        }
+        const options: ReportWidgetOptions = {
+            uri: uri.toString(),
+            templateId: template.id,
+            templateLabel: template.label,
+            templateUri: template.uri,
+            configJson: await this.buildConfigJson(),
+        };
+        const widget = await this.getOrCreateReport(options);
+        if (!widget.isAttached) {
+            await this.shell.addWidget(widget, { area: 'main' });
+        }
+        this.shell.activateWidget(widget.id);
+    }
+
+    /**
+     * Returns the URI of the active editor when its language is Cooklang,
+     * or `undefined` otherwise.
+     */
+    protected getActiveCooklangEditorUri(): URI | undefined {
+        const editorWidget = this.editorManager.currentEditor;
+        if (!editorWidget) {
+            return undefined;
+        }
+        const { languageId, uri } = editorWidget.editor.document;
+        if (languageId !== COOKLANG_LANGUAGE_ID) {
+            return undefined;
+        }
+        return new URI(uri);
+    }
+
+    /**
+     * Shows a QuickPick of workspace templates (config/reports/*.jinja|j2|jinja2)
+     * followed by the built-in templates.
+     */
+    protected async pickTemplate(): Promise<ReportTemplatePick | undefined> {
+        const workspaceTemplates = await this.findWorkspaceTemplates();
+        const items: Array<(QuickPickItem & { template: ReportTemplatePick }) | QuickPickSeparator> = [];
+        if (workspaceTemplates.length > 0) {
+            items.push({
+                type: 'separator',
+                label: nls.localize('theia/cooklang/workspaceTemplates', 'Workspace Templates'),
+            });
+            for (const template of workspaceTemplates) {
+                items.push({ label: template.label, description: ReportTemplates.WORKSPACE_TEMPLATE_DIR, template });
+            }
+        }
+        items.push({
+            type: 'separator',
+            label: nls.localize('theia/cooklang/builtInTemplates', 'Built-in Templates'),
+        });
+        for (const builtIn of ReportTemplates.BUILT_IN) {
+            const label = this.localizeBuiltInLabel(builtIn);
+            items.push({ label, template: { id: builtIn.id, label } });
+        }
+        const picked = await this.quickPickService.show(items, {
+            placeholder: nls.localize('theia/cooklang/pickReportTemplate', 'Select a report template'),
+        });
+        return picked && 'template' in picked ? picked.template : undefined;
+    }
+
+    /**
+     * Built-in template labels are user-facing; localize them at the display
+     * point (the stored labels double as stable fallbacks).
+     */
+    protected localizeBuiltInLabel(template: BuiltInReportTemplate): string {
+        switch (template.id) {
+            case 'builtin:ingredients':
+                return nls.localize('theia/cooklang/templateIngredients', 'Ingredients List (built-in)');
+            case 'builtin:shopping-list':
+                return nls.localize('theia/cooklang/templateShoppingList', 'Shopping List (built-in)');
+            default:
+                return template.label;
+        }
+    }
+
+    /**
+     * Lists template files in `config/reports/` of the first workspace root.
+     */
+    protected async findWorkspaceTemplates(): Promise<ReportTemplatePick[]> {
+        const root = this.workspaceService.tryGetRoots()[0];
+        if (!root) {
+            return [];
+        }
+        const dir = root.resource.resolve(ReportTemplates.WORKSPACE_TEMPLATE_DIR);
+        try {
+            const stat = await this.fileService.resolve(dir);
+            if (!stat.isDirectory || !stat.children) {
+                return [];
+            }
+            return stat.children
+                .filter(child => !child.isDirectory && ReportTemplates.isTemplateFile(child.name))
+                .map(child => ({
+                    id: `workspace:${child.resource.toString()}`,
+                    label: child.name,
+                    uri: child.resource.toString(),
+                }))
+                .sort((a, b) => a.label.localeCompare(b.label));
+        } catch {
+            // Directory does not exist — no workspace templates.
+            return [];
+        }
+    }
+
+    /**
+     * Builds the render config from workspace conventions. Paths are sent as
+     * URI strings; the backend converts them to filesystem paths.
+     */
+    protected async buildConfigJson(): Promise<string> {
+        const config: {
+            scale: number;
+            basePath?: string;
+            aislePath?: string;
+            pantryPath?: string;
+            datastorePath?: string;
+        } = { scale: 1 };
+        const root = this.workspaceService.tryGetRoots()[0];
+        if (root) {
+            config.basePath = root.resource.toString();
+            const aisle = root.resource.resolve('config/aisle.conf');
+            if (await this.fileService.exists(aisle)) {
+                config.aislePath = aisle.toString();
+            }
+            const pantry = root.resource.resolve('config/pantry.conf');
+            if (await this.fileService.exists(pantry)) {
+                config.pantryPath = pantry.toString();
+            }
+            const datastore = root.resource.resolve('db');
+            if (await this.fileService.exists(datastore)) {
+                config.datastorePath = datastore.toString();
+            }
+        }
+        return JSON.stringify(config);
+    }
+
+    /**
+     * Returns an existing report widget for (uri, template) if open, otherwise
+     * creates one via the widget factory. A fresh `setOptions` re-render is
+     * triggered on reuse so the report reflects the latest config.
+     */
+    protected async getOrCreateReport(options: ReportWidgetOptions): Promise<ReportWidget> {
+        const widgetId = createReportWidgetId(new URI(options.uri), options.templateId);
+        const existing = this.widgetManager.tryGetWidget<ReportWidget>(widgetId);
+        if (existing) {
+            existing.setOptions(options);
+            return existing;
+        }
+        return this.widgetManager.getOrCreateWidget<ReportWidget>(REPORT_WIDGET_ID, options);
+    }
+}

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -18,6 +18,7 @@ import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
 import { QuickPickService, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { nls } from '@theia/core/lib/common/nls';
+import { NavigatableWidget } from '@theia/core/lib/browser/navigatable-types';
 import { EditorManager, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
@@ -77,7 +78,7 @@ export class ReportContribution implements CommandContribution, MenuContribution
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(CooklangReportCommands.RENDER_REPORT, {
             execute: () => this.renderReport(),
-            isEnabled: () => this.getActiveCooklangEditorUri() !== undefined,
+            isEnabled: () => this.getActiveCooklangUri() !== undefined,
         });
     }
 
@@ -93,7 +94,7 @@ export class ReportContribution implements CommandContribution, MenuContribution
     // --- Command execution ---
 
     protected async renderReport(): Promise<void> {
-        const uri = this.getActiveCooklangEditorUri();
+        const uri = this.getActiveCooklangUri();
         if (!uri) {
             return;
         }
@@ -119,6 +120,24 @@ export class ReportContribution implements CommandContribution, MenuContribution
             await this.shell.addWidget(widget, { area: 'main' });
         }
         this.shell.activateWidget(widget.id);
+    }
+
+    /**
+     * Resolves the recipe URI from the current widget when it is a navigatable
+     * showing a `.cook` or `.menu` resource (recipe preview, report tab), or
+     * falls back to the active Cooklang text editor. `.cook` files open in
+     * preview mode by default, so the preview widget — not an editor — is the
+     * common context for this command.
+     */
+    protected getActiveCooklangUri(): URI | undefined {
+        const current = this.shell.currentWidget;
+        if (NavigatableWidget.is(current)) {
+            const uri = current.getResourceUri();
+            if (uri && (uri.path.ext === '.cook' || uri.path.ext === '.menu')) {
+                return uri;
+            }
+        }
+        return this.getActiveCooklangEditorUri();
     }
 
     /**

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -20,6 +20,7 @@ import { MessageService } from '@theia/core/lib/common/message-service';
 import { nls } from '@theia/core/lib/common/nls';
 import { NavigatableWidget } from '@theia/core/lib/browser/navigatable-types';
 import { EditorManager, EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
+import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
@@ -71,6 +72,9 @@ export class ReportContribution implements CommandContribution, MenuContribution
 
     @inject(FileService)
     protected readonly fileService: FileService;
+
+    @inject(FileSearchService)
+    protected readonly fileSearchService: FileSearchService;
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
@@ -208,57 +212,41 @@ export class ReportContribution implements CommandContribution, MenuContribution
     }
 
     /**
-     * Lists template files found in the workspace's template directories
-     * (`reports`/`templates` in any case, at the root and under `config/`).
+     * Finds template files (*.jinja|j2|jinja2) anywhere in the workspace via
+     * the ripgrep-backed file search (respects .gitignore).
      */
     protected async findWorkspaceTemplates(): Promise<ReportTemplatePick[]> {
-        const root = this.workspaceService.tryGetRoots()[0];
-        if (!root) {
+        const roots = this.workspaceService.tryGetRoots();
+        if (roots.length === 0) {
             return [];
         }
-        const picks: ReportTemplatePick[] = [];
-        for (const dir of await this.resolveTemplateDirectories(root.resource)) {
-            const relative = root.resource.relative(dir)?.toString() ?? dir.path.base;
-            try {
-                const stat = await this.fileService.resolve(dir);
-                for (const child of stat.children ?? []) {
-                    if (!child.isDirectory && ReportTemplates.isTemplateFile(child.name)) {
-                        picks.push({
-                            id: `workspace:${child.resource.toString()}`,
-                            label: child.name,
-                            uri: child.resource.toString(),
-                            description: relative,
-                        });
-                    }
-                }
-            } catch {
-                // Unreadable directory — skip it.
-            }
+        let matches: string[];
+        try {
+            matches = await this.fileSearchService.find('', {
+                rootUris: roots.map(root => root.resource.toString()),
+                includePatterns: ReportTemplates.FILE_EXTENSIONS.map(ext => `**/*${ext}`),
+                useGitIgnore: true,
+                fuzzyMatch: false,
+                limit: 200,
+            });
+        } catch (error) {
+            console.warn('[cooklang] Report template search failed:', error);
+            return [];
         }
-        return picks.sort((a, b) => a.label.localeCompare(b.label));
-    }
-
-    /**
-     * Resolves the directories scanned for templates: children of the
-     * workspace root and of `config/` whose name matches a template
-     * directory name (case-insensitive).
-     */
-    protected async resolveTemplateDirectories(root: URI): Promise<URI[]> {
-        const directories: URI[] = [];
-        const scan = async (parent: URI): Promise<void> => {
-            try {
-                const stat = await this.fileService.resolve(parent);
-                for (const child of stat.children ?? []) {
-                    if (child.isDirectory && ReportTemplates.isTemplateDirName(child.name)) {
-                        directories.push(child.resource);
-                    }
-                }
-            } catch {
-                // Missing directory — nothing to scan.
-            }
-        };
-        await Promise.all([scan(root), scan(root.resolve('config'))]);
-        return directories;
+        return matches
+            .filter(match => ReportTemplates.isTemplateFile(match))
+            .map(match => {
+                const uri = new URI(match);
+                const root = roots.find(candidate => candidate.resource.isEqualOrParent(uri));
+                const parentDir = root ? root.resource.relative(uri.parent)?.toString() : undefined;
+                return {
+                    id: `workspace:${uri.toString()}`,
+                    label: uri.path.base,
+                    uri: uri.toString(),
+                    description: parentDir || undefined,
+                };
+            })
+            .sort((a, b) => a.label.localeCompare(b.label));
     }
 
     /**

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -12,6 +12,7 @@
 // *****************************************************************************
 
 import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { Message } from '@theia/core/shared/@lumino/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
@@ -81,21 +82,28 @@ export class ReportWidget extends ReactWidget implements Navigatable {
     @postConstruct()
     protected init(): void {
         this.addClass('theia-cooklang-report');
+        this.node.tabIndex = 0;
         this.scrollOptions = {
             suppressScrollX: true,
             minScrollbarLength: 35,
         };
         this.toDispose.push(
             this.monacoWorkspace.onDidChangeTextDocument(event => {
-                if (
-                    event.model.languageId !== COOKLANG_LANGUAGE_ID ||
-                    event.model.uri !== this.uri?.toString()
-                ) {
-                    return;
+                const changedUri = event.model.uri;
+                const isRecipeChange = changedUri === this.uri?.toString()
+                    && event.model.languageId === COOKLANG_LANGUAGE_ID;
+                const isTemplateChange = !!this.options?.templateUri
+                    && changedUri === this.options.templateUri;
+                if (isRecipeChange || isTemplateChange) {
+                    this.debouncedRender();
                 }
-                this.debouncedRender();
             })
         );
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.node.focus();
     }
 
     /**
@@ -170,6 +178,10 @@ export class ReportWidget extends ReactWidget implements Navigatable {
 
     protected async readTemplateContent(): Promise<string> {
         if (this.options.templateUri) {
+            const model = this.monacoWorkspace.getTextDocument(this.options.templateUri);
+            if (model) {
+                return model.getText();
+            }
             const content = await this.fileService.read(new URI(this.options.templateUri));
             return content.value;
         }

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -75,6 +75,7 @@ export class ReportWidget extends ReactWidget implements Navigatable {
     protected output: string | undefined;
     protected errorMessage: string | undefined;
     protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    protected renderSequence = 0;
 
     @postConstruct()
     protected init(): void {
@@ -133,17 +134,27 @@ export class ReportWidget extends ReactWidget implements Navigatable {
     }
 
     protected async renderReport(): Promise<void> {
+        const sequence = ++this.renderSequence;
+        let output: string | undefined;
+        let errorMessage: string | undefined;
         try {
             const recipe = await this.readRecipeContent();
             const template = await this.readTemplateContent();
             const resultJson = await this.service.renderReport(recipe, template, this.options.configJson);
             const result = JSON.parse(resultJson) as { output?: string; error?: string };
-            this.output = result.output;
-            this.errorMessage = result.error;
+            output = result.output;
+            errorMessage = result.error;
+            if (output === undefined && errorMessage === undefined) {
+                errorMessage = nls.localize('theia/cooklang/reportEmptyResponse', 'Report rendering returned no output.');
+            }
         } catch (error) {
-            this.output = undefined;
-            this.errorMessage = String(error);
+            errorMessage = String(error);
         }
+        if (this.isDisposed || sequence !== this.renderSequence) {
+            return;
+        }
+        this.output = output;
+        this.errorMessage = errorMessage;
         this.update();
     }
 

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -79,7 +79,7 @@ export class ReportWidget extends ReactWidget implements Navigatable {
 
     @postConstruct()
     protected init(): void {
-        this.addClass('cooklang-report');
+        this.addClass('theia-cooklang-report');
         this.scrollOptions = {
             suppressScrollX: true,
             minScrollbarLength: 35,
@@ -184,20 +184,20 @@ export class ReportWidget extends ReactWidget implements Navigatable {
     protected render(): React.ReactNode {
         if (this.errorMessage) {
             return (
-                <div className='cooklang-report-error'>
+                <div className='theia-cooklang-report-error'>
                     <strong>{nls.localize('theia/cooklang/reportError', 'Report rendering failed:')}</strong>
                     <pre>{this.errorMessage}</pre>
                 </div>
             );
         }
         if (this.output === undefined) {
-            return <div className='cooklang-report-loading'>{nls.localizeByDefault('Loading...')}</div>;
+            return <div className='theia-cooklang-report-loading'>{nls.localizeByDefault('Loading...')}</div>;
         }
         return (
             <Markdown
                 markdown={this.output}
                 markdownRenderer={this.markdownRenderer}
-                className='cooklang-report-content'
+                className='theia-cooklang-report-content'
             />
         );
     }

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -21,7 +21,8 @@ import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import URI from '@theia/core/lib/common/uri';
 import * as React from '@theia/core/shared/react';
-import { CooklangLanguageService, COOKLANG_LANGUAGE_ID, ReportTemplates } from '../common';
+import * as DOMPurify from '@theia/core/shared/dompurify';
+import { CooklangLanguageService, COOKLANG_LANGUAGE_ID, ReportOutputFormat, ReportTemplates } from '../common';
 
 import '../../src/browser/style/report.css';
 
@@ -193,13 +194,37 @@ export class ReportWidget extends ReactWidget implements Navigatable {
         if (this.output === undefined) {
             return <div className='theia-cooklang-report-loading'>{nls.localizeByDefault('Loading...')}</div>;
         }
-        return (
-            <Markdown
-                markdown={this.output}
-                markdownRenderer={this.markdownRenderer}
-                className='theia-cooklang-report-content'
-            />
-        );
+        switch (this.getOutputFormat()) {
+            case 'html':
+                return (
+                    <div
+                        className='theia-cooklang-report-content'
+                        // eslint-disable-next-line react/no-danger
+                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(this.output) }}
+                    />
+                );
+            case 'text':
+                return <pre className='theia-cooklang-report-text'>{this.output}</pre>;
+            default:
+                return (
+                    <Markdown
+                        markdown={this.output}
+                        markdownRenderer={this.markdownRenderer}
+                        className='theia-cooklang-report-content'
+                    />
+                );
+        }
+    }
+
+    /**
+     * Workspace templates declare their output format via the inner file
+     * extension (e.g. `shopping-list.yaml.jinja`); built-ins are markdown.
+     */
+    protected getOutputFormat(): ReportOutputFormat {
+        if (this.options.templateUri) {
+            return ReportTemplates.outputFormat(new URI(this.options.templateUri).path.base);
+        }
+        return 'markdown';
     }
 
     // --- Disposal ---

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -1,0 +1,224 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { Markdown } from '@theia/core/lib/browser/markdown-rendering/markdown';
+import { nls } from '@theia/core/lib/common/nls';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import URI from '@theia/core/lib/common/uri';
+import * as React from '@theia/core/shared/react';
+import { CooklangLanguageService, COOKLANG_LANGUAGE_ID, ReportTemplates } from '../common';
+
+import '../../src/browser/style/report.css';
+
+// ---------------------------------------------------------------------------
+// Public constants and helpers
+// ---------------------------------------------------------------------------
+
+export const REPORT_WIDGET_ID = 'cooklang-report-widget';
+
+export interface ReportWidgetOptions {
+    /** URI string of the source `.cook` file. */
+    uri: string;
+    /** Template id: `builtin:*` or `workspace:<template uri>`. */
+    templateId: string;
+    /** Human-readable template name for the tab title. */
+    templateLabel: string;
+    /** URI string of a workspace template file; unset for built-ins. */
+    templateUri?: string;
+    /** Render config (scale + URI-string paths), passed through to the RPC. */
+    configJson: string;
+}
+
+/**
+ * Constructs a unique widget ID for a report tab tied to a recipe + template.
+ */
+export function createReportWidgetId(uri: URI, templateId: string): string {
+    return `${REPORT_WIDGET_ID}:${templateId}:${uri.toString()}`;
+}
+
+// ---------------------------------------------------------------------------
+// ReportWidget
+// ---------------------------------------------------------------------------
+
+@injectable()
+export class ReportWidget extends ReactWidget implements Navigatable {
+
+    @inject(CooklangLanguageService)
+    protected readonly service: CooklangLanguageService;
+
+    @inject(MonacoWorkspace)
+    protected readonly monacoWorkspace: MonacoWorkspace;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(MarkdownRenderer)
+    protected readonly markdownRenderer: MarkdownRenderer;
+
+    protected uri: URI;
+    protected options: ReportWidgetOptions;
+    protected output: string | undefined;
+    protected errorMessage: string | undefined;
+    protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        this.addClass('cooklang-report');
+        this.scrollOptions = {
+            suppressScrollX: true,
+            minScrollbarLength: 35,
+        };
+        this.toDispose.push(
+            this.monacoWorkspace.onDidChangeTextDocument(event => {
+                if (
+                    event.model.languageId !== COOKLANG_LANGUAGE_ID ||
+                    event.model.uri !== this.uri?.toString()
+                ) {
+                    return;
+                }
+                this.debouncedRender();
+            })
+        );
+    }
+
+    /**
+     * Bind this widget to a recipe + template and trigger the first render.
+     */
+    setOptions(options: ReportWidgetOptions): void {
+        this.options = options;
+        this.uri = new URI(options.uri);
+        this.id = createReportWidgetId(this.uri, options.templateId);
+        this.title.label = nls.localize('theia/cooklang/reportTabTitle', 'Report: {0} ({1})', this.uri.path.base, options.templateLabel);
+        this.title.caption = this.title.label;
+        this.title.closable = true;
+        this.title.iconClass = 'codicon codicon-output';
+        this.renderReport();
+    }
+
+    // --- Navigatable ---
+
+    getResourceUri(): URI | undefined {
+        return this.uri;
+    }
+
+    createMoveToUri(resourceUri: URI): URI | undefined {
+        return resourceUri;
+    }
+
+    // --- Report rendering ---
+
+    protected debouncedRender(): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+        }
+        this.debounceTimer = setTimeout(() => {
+            this.debounceTimer = undefined;
+            this.renderReport();
+        }, 300);
+    }
+
+    protected async renderReport(): Promise<void> {
+        try {
+            const recipe = await this.readRecipeContent();
+            const template = await this.readTemplateContent();
+            const resultJson = await this.service.renderReport(recipe, template, this.options.configJson);
+            const result = JSON.parse(resultJson) as { output?: string; error?: string };
+            this.output = result.output;
+            this.errorMessage = result.error;
+        } catch (error) {
+            this.output = undefined;
+            this.errorMessage = String(error);
+        }
+        this.update();
+    }
+
+    protected async readRecipeContent(): Promise<string> {
+        const model = this.monacoWorkspace.getTextDocument(this.uri.toString());
+        if (model) {
+            return model.getText();
+        }
+        const content = await this.fileService.read(this.uri);
+        return content.value;
+    }
+
+    protected async readTemplateContent(): Promise<string> {
+        if (this.options.templateUri) {
+            const content = await this.fileService.read(new URI(this.options.templateUri));
+            return content.value;
+        }
+        const builtIn = ReportTemplates.byId(this.options.templateId);
+        if (!builtIn) {
+            throw new Error(`Unknown built-in report template: ${this.options.templateId}`);
+        }
+        return builtIn.content;
+    }
+
+    // --- Rendering ---
+
+    protected render(): React.ReactNode {
+        if (this.errorMessage) {
+            return (
+                <div className='cooklang-report-error'>
+                    <strong>{nls.localize('theia/cooklang/reportError', 'Report rendering failed:')}</strong>
+                    <pre>{this.errorMessage}</pre>
+                </div>
+            );
+        }
+        if (this.output === undefined) {
+            return <div className='cooklang-report-loading'>{nls.localizeByDefault('Loading...')}</div>;
+        }
+        return (
+            <Markdown
+                markdown={this.output}
+                markdownRenderer={this.markdownRenderer}
+                className='cooklang-report-content'
+            />
+        );
+    }
+
+    // --- Disposal ---
+
+    override dispose(): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = undefined;
+        }
+        super.dispose();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a fully initialised {@link ReportWidget} bound to `options`.
+ *
+ * Uses a child container so each report tab gets its own widget instance
+ * while inheriting all parent bindings.
+ */
+export function createReportWidget(
+    container: interfaces.Container,
+    options: ReportWidgetOptions
+): ReportWidget {
+    const child = container.createChild();
+    child.bind(ReportWidget).toSelf().inTransientScope();
+    const widget = child.get(ReportWidget);
+    widget.setOptions(options);
+    return widget;
+}

--- a/packages/cooklang/src/browser/style/report.css
+++ b/packages/cooklang/src/browser/style/report.css
@@ -14,3 +14,9 @@
     padding: 20px;
     color: var(--theia-descriptionForeground);
 }
+
+.theia-cooklang-report-text {
+    white-space: pre-wrap;
+    font-family: var(--theia-code-font-family);
+    font-size: var(--theia-code-font-size);
+}

--- a/packages/cooklang/src/browser/style/report.css
+++ b/packages/cooklang/src/browser/style/report.css
@@ -1,16 +1,16 @@
-.cooklang-report {
+.theia-cooklang-report {
     padding: 0 20px 20px 20px;
     color: var(--theia-editor-foreground);
     background: var(--theia-editor-background);
 }
 
-.cooklang-report-error pre {
+.theia-cooklang-report-error pre {
     color: var(--theia-errorForeground);
     white-space: pre-wrap;
     font-family: var(--theia-code-font-family);
 }
 
-.cooklang-report-loading {
+.theia-cooklang-report-loading {
     padding: 20px;
     color: var(--theia-descriptionForeground);
 }

--- a/packages/cooklang/src/browser/style/report.css
+++ b/packages/cooklang/src/browser/style/report.css
@@ -1,0 +1,16 @@
+.cooklang-report {
+    padding: 0 20px 20px 20px;
+    color: var(--theia-editor-foreground);
+    background: var(--theia-editor-background);
+}
+
+.cooklang-report-error pre {
+    color: var(--theia-errorForeground);
+    white-space: pre-wrap;
+    font-family: var(--theia-code-font-family);
+}
+
+.cooklang-report-loading {
+    padding: 20px;
+    color: var(--theia-descriptionForeground);
+}

--- a/packages/cooklang/src/common/cooklang-language-service.ts
+++ b/packages/cooklang/src/common/cooklang-language-service.ts
@@ -65,6 +65,18 @@ export interface CooklangLanguageService {
      * Electron-only by design; remote/virtual workspaces are not supported.
      */
     findRecipe(baseDir: string, name: string): Promise<string | undefined>;
+
+    /**
+     * Render a Jinja2 report template against a recipe (cookcli-compatible,
+     * via the cooklang-reports crate).
+     *
+     * `configJson` is a JSON object with optional `scale` (number) and
+     * optional `basePath`, `aislePath`, `pantryPath`, `datastorePath` given
+     * as **URI strings** — the backend converts them to filesystem paths.
+     *
+     * Returns JSON: `{"output": "..."}` on success or `{"error": "..."}`.
+     */
+    renderReport(recipeContent: string, templateContent: string, configJson: string): Promise<string>;
 }
 
 // Plain JSON DTOs — subsets of vscode-languageserver-protocol types

--- a/packages/cooklang/src/common/index.ts
+++ b/packages/cooklang/src/common/index.ts
@@ -20,3 +20,4 @@ export * from './recipe-types';
 export { CooklangPreferences, bindCooklangPreferences } from './cooklang-preferences';
 export * from './shopping-list-types';
 export * from './menu-types';
+export * from './report-templates';

--- a/packages/cooklang/src/common/report-templates.spec.ts
+++ b/packages/cooklang/src/common/report-templates.spec.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ReportTemplates } from './report-templates';
+
+describe('ReportTemplates', () => {
+
+    it('recognizes template files by extension, case-insensitively', () => {
+        expect(ReportTemplates.isTemplateFile('cost.jinja')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.md.jinja')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.J2')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.jinja2')).to.equal(true);
+        expect(ReportTemplates.isTemplateFile('cost.txt')).to.equal(false);
+        expect(ReportTemplates.isTemplateFile('recipe.cook')).to.equal(false);
+    });
+
+    it('resolves built-in templates by id', () => {
+        for (const template of ReportTemplates.BUILT_IN) {
+            expect(ReportTemplates.byId(template.id)).to.equal(template);
+            expect(template.content.length).to.be.greaterThan(0);
+        }
+        expect(ReportTemplates.byId('nope')).to.equal(undefined);
+    });
+});

--- a/packages/cooklang/src/common/report-templates.spec.ts
+++ b/packages/cooklang/src/common/report-templates.spec.ts
@@ -25,6 +25,14 @@ describe('ReportTemplates', () => {
         expect(ReportTemplates.isTemplateFile('recipe.cook')).to.equal(false);
     });
 
+    it('recognizes template directories by name, case-insensitively', () => {
+        expect(ReportTemplates.isTemplateDirName('reports')).to.equal(true);
+        expect(ReportTemplates.isTemplateDirName('Reports')).to.equal(true);
+        expect(ReportTemplates.isTemplateDirName('TEMPLATES')).to.equal(true);
+        expect(ReportTemplates.isTemplateDirName('config')).to.equal(false);
+        expect(ReportTemplates.isTemplateDirName('Drafts')).to.equal(false);
+    });
+
     it('resolves built-in templates by id', () => {
         for (const template of ReportTemplates.BUILT_IN) {
             expect(ReportTemplates.byId(template.id)).to.equal(template);

--- a/packages/cooklang/src/common/report-templates.spec.ts
+++ b/packages/cooklang/src/common/report-templates.spec.ts
@@ -25,12 +25,14 @@ describe('ReportTemplates', () => {
         expect(ReportTemplates.isTemplateFile('recipe.cook')).to.equal(false);
     });
 
-    it('recognizes template directories by name, case-insensitively', () => {
-        expect(ReportTemplates.isTemplateDirName('reports')).to.equal(true);
-        expect(ReportTemplates.isTemplateDirName('Reports')).to.equal(true);
-        expect(ReportTemplates.isTemplateDirName('TEMPLATES')).to.equal(true);
-        expect(ReportTemplates.isTemplateDirName('config')).to.equal(false);
-        expect(ReportTemplates.isTemplateDirName('Drafts')).to.equal(false);
+    it('derives the output format from the inner extension', () => {
+        expect(ReportTemplates.outputFormat('cost.jinja')).to.equal('markdown');
+        expect(ReportTemplates.outputFormat('cost.md.jinja')).to.equal('markdown');
+        expect(ReportTemplates.outputFormat('report.HTML.j2')).to.equal('html');
+        expect(ReportTemplates.outputFormat('page.htm.jinja2')).to.equal('html');
+        expect(ReportTemplates.outputFormat('shopping-list.yaml.jinja')).to.equal('text');
+        expect(ReportTemplates.outputFormat('data.json.jinja')).to.equal('text');
+        expect(ReportTemplates.outputFormat('notes.txt.j2')).to.equal('text');
     });
 
     it('resolves built-in templates by id', () => {

--- a/packages/cooklang/src/common/report-templates.ts
+++ b/packages/cooklang/src/common/report-templates.ts
@@ -23,24 +23,37 @@ export interface BuiltInReportTemplate {
     content: string;
 }
 
+/** How rendered report output should be displayed. */
+export type ReportOutputFormat = 'markdown' | 'html' | 'text';
+
 export namespace ReportTemplates {
 
     /** File extensions recognized as Jinja2 report templates. */
     export const FILE_EXTENSIONS: ReadonlyArray<string> = ['.jinja', '.j2', '.jinja2'];
-
-    /**
-     * Directory names (matched case-insensitively) scanned for report
-     * templates, both at the workspace root and inside `config/`.
-     */
-    export const TEMPLATE_DIR_NAMES: ReadonlyArray<string> = ['reports', 'templates'];
 
     export function isTemplateFile(fileName: string): boolean {
         const lower = fileName.toLowerCase();
         return FILE_EXTENSIONS.some(ext => lower.endsWith(ext));
     }
 
-    export function isTemplateDirName(dirName: string): boolean {
-        return TEMPLATE_DIR_NAMES.includes(dirName.toLowerCase());
+    /**
+     * Derives how report output should be displayed from the template file
+     * name's inner extension: `report.html.jinja` renders as HTML,
+     * `report.md.jinja` (or no inner extension, like the built-ins) as
+     * markdown, and anything else (`.yaml`, `.json`, `.txt`, …) as
+     * preformatted text.
+     */
+    export function outputFormat(fileName: string): ReportOutputFormat {
+        const lower = fileName.toLowerCase();
+        const templateExt = FILE_EXTENSIONS.find(ext => lower.endsWith(ext));
+        const inner = templateExt ? lower.slice(0, -templateExt.length) : lower;
+        if (inner.endsWith('.html') || inner.endsWith('.htm')) {
+            return 'html';
+        }
+        if (inner.endsWith('.md') || inner.endsWith('.markdown') || !inner.includes('.')) {
+            return 'markdown';
+        }
+        return 'text';
     }
 
     export const BUILT_IN: ReadonlyArray<BuiltInReportTemplate> = [

--- a/packages/cooklang/src/common/report-templates.ts
+++ b/packages/cooklang/src/common/report-templates.ts
@@ -18,6 +18,8 @@
 export interface BuiltInReportTemplate {
     id: string;
     label: string;
+    /** nls key used to localize `label` at display points. */
+    localizationKey?: string;
     content: string;
 }
 
@@ -38,6 +40,7 @@ export namespace ReportTemplates {
         {
             id: 'builtin:ingredients',
             label: 'Ingredients List (built-in)',
+            localizationKey: 'theia/cooklang/templateIngredients',
             content: `# {{ metadata.title | default("Ingredients") }}
 
 {% for ingredient in ingredients | sort(attribute='name') -%}
@@ -47,6 +50,7 @@ export namespace ReportTemplates {
         {
             id: 'builtin:shopping-list',
             label: 'Shopping List (built-in)',
+            localizationKey: 'theia/cooklang/templateShoppingList',
             content: `# Shopping List
 
 {% for (aisle, items) in aisled(ingredients) | items -%}

--- a/packages/cooklang/src/common/report-templates.ts
+++ b/packages/cooklang/src/common/report-templates.ts
@@ -13,7 +13,7 @@
 
 /**
  * A report template bundled with the editor, available even when the
- * workspace has no `config/reports/` directory.
+ * workspace has no template directories.
  */
 export interface BuiltInReportTemplate {
     id: string;
@@ -28,12 +28,19 @@ export namespace ReportTemplates {
     /** File extensions recognized as Jinja2 report templates. */
     export const FILE_EXTENSIONS: ReadonlyArray<string> = ['.jinja', '.j2', '.jinja2'];
 
-    /** Workspace directory scanned for report templates. */
-    export const WORKSPACE_TEMPLATE_DIR = 'config/reports';
+    /**
+     * Directory names (matched case-insensitively) scanned for report
+     * templates, both at the workspace root and inside `config/`.
+     */
+    export const TEMPLATE_DIR_NAMES: ReadonlyArray<string> = ['reports', 'templates'];
 
     export function isTemplateFile(fileName: string): boolean {
         const lower = fileName.toLowerCase();
         return FILE_EXTENSIONS.some(ext => lower.endsWith(ext));
+    }
+
+    export function isTemplateDirName(dirName: string): boolean {
+        return TEMPLATE_DIR_NAMES.includes(dirName.toLowerCase());
     }
 
     export const BUILT_IN: ReadonlyArray<BuiltInReportTemplate> = [

--- a/packages/cooklang/src/common/report-templates.ts
+++ b/packages/cooklang/src/common/report-templates.ts
@@ -1,0 +1,65 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * A report template bundled with the editor, available even when the
+ * workspace has no `config/reports/` directory.
+ */
+export interface BuiltInReportTemplate {
+    id: string;
+    label: string;
+    content: string;
+}
+
+export namespace ReportTemplates {
+
+    /** File extensions recognized as Jinja2 report templates. */
+    export const FILE_EXTENSIONS: ReadonlyArray<string> = ['.jinja', '.j2', '.jinja2'];
+
+    /** Workspace directory scanned for report templates. */
+    export const WORKSPACE_TEMPLATE_DIR = 'config/reports';
+
+    export function isTemplateFile(fileName: string): boolean {
+        const lower = fileName.toLowerCase();
+        return FILE_EXTENSIONS.some(ext => lower.endsWith(ext));
+    }
+
+    export const BUILT_IN: ReadonlyArray<BuiltInReportTemplate> = [
+        {
+            id: 'builtin:ingredients',
+            label: 'Ingredients List (built-in)',
+            content: `# {{ metadata.title | default("Ingredients") }}
+
+{% for ingredient in ingredients | sort(attribute='name') -%}
+- {{ ingredient.name }}{% if ingredient.quantity %}: {{ ingredient.quantity }}{% endif %}
+{% endfor %}`
+        },
+        {
+            id: 'builtin:shopping-list',
+            label: 'Shopping List (built-in)',
+            content: `# Shopping List
+
+{% for (aisle, items) in aisled(ingredients) | items -%}
+## {{ aisle | titleize }}
+
+{% for ingredient in items -%}
+- [ ] {{ ingredient.name }}{% if ingredient.quantity %}: {{ ingredient.quantity }}{% endif %}
+{% endfor %}
+{% endfor %}`
+        }
+    ];
+
+    export function byId(id: string): BuiltInReportTemplate | undefined {
+        return BUILT_IN.find(template => template.id === id);
+    }
+}

--- a/packages/cooklang/src/node/cooklang-language-service-impl.spec.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.spec.ts
@@ -1,0 +1,37 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { CooklangLanguageServiceImpl } from './cooklang-language-service-impl';
+
+describe('CooklangLanguageServiceImpl report config conversion', () => {
+
+    it('converts URI entries to filesystem paths', () => {
+        const impl = new CooklangLanguageServiceImpl();
+        const result = impl['convertReportConfigPaths'](JSON.stringify({
+            scale: 1,
+            basePath: 'file:///tmp/workspace',
+            aislePath: 'file:///tmp/workspace/config/aisle.conf'
+        }));
+        const config = JSON.parse(result);
+        expect(config.scale).to.equal(1);
+        expect(config.basePath).to.equal('/tmp/workspace');
+        expect(config.aislePath).to.equal('/tmp/workspace/config/aisle.conf');
+    });
+
+    it('leaves absent path entries absent', () => {
+        const impl = new CooklangLanguageServiceImpl();
+        const config = JSON.parse(impl['convertReportConfigPaths']('{"scale":2}'));
+        expect(config).to.deep.equal({ scale: 2 });
+    });
+});

--- a/packages/cooklang/src/node/cooklang-language-service-impl.spec.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.spec.ts
@@ -34,4 +34,10 @@ describe('CooklangLanguageServiceImpl report config conversion', () => {
         const config = JSON.parse(impl['convertReportConfigPaths']('{"scale":2}'));
         expect(config).to.deep.equal({ scale: 2 });
     });
+
+    it('returns the error contract for malformed config JSON', async () => {
+        const impl = new CooklangLanguageServiceImpl();
+        const result = JSON.parse(await impl.renderReport('', '', 'not json'));
+        expect(result.error).to.be.a('string').that.is.not.empty;
+    });
 });

--- a/packages/cooklang/src/node/cooklang-language-service-impl.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.ts
@@ -21,6 +21,7 @@
 // *****************************************************************************
 
 import { injectable, postConstruct } from '@theia/core/shared/inversify';
+import { FileUri } from '@theia/core/lib/common/file-uri';
 import {
     CooklangLanguageService,
     CooklangInitializeResult,
@@ -272,5 +273,30 @@ export class CooklangLanguageServiceImpl implements CooklangLanguageService {
         const native = require('@theia/cooklang-native');
         const result = native.findRecipe(baseDir, name);
         return result ?? undefined;
+    }
+
+    async renderReport(recipeContent: string, templateContent: string, configJson: string): Promise<string> {
+        try {
+            const native = require('@theia/cooklang-native');
+            return native.renderReport(recipeContent, templateContent, this.convertReportConfigPaths(configJson));
+        } catch (error) {
+            console.error('[cooklang] Failed to render report:', error);
+            return JSON.stringify({ error: String(error) });
+        }
+    }
+
+    /**
+     * The frontend sends path-like config entries as URI strings (URIs cross
+     * the wire, never raw paths); the native addon needs OS filesystem paths.
+     */
+    protected convertReportConfigPaths(configJson: string): string {
+        const config = JSON.parse(configJson) as Record<string, unknown>;
+        for (const key of ['basePath', 'aislePath', 'pantryPath', 'datastorePath']) {
+            const value = config[key];
+            if (typeof value === 'string') {
+                config[key] = FileUri.fsPath(value);
+            }
+        }
+        return JSON.stringify(config);
     }
 }

--- a/packages/cooklang/tsconfig.json
+++ b/packages/cooklang/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../core" },
     { "path": "../editor" },
+    { "path": "../file-search" },
     { "path": "../filesystem" },
     { "path": "../monaco" },
     { "path": "../navigator" },


### PR DESCRIPTION
## Summary
- New **Cooklang: Render Report…** command (palette + `.cook` editor context menu) that applies a Jinja2 report template to the open recipe and shows the result in a new main-area tab — cookcli-compatible via the `cooklang-reports` crate (same engine, filters like `db()`, `aisled()`, `excluding_pantry()`).
- Full stack: `renderReport` NAPI function in `cooklang-native` → `CooklangLanguageService.renderReport` RPC (URI→fsPath conversion on the backend) → `ReportContribution` → `ReportWidget` (live re-render on document change, stale/dispose guards).
- **Template discovery:** whole-workspace search for `*.jinja|j2|jinja2` via the ripgrep-backed `FileSearchService` (respects `.gitignore`, 200-file cap), plus 2 built-in templates; QuickPick shows each template's parent folder.
- **Output formats by inner extension:** `*.md.jinja`/extension-less → rendered markdown, `*.html.jinja` → DOMPurify-sanitized HTML, anything else (yaml/json/txt) → preformatted text.
- Works from the recipe **preview tab** (the default view) as well as source editors — target resolution checks focused widget, then current main-area tab (`shell.getCurrentWidget('main')`, since preview widgets never take DOM focus), then active editor.
- Config auto-wired from workspace conventions when present: `config/aisle.conf`, `config/pantry.conf`, `db/` or `config/db` datastore, workspace root as base path. `.menu` files show a friendly "not supported yet" message (upstream crate is recipe-only).

## Test Plan
- [x] 4 cargo tests for `render_report` (render, scale config, bad template, unparsable recipe)
- [x] 6 mocha specs (config conversion, error contract, template helpers, output-format mapping) — 18 passing total
- [x] `lerna run compile/lint --scope @theia/cooklang` clean; `app && npm run bundle` succeeds
- [x] Manually verified in the Electron app: discovery of `Reports/shopping-list.yaml.jinja`, YAML text rendering, built-ins, command from preview tab and source editor