### PR TITLE
fix(ai-chat-ui): add trailing space after inserted #file mention

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts
@@ -323,9 +323,13 @@ export class ChatViewLanguageContribution implements FrontendApplicationContribu
                         command: {
                             title: VARIABLE_ADD_CONTEXT_COMMAND.label!,
                             id: VARIABLE_ADD_CONTEXT_COMMAND.id,
+                            // Keep the raw value (no trailing space) as the context variable argument.
                             arguments: [variable.name, item.insertText]
                         },
                         ...item,
+                        // Append a trailing space to the editor insertion so the next word
+                        // the user types does not glue onto the inserted reference.
+                        insertText: `${item.insertText} `,
                     })));
                 }
             }
@@ -372,9 +376,11 @@ export class ChatViewLanguageContribution implements FrontendApplicationContribu
             return;
         }
 
+        // Append a trailing space so the next word the user types does not glue
+        // onto the inserted reference (e.g. `#file:foo.cook` + `report`).
         inputEditor.executeEdits('variable-argument-picker', [{
             range: new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column),
-            text: arg
+            text: `${arg} `
         }]);
 
         await this.chatFrontendContribution.addContextVariable(variableName, arg);


### PR DESCRIPTION
## Problem
Selecting a file for a `#file:` mention in the chat input inserted the path with **no trailing space**, so the next word the user typed glued onto the reference:

> `let's render a #file:Reports/shopping-list.yaml.jinja` + `report` → `#file:Reports/shopping-list.yaml.jinjareport`

The agent then tried to read a non-existent `…jinjareport` path.

## Fix
`packages/ai-chat-ui/src/browser/chat-view-language-contribution.ts` — append a trailing space to the **editor insertion** in both insertion paths:
- `triggerVariableArgumentPicker` (the quick-input file picker)
- `provideVariableWithArgCompletions` (inline `#file:` arg completion)

The context-variable argument keeps the raw value (no trailing space); only the text inserted into the editor gets the space. This matches the behavior of argument-less variables, which already insert with a trailing space.

## Testing
- `npx lerna run compile --scope @theia/ai-chat-ui` ✓
- `npx lerna run lint --scope @theia/ai-chat-ui` ✓
- Manual: select a file via `#` → picker, confirm a space follows the inserted `#file:<path>` and typing continues as a separate word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)