### PR TITLE
fix(cooklang): match recipe/menu file extensions case-insensitively (#50)

### DIFF
--- a/packages/cooklang/src/browser/menu-preview-contribution.ts
+++ b/packages/cooklang/src/browser/menu-preview-contribution.ts
@@ -24,7 +24,7 @@ import URI from '@theia/core/lib/common/uri';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
-import { COOKLANG_LANGUAGE_ID } from '../common';
+import { COOKLANG_LANGUAGE_ID, CooklangUri } from '../common';
 import {
     MenuPreviewWidget,
     MENU_PREVIEW_WIDGET_ID,
@@ -76,7 +76,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
     readonly label = 'Cooklang: Menu Preview';
 
     canHandle(uri: URI): number {
-        if (uri.scheme === 'file' && uri.path.ext === '.menu') {
+        if (uri.scheme === 'file' && CooklangUri.isMenu(uri)) {
             return 200;
         }
         return 0;
@@ -105,7 +105,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
         commands.registerCommand(CooklangMenuPreviewCommands.OPEN_MENU_SOURCE,
             UriAwareCommandHandler.MonoSelect(this.selectionService, {
                 execute: uri => this.editorManager.open(uri),
-                isEnabled: uri => uri.path.ext === '.menu',
+                isEnabled: uri => CooklangUri.isMenu(uri),
             })
         );
     }
@@ -122,8 +122,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
                     return true;
                 }
                 if (NavigatableWidget.is(widget)) {
-                    const uri = widget.getResourceUri();
-                    return uri !== undefined && uri.path.ext === '.menu';
+                    return CooklangUri.isMenu(widget.getResourceUri());
                 }
                 return false;
             },
@@ -179,7 +178,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
             return undefined;
         }
         const uri = new URI(editorWidget.editor.document.uri);
-        if (uri.path.ext !== '.menu') {
+        if (!CooklangUri.isMenu(uri)) {
             return undefined;
         }
         return uri;
@@ -196,7 +195,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
             }
             if (NavigatableWidget.is(args[0])) {
                 const uri = (args[0] as NavigatableWidget).getResourceUri();
-                if (uri && uri.path.ext === '.menu') {
+                if (CooklangUri.isMenu(uri)) {
                     return true;
                 }
             }
@@ -222,7 +221,7 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
             return;
         }
 
-        const uri = (NavigatableWidget.is(target) && target.getResourceUri()?.path.ext === '.menu')
+        const uri = (NavigatableWidget.is(target) && CooklangUri.isMenu(target.getResourceUri()))
             ? target.getResourceUri()!
             : this.getActiveMenuEditorUri();
         if (!uri) {
@@ -241,13 +240,13 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
     protected resolveUri(args: unknown[]): URI | undefined {
         if (args.length > 0 && args[0] instanceof URI) {
             const uri = args[0] as URI;
-            if (uri.path.ext === '.menu') {
+            if (CooklangUri.isMenu(uri)) {
                 return uri;
             }
         }
         if (args.length > 0 && NavigatableWidget.is(args[0])) {
             const uri = (args[0] as NavigatableWidget).getResourceUri();
-            if (uri && uri.path.ext === '.menu') {
+            if (CooklangUri.isMenu(uri)) {
                 return uri;
             }
         }

--- a/packages/cooklang/src/browser/recipe-preview-contribution.ts
+++ b/packages/cooklang/src/browser/recipe-preview-contribution.ts
@@ -24,7 +24,7 @@ import URI from '@theia/core/lib/common/uri';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
-import { COOKLANG_LANGUAGE_ID, CooklangPreferences } from '../common';
+import { COOKLANG_LANGUAGE_ID, CooklangPreferences, CooklangUri } from '../common';
 import {
     RecipePreviewWidget,
     RECIPE_PREVIEW_WIDGET_ID,
@@ -79,7 +79,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
     readonly label = 'Cooklang: Recipe Preview';
 
     canHandle(uri: URI): number {
-        if (uri.scheme === 'file' && uri.path.ext === '.cook' && this.preferences['cooklang.openInPreviewMode']) {
+        if (uri.scheme === 'file' && CooklangUri.isRecipe(uri) && this.preferences['cooklang.openInPreviewMode']) {
             return 200;
         }
         return 0;
@@ -108,7 +108,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
         commands.registerCommand(CooklangPreviewCommands.OPEN_SOURCE,
             UriAwareCommandHandler.MonoSelect(this.selectionService, {
                 execute: uri => this.editorManager.open(uri),
-                isEnabled: uri => uri.path.ext === '.cook',
+                isEnabled: uri => CooklangUri.isRecipe(uri),
             })
         );
     }
@@ -125,8 +125,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
                     return true;
                 }
                 if (NavigatableWidget.is(widget)) {
-                    const uri = widget.getResourceUri();
-                    return uri !== undefined && uri.path.ext === '.cook';
+                    return CooklangUri.isRecipe(widget.getResourceUri());
                 }
                 return false;
             },
@@ -198,7 +197,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
             }
             if (NavigatableWidget.is(args[0])) {
                 const uri = (args[0] as NavigatableWidget).getResourceUri();
-                if (uri && uri.path.ext === '.cook') {
+                if (CooklangUri.isRecipe(uri)) {
                     return true;
                 }
             }
@@ -225,7 +224,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
             return;
         }
 
-        const uri = (NavigatableWidget.is(target) && target.getResourceUri()?.path.ext === '.cook')
+        const uri = (NavigatableWidget.is(target) && CooklangUri.isRecipe(target.getResourceUri()))
             ? target.getResourceUri()!
             : this.getActiveCooklangEditorUri();
         if (!uri) {
@@ -244,13 +243,13 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
     protected resolveUri(args: unknown[]): URI | undefined {
         if (args.length > 0 && args[0] instanceof URI) {
             const uri = args[0] as URI;
-            if (uri.path.ext === '.cook') {
+            if (CooklangUri.isRecipe(uri)) {
                 return uri;
             }
         }
         if (args.length > 0 && NavigatableWidget.is(args[0])) {
             const uri = (args[0] as NavigatableWidget).getResourceUri();
-            if (uri && uri.path.ext === '.cook') {
+            if (CooklangUri.isRecipe(uri)) {
                 return uri;
             }
         }

--- a/packages/cooklang/src/browser/render-template-tool.ts
+++ b/packages/cooklang/src/browser/render-template-tool.ts
@@ -15,7 +15,7 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import URI from '@theia/core/lib/common/uri';
-import { CooklangLanguageService, ReportOutputFormat } from '../common';
+import { CooklangLanguageService, CooklangUri, ReportOutputFormat } from '../common';
 import { ReportConfigService } from './report-config-service';
 import { ReportPresenter } from './report-presenter';
 
@@ -121,7 +121,7 @@ export class RenderTemplateTool implements ToolProvider {
                 return this.fail('No recipe specified and no active .cook or .menu file. Pass recipeUri.');
             }
         }
-        if (recipeUri.path.ext !== '.cook' && recipeUri.path.ext !== '.menu') {
+        if (!CooklangUri.isCooklang(recipeUri)) {
             return this.fail(`recipeUri must be a .cook or .menu file, got: ${recipeUri.path.base}`);
         }
         let recipeContent: string;

--- a/packages/cooklang/src/browser/report-config-service.ts
+++ b/packages/cooklang/src/browser/report-config-service.ts
@@ -18,7 +18,7 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
-import { COOKLANG_LANGUAGE_ID } from '../common';
+import { COOKLANG_LANGUAGE_ID, CooklangUri } from '../common';
 
 /**
  * Resolves the active recipe/menu URI and assembles the render config from
@@ -61,7 +61,7 @@ export class ReportConfigService {
     protected getCooklangResourceUri(widget: Widget | undefined): URI | undefined {
         if (NavigatableWidget.is(widget)) {
             const uri = widget.getResourceUri();
-            if (uri && (uri.path.ext === '.cook' || uri.path.ext === '.menu')) {
+            if (CooklangUri.isCooklang(uri)) {
                 return uri;
             }
         }

--- a/packages/cooklang/src/browser/shopping-list-contribution.ts
+++ b/packages/cooklang/src/browser/shopping-list-contribution.ts
@@ -27,7 +27,7 @@ import URI from '@theia/core/lib/common/uri';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { ShoppingListWidget, SHOPPING_LIST_WIDGET_ID } from './shopping-list-widget';
 import { ShoppingListService } from './shopping-list-service';
-import { COOKLANG_LANGUAGE_ID } from '../common';
+import { COOKLANG_LANGUAGE_ID, CooklangUri } from '../common';
 import { CooklangLanguageService } from '../common/cooklang-language-service';
 
 // ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ export class ShoppingListContribution
         // 1. Direct URI argument (from context menu or programmatic invocation)
         if (args.length > 0 && args[0] instanceof URI) {
             const uri = args[0] as URI;
-            if (uri.path.ext === '.cook') {
+            if (CooklangUri.isRecipe(uri)) {
                 return uri;
             }
         }
@@ -153,7 +153,7 @@ export class ShoppingListContribution
         // 2. Widget argument (toolbar passes the widget as first arg)
         if (args.length > 0 && NavigatableWidget.is(args[0])) {
             const uri = (args[0] as NavigatableWidget).getResourceUri();
-            if (uri && uri.path.ext === '.cook') {
+            if (CooklangUri.isRecipe(uri)) {
                 return uri;
             }
         }
@@ -161,7 +161,7 @@ export class ShoppingListContribution
         // 3. Navigator selection (right-click context menu)
         const selection = this.selectionService.selection;
         const selectedUri = UriSelection.getUri(selection);
-        if (selectedUri && selectedUri.path.ext === '.cook') {
+        if (CooklangUri.isRecipe(selectedUri)) {
             return selectedUri;
         }
 
@@ -170,7 +170,7 @@ export class ShoppingListContribution
         const currentWidget = this.shell?.currentWidget;
         if (NavigatableWidget.is(currentWidget)) {
             const uri = currentWidget.getResourceUri();
-            if (uri && uri.path.ext === '.cook') {
+            if (CooklangUri.isRecipe(uri)) {
                 return uri;
             }
         }
@@ -222,19 +222,19 @@ export class ShoppingListContribution
     protected resolveMenuUri(args: unknown[]): URI | undefined {
         if (args.length > 0 && args[0] instanceof URI) {
             const uri = args[0] as URI;
-            if (uri.path.ext === '.menu') { return uri; }
+            if (CooklangUri.isMenu(uri)) { return uri; }
         }
         if (args.length > 0 && NavigatableWidget.is(args[0])) {
             const uri = (args[0] as NavigatableWidget).getResourceUri();
-            if (uri && uri.path.ext === '.menu') { return uri; }
+            if (CooklangUri.isMenu(uri)) { return uri; }
         }
         const selection = this.selectionService.selection;
         const selectedUri = UriSelection.getUri(selection);
-        if (selectedUri && selectedUri.path.ext === '.menu') { return selectedUri; }
+        if (CooklangUri.isMenu(selectedUri)) { return selectedUri; }
         const currentWidget = this.shell?.currentWidget;
         if (NavigatableWidget.is(currentWidget)) {
             const uri = currentWidget.getResourceUri();
-            if (uri && uri.path.ext === '.menu') { return uri; }
+            if (CooklangUri.isMenu(uri)) { return uri; }
         }
         return undefined;
     }

--- a/packages/cooklang/src/common/cooklang-uri.spec.ts
+++ b/packages/cooklang/src/common/cooklang-uri.spec.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { CooklangUri } from './cooklang-uri';
+
+describe('CooklangUri', () => {
+
+    describe('isRecipe', () => {
+        it('matches a lower-case .cook extension', () => {
+            expect(CooklangUri.isRecipe(new URI('file:///recipes/bread.cook'))).to.be.true;
+        });
+
+        // Regression: a file recognized as Cooklang by Monaco (which matches
+        // extensions case-insensitively) must also be recognized here, or the
+        // preview toolbar button silently disappears. See issue #50.
+        it('matches upper-case and mixed-case .cook extensions', () => {
+            expect(CooklangUri.isRecipe(new URI('file:///recipes/Bread.COOK'))).to.be.true;
+            expect(CooklangUri.isRecipe(new URI('file:///recipes/Bread.Cook'))).to.be.true;
+        });
+
+        it('matches names containing spaces and dashes', () => {
+            expect(CooklangUri.isRecipe(new URI('file:///r/Bread - Sourdough - White.cook'))).to.be.true;
+        });
+
+        it('rejects non-recipe extensions and undefined', () => {
+            expect(CooklangUri.isRecipe(new URI('file:///r/menu.menu'))).to.be.false;
+            expect(CooklangUri.isRecipe(new URI('file:///r/notes.txt'))).to.be.false;
+            expect(CooklangUri.isRecipe(undefined)).to.be.false;
+        });
+    });
+
+    describe('isMenu', () => {
+        it('matches .menu case-insensitively', () => {
+            expect(CooklangUri.isMenu(new URI('file:///r/dinner.menu'))).to.be.true;
+            expect(CooklangUri.isMenu(new URI('file:///r/Dinner.MENU'))).to.be.true;
+        });
+
+        it('rejects recipe and other extensions', () => {
+            expect(CooklangUri.isMenu(new URI('file:///r/bread.cook'))).to.be.false;
+            expect(CooklangUri.isMenu(undefined)).to.be.false;
+        });
+    });
+
+    describe('isCooklang', () => {
+        it('matches both recipe and menu files, any case', () => {
+            expect(CooklangUri.isCooklang(new URI('file:///r/bread.COOK'))).to.be.true;
+            expect(CooklangUri.isCooklang(new URI('file:///r/dinner.Menu'))).to.be.true;
+            expect(CooklangUri.isCooklang(new URI('file:///r/notes.md'))).to.be.false;
+        });
+    });
+});

--- a/packages/cooklang/src/common/cooklang-uri.ts
+++ b/packages/cooklang/src/common/cooklang-uri.ts
@@ -1,0 +1,54 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import URI from '@theia/core/lib/common/uri';
+
+/**
+ * Helpers for recognizing Cooklang files by their URI.
+ *
+ * The Cooklang language is associated with editors purely by file extension
+ * (`.cook` / `.menu`, registered in {@link cooklang-grammar-contribution}).
+ * Monaco matches those extensions case-insensitively, so a file named
+ * `Recipe.COOK` is highlighted and served by the language server just like
+ * `recipe.cook`. Feature gates (preview toolbar buttons, open handlers,
+ * shopping-list/report commands) must therefore match case-insensitively too —
+ * a case-sensitive `uri.path.ext === '.cook'` check silently hides the preview
+ * affordance for such files even though they are fully recognized as Cooklang.
+ */
+export namespace CooklangUri {
+
+    /** File extension for Cooklang recipe files. */
+    export const RECIPE_EXTENSION = '.cook';
+
+    /** File extension for Cooklang menu files. */
+    export const MENU_EXTENSION = '.menu';
+
+    function hasExtension(uri: URI | undefined, extension: string): boolean {
+        return uri !== undefined && uri.path.ext.toLowerCase() === extension;
+    }
+
+    /** Whether `uri` denotes a Cooklang recipe file (`.cook`, any case). */
+    export function isRecipe(uri: URI | undefined): boolean {
+        return hasExtension(uri, RECIPE_EXTENSION);
+    }
+
+    /** Whether `uri` denotes a Cooklang menu file (`.menu`, any case). */
+    export function isMenu(uri: URI | undefined): boolean {
+        return hasExtension(uri, MENU_EXTENSION);
+    }
+
+    /** Whether `uri` denotes any Cooklang file (recipe or menu). */
+    export function isCooklang(uri: URI | undefined): boolean {
+        return isRecipe(uri) || isMenu(uri);
+    }
+}

--- a/packages/cooklang/src/common/index.ts
+++ b/packages/cooklang/src/common/index.ts
@@ -16,6 +16,7 @@ export const COOKLANG_TEXTMATE_SCOPE = 'source.cooklang';
 export const AISLE_CONF_LANGUAGE_ID = 'aisle-conf';
 export const AISLE_CONF_TEXTMATE_SCOPE = 'source.aisle-conf';
 export { CooklangLanguageService, CooklangLanguageServicePath } from './cooklang-language-service';
+export { CooklangUri } from './cooklang-uri';
 export * from './recipe-types';
 export { CooklangPreferences, bindCooklangPreferences } from './cooklang-preferences';
 export * from './shopping-list-types';


### PR DESCRIPTION
## Summary

Fixes #50 — "No preview available in Cooklang Editor (Linux AppImage)".

The Cooklang language attaches to editors **purely by file extension** (`.cook` / `.menu`, registered in `cooklang-grammar-contribution` with `filenames: []`), and Monaco matches those extensions **case-insensitively**. But the preview toolbar buttons, open handlers, and shopping-list/report commands all gated on the **case-sensitive** `uri.path.ext === '.cook'`.

So a file like `Recipe.COOK` is fully syntax-highlighted and LSP-served, yet shows **no preview affordance** — the feature gate is stricter than the language association.

## Why it looked Linux-specific (but isn't)

Diffing the shipped `app.asar` bundles, the entire frontend renderer is **byte-identical** across macOS and Linux (all 386 JS files, same hashes). `Path.ext` is OS-independent, so the trigger was the reporter's file having a non-lowercase extension — not the OS. Lowercase `.cook` files (as on the maintainer's machine) were unaffected, which is why it only showed up for one reporter.

## Change

- New `CooklangUri.isRecipe` / `isMenu` / `isCooklang` helper in `common` (monaco-free, case-insensitive).
- Routed every `uri.path.ext === '.cook'`/`'.menu'` gate through it across recipe-preview, menu-preview, shopping-list, report-config, and the AI render tool.

Because the language attaches only by extension, a case-insensitive extension check is exactly as permissive as the association — the correct gate by construction.

## Testing

- New `cooklang-uri.spec.ts` (monaco-free) covering lower/upper/mixed-case extensions — 7/7 pass.
- Full `@theia/cooklang` suite: **48 passing**; `compile` and `lint` clean.

Verified at the unit + bundle-analysis level. Not yet driven in the packaged AppImage on the reporter's exact file.