### PR TITLE
feat: nutrition reports for Cook Pro users

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -70,10 +70,6 @@ jobs:
         run: npx lerna run afterInstall
 
       # cooklang-native git-depends on the private cook-md/db crates
-      # (nutrition-client/nutrition-jinja) over SSH. Load a read-only deploy key
-      # so the `--features nutrition` build can fetch them. Set DB_DEPLOY_KEY in
-      # the repo's Actions secrets (private half of a deploy key on cook-md/db).
-      # cooklang-native git-depends on the private cook-md/db crates
       # (nutrition-client/nutrition-jinja). Mint a short-lived, repo-scoped token
       # from a GitHub App (Contents: read on cook-md/db) and rewrite the ssh URL
       # to authenticated https so the `--features nutrition` build can fetch them.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,6 +69,26 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit == 'true'
         run: npx lerna run afterInstall
 
+      # cooklang-native git-depends on the private cook-md/db crates
+      # (nutrition-client/nutrition-jinja) over SSH. Load a read-only deploy key
+      # so the `--features nutrition` build can fetch them. Set DB_DEPLOY_KEY in
+      # the repo's Actions secrets (private half of a deploy key on cook-md/db).
+      - name: Authenticate to private nutrition crates (cook-md/db)
+        env:
+          DB_DEPLOY_KEY: ${{ secrets.DB_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DB_DEPLOY_KEY" > ~/.ssh/db_deploy_key
+          chmod 600 ~/.ssh/db_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<'EOF'
+          Host github.com
+            User git
+            IdentityFile ~/.ssh/db_deploy_key
+            IdentitiesOnly yes
+          EOF
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
+
       - name: Build native addon
         working-directory: packages/cooklang-native
         run: npm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -73,20 +73,27 @@ jobs:
       # (nutrition-client/nutrition-jinja) over SSH. Load a read-only deploy key
       # so the `--features nutrition` build can fetch them. Set DB_DEPLOY_KEY in
       # the repo's Actions secrets (private half of a deploy key on cook-md/db).
-      - name: Authenticate to private nutrition crates (cook-md/db)
+      # cooklang-native git-depends on the private cook-md/db crates
+      # (nutrition-client/nutrition-jinja). Mint a short-lived, repo-scoped token
+      # from a GitHub App (Contents: read on cook-md/db) and rewrite the ssh URL
+      # to authenticated https so the `--features nutrition` build can fetch them.
+      # Requires DB_APP_ID + DB_APP_PRIVATE_KEY secrets on this repo.
+      - name: Mint cook-md/db access token
+        id: db_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DB_APP_ID }}
+          private-key: ${{ secrets.DB_APP_PRIVATE_KEY }}
+          owner: cook-md
+          repositories: db
+
+      - name: Configure git for private nutrition crates
         env:
-          DB_DEPLOY_KEY: ${{ secrets.DB_DEPLOY_KEY }}
+          DB_TOKEN: ${{ steps.db_token.outputs.token }}
         run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DB_DEPLOY_KEY" > ~/.ssh/db_deploy_key
-          chmod 600 ~/.ssh/db_deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          cat >> ~/.ssh/config <<'EOF'
-          Host github.com
-            User git
-            IdentityFile ~/.ssh/db_deploy_key
-            IdentitiesOnly yes
-          EOF
+          git config --global \
+            url."https://x-access-token:${DB_TOKEN}@github.com/cook-md/db".insteadOf \
+            "ssh://git@github.com/cook-md/db"
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
 
       - name: Build native addon

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -188,6 +188,26 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-eb-
 
+      # cooklang-native git-depends on the private cook-md/db crates over SSH;
+      # load a read-only deploy key (DB_DEPLOY_KEY secret) so the
+      # `--features nutrition` build can fetch them across all targets.
+      - name: Authenticate to private nutrition crates (cook-md/db)
+        shell: bash
+        env:
+          DB_DEPLOY_KEY: ${{ secrets.DB_DEPLOY_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$DB_DEPLOY_KEY" > ~/.ssh/db_deploy_key
+          chmod 600 ~/.ssh/db_deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+          cat >> ~/.ssh/config <<'EOF'
+          Host github.com
+            User git
+            IdentityFile ~/.ssh/db_deploy_key
+            IdentitiesOnly yes
+          EOF
+          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
+
       - name: Build native addon
         working-directory: packages/cooklang-native
         shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -193,7 +193,9 @@ jobs:
         shell: bash
         run: |
           if [ -n "${{ matrix.rust_target }}" ]; then
-            npx napi build --release --platform --target ${{ matrix.rust_target }}
+            # Keep --features nutrition in sync with `npm run build` (package.json);
+            # the cross-target path bypasses that script, so set the flag here too.
+            npx napi build --release --platform --target ${{ matrix.rust_target }} --features nutrition
           else
             npm run build
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -188,24 +188,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-eb-
 
-      # cooklang-native git-depends on the private cook-md/db crates over SSH;
-      # load a read-only deploy key (DB_DEPLOY_KEY secret) so the
+      # cooklang-native git-depends on the private cook-md/db crates. Mint a
+      # short-lived, repo-scoped GitHub App token (Contents: read on cook-md/db)
+      # and rewrite the ssh URL to authenticated https so the
       # `--features nutrition` build can fetch them across all targets.
-      - name: Authenticate to private nutrition crates (cook-md/db)
+      # Requires DB_APP_ID + DB_APP_PRIVATE_KEY secrets on this repo.
+      - name: Mint cook-md/db access token
+        id: db_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DB_APP_ID }}
+          private-key: ${{ secrets.DB_APP_PRIVATE_KEY }}
+          owner: cook-md
+          repositories: db
+
+      - name: Configure git for private nutrition crates
         shell: bash
         env:
-          DB_DEPLOY_KEY: ${{ secrets.DB_DEPLOY_KEY }}
+          DB_TOKEN: ${{ steps.db_token.outputs.token }}
         run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "$DB_DEPLOY_KEY" > ~/.ssh/db_deploy_key
-          chmod 600 ~/.ssh/db_deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
-          cat >> ~/.ssh/config <<'EOF'
-          Host github.com
-            User git
-            IdentityFile ~/.ssh/db_deploy_key
-            IdentitiesOnly yes
-          EOF
+          git config --global \
+            url."https://x-access-token:${DB_TOKEN}@github.com/cook-md/db".insteadOf \
+            "ssh://git@github.com/cook-md/db"
           echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
 
       - name: Build native addon

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,11 @@ This is an **Electron-only** application. There is no browser target. Only `app/
 - `npx lerna run compile --scope @theia/cooklang` - Compile the Cooklang extension
 - `cd packages/cooklang-native && cargo build` - Build the NAPI-RS native addon (Rust)
 - `cd packages/cooklang-native && npm run build` - Build native addon for Node.js (requires @napi-rs/cli)
+  - The `build`/`build:debug` scripts compile with `--features nutrition`, which
+    git-depends on the private `cook-md/db` crates over SSH. Building the addon
+    therefore requires read access to `cook-md/db` (CI mints a GitHub App token;
+    locally use your own SSH access). A plain `cargo build` with no feature flag
+    builds without nutrition and needs no `cook-md/db` access.
 
 **Package-specific (using lerna):**
 - `npx lerna run compile --scope @theia/package-name` - Build specific package

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "app": {
       "name": "@cook-md/editor-app",
-      "version": "0.1.0-alpha.23",
+      "version": "0.1.0-alpha.24",
       "license": "(EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/ai-chat": "1.70.0",
@@ -28025,6 +28025,7 @@
       "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/ai-core": "1.70.0",
+        "@theia/cooklang-account": "1.70.0",
         "@theia/cooklang-native": "0.1.0",
         "@theia/core": "1.70.0",
         "@theia/editor": "1.70.0",

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -446,6 +446,8 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
+ "nutrition-client",
+ "nutrition-jinja",
  "serde",
  "serde_json",
  "tokio",
@@ -1705,6 +1707,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nutrition-client"
+version = "0.1.0"
+source = "git+ssh://git@github.com/cook-md/db?rev=82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6#82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "nutrition-jinja"
+version = "0.1.0"
+source = "git+ssh://git@github.com/cook-md/db?rev=82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6#82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6"
+dependencies = [
+ "cooklang",
+ "cooklang-reports",
+ "minijinja",
+ "nutrition-client",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2033,6 +2062,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "nutrition-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6#82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6"
+source = "git+ssh://git@github.com/cook-md/db?rev=aeabf6af121c483a866f8e8f536a7a0e397ccb3d#aeabf6af121c483a866f8e8f536a7a0e397ccb3d"
 dependencies = [
  "reqwest",
  "serde",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "nutrition-jinja"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6#82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6"
+source = "git+ssh://git@github.com/cook-md/db?rev=aeabf6af121c483a866f8e8f536a7a0e397ccb3d#aeabf6af121c483a866f8e8f536a7a0e397ccb3d"
 dependencies = [
  "cooklang",
  "cooklang-reports",

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -20,6 +20,11 @@ tokio = { version = "1", features = ["full"] }
 cooklang-language-server = { path = "../../../cooklang-language-server" }
 cooklang-sync-client = "0.5"
 chrono = "0.4"
+nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6", optional = true }
+nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6", optional = true }
+
+[features]
+nutrition = ["dep:nutrition-client", "dep:nutrition-jinja"]
 
 [build-dependencies]
 napi-build = "2"

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -20,8 +20,8 @@ tokio = { version = "1", features = ["full"] }
 cooklang-language-server = { path = "../../../cooklang-language-server" }
 cooklang-sync-client = "0.5"
 chrono = "0.4"
-nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6", optional = true }
-nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "82eb404cd9c45fadb5bb998cb55d6fb4a44b2da6", optional = true }
+nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "aeabf6af121c483a866f8e8f536a7a0e397ccb3d", optional = true }
+nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "aeabf6af121c483a866f8e8f536a7a0e397ccb3d", optional = true }
 
 [features]
 nutrition = ["dep:nutrition-client", "dep:nutrition-jinja"]

--- a/packages/cooklang-native/package.json
+++ b/packages/cooklang-native/package.json
@@ -15,8 +15,8 @@
   },
   "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
   "scripts": {
-    "build": "napi build --release --platform",
-    "build:debug": "napi build --platform"
+    "build": "napi build --release --platform --features nutrition",
+    "build:debug": "napi build --platform --features nutrition"
   },
   "devDependencies": {
     "@napi-rs/cli": "^2.18.0"

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -911,6 +911,10 @@ struct ReportConfig {
     aisle_path: Option<String>,
     pantry_path: Option<String>,
     datastore_path: Option<String>,
+    // Consumed only under `cfg(feature = "nutrition")`; always deserialized so
+    // the TS layer sends an identical config shape regardless of build features.
+    nutrition_api_url: Option<String>,
+    nutrition_token: Option<String>,
 }
 
 /// Render a Jinja2 report template against a recipe via cooklang-reports
@@ -935,6 +939,18 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
         builder.datastore_path(p);
     }
     let config = builder.build();
+    #[cfg(feature = "nutrition")]
+    let config = match cfg.nutrition_api_url {
+        Some(url) => {
+            let mut client = nutrition_client::Client::new(url);
+            if let Some(tok) = cfg.nutrition_token.filter(|t| !t.is_empty()) {
+                client = client.with_auth_token(tok);
+            }
+            let ext = nutrition_jinja::NutritionExtension::new(std::sync::Arc::new(client));
+            config.with_extension(ext)
+        }
+        None => config,
+    };
     match cooklang_reports::render_template_with_config(&recipe, &template, &config) {
         Ok(output) => serde_json::json!({ "output": output }).to_string(),
         Err(err) => serde_json::json!({ "error": err.format_with_source() }).to_string(),
@@ -976,5 +992,35 @@ mod render_report_tests {
         let result = super::render_report(garbage.into(), "{{ scale }}".into(), "{}".into());
         let v: serde_json::Value = serde_json::from_str(&result).expect("must return valid JSON");
         assert!(v.get("output").is_some() || v.get("error").is_some());
+    }
+}
+
+#[cfg(test)]
+mod nutrition_wiring_tests {
+    // A template that calls nutrition_for. When the nutrition feature is OFF the
+    // function is unregistered (render errors with "unknown"); when ON the
+    // extension is registered and attempts a call to the configured URL.
+    const NUTRITION_TEMPLATE: &str =
+        "{{ nutrition_for(ingredient='salmon', amount=100, unit='g').kcal }}";
+    const RECIPE: &str = "Add @salmon{100%g}.";
+
+    #[cfg(not(feature = "nutrition"))]
+    #[test]
+    fn feature_off_nutrition_for_is_unregistered() {
+        let cfg = r#"{"nutritionApiUrl":"http://127.0.0.1:9"}"#;
+        let out = super::render_report(RECIPE.into(), NUTRITION_TEMPLATE.into(), cfg.into());
+        assert!(out.contains("\"error\""), "expected an error payload, got: {out}");
+        assert!(out.contains("nutrition_for"), "error should mention the unknown function: {out}");
+    }
+
+    #[cfg(feature = "nutrition")]
+    #[test]
+    fn feature_on_registers_extension_and_attempts_call() {
+        // Point at a closed port so the call fails fast with a transport error,
+        // proving the extension was registered and invoked.
+        let cfg = r#"{"nutritionApiUrl":"http://127.0.0.1:9","nutritionToken":"tok"}"#;
+        let out = super::render_report(RECIPE.into(), NUTRITION_TEMPLATE.into(), cfg.into());
+        assert!(out.contains("\"error\""), "expected an error payload, got: {out}");
+        assert!(!out.contains("unknown"), "function should be registered: {out}");
     }
 }

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -923,7 +923,13 @@ struct ReportConfig {
 /// Returns JSON: `{"output": "..."}` on success or `{"error": "..."}` on failure.
 #[napi]
 pub fn render_report(recipe: String, template: String, config_json: String) -> String {
-    let cfg: ReportConfig = serde_json::from_str(&config_json).unwrap_or_default();
+    // A malformed config silently degrades to defaults (no base path, no
+    // nutrition wiring); log it so a bad config surfaces in the addon's stderr
+    // rather than as a confusing downstream "extension not registered" error.
+    let cfg: ReportConfig = serde_json::from_str(&config_json).unwrap_or_else(|e| {
+        eprintln!("[cooklang-native] invalid report config JSON, using defaults: {e}");
+        ReportConfig::default()
+    });
     let mut builder = cooklang_reports::config::Config::builder();
     builder.scale(cfg.scale.unwrap_or(1.0));
     if let Some(p) = cfg.base_path {

--- a/packages/cooklang/package.json
+++ b/packages/cooklang/package.json
@@ -12,6 +12,7 @@
     "@theia/monaco-editor-core": "1.108.201",
     "@theia/navigator": "1.70.0",
     "@theia/cooklang-native": "0.1.0",
+    "@theia/cooklang-account": "1.70.0",
     "@theia/workspace": "1.70.0",
     "tslib": "^2.6.2"
   },

--- a/packages/cooklang/src/browser/report-config-service.spec.ts
+++ b/packages/cooklang/src/browser/report-config-service.spec.ts
@@ -50,27 +50,37 @@ class FakeWorkspaceService {
     }
 }
 
-function createService(root: URI | undefined, existing: string[] = []): {
+function createService(root: URI | undefined, existing: string[] = [], opts: {
+    serviceUrl?: string;
+    getToken?: () => Promise<string | undefined>;
+} = {}): {
     service: ReportConfigService;
     fileService: FakeFileService;
 } {
     const fileService = new FakeFileService();
     existing.forEach(p => fileService.existing.add(p));
     const service = new ReportConfigService();
-    // Property injection — assign the fakes the service actually uses.
     /* eslint-disable @typescript-eslint/no-explicit-any */
     (service as any).fileService = fileService;
     (service as any).workspaceService = new FakeWorkspaceService(root);
+    (service as any).preferences = {
+        get: (_key: string, fallback?: string) => opts.serviceUrl ?? fallback,
+    };
+    (service as any).authService = { getToken: opts.getToken ?? (async () => 'tok-123') };
     /* eslint-enable @typescript-eslint/no-explicit-any */
     return { service, fileService };
 }
 
 describe('ReportConfigService#buildConfigJson', () => {
 
-    it('returns only the scale when there is no workspace root', async () => {
+    it('returns scale + nutrition fields when there is no workspace root', async () => {
         const { service } = createService(undefined);
         const config = JSON.parse(await service.buildConfigJson());
-        expect(config).to.deep.equal({ scale: 1 });
+        expect(config).to.deep.equal({
+            scale: 1,
+            nutritionApiUrl: 'https://nutrition.cook.md',
+            nutritionToken: 'tok-123',
+        });
     });
 
     it('respects the scale argument', async () => {
@@ -108,6 +118,30 @@ describe('ReportConfigService#buildConfigJson', () => {
         const { service } = createService(root, [db, configDb]);
         const config = JSON.parse(await service.buildConfigJson());
         expect(config.datastorePath).to.equal(db);
+    });
+
+    it('uses the configured nutrition service URL', async () => {
+        const { service } = createService(undefined, [], { serviceUrl: 'http://127.0.0.1:8080' });
+        const config = JSON.parse(await service.buildConfigJson());
+        expect(config.nutritionApiUrl).to.equal('http://127.0.0.1:8080');
+    });
+
+    it('plumbs the auth token from AuthService', async () => {
+        const { service } = createService(undefined, [], { getToken: async () => 'jwt-xyz' });
+        const config = JSON.parse(await service.buildConfigJson());
+        expect(config.nutritionToken).to.equal('jwt-xyz');
+    });
+
+    it('sends an empty token when logged out (getToken returns undefined)', async () => {
+        const { service } = createService(undefined, [], { getToken: async () => undefined });
+        const config = JSON.parse(await service.buildConfigJson());
+        expect(config.nutritionToken).to.equal('');
+    });
+
+    it('sends an empty token when getToken rejects', async () => {
+        const { service } = createService(undefined, [], { getToken: async () => { throw new Error('no session'); } });
+        const config = JSON.parse(await service.buildConfigJson());
+        expect(config.nutritionToken).to.equal('');
     });
 });
 

--- a/packages/cooklang/src/browser/report-config-service.ts
+++ b/packages/cooklang/src/browser/report-config-service.ts
@@ -18,7 +18,11 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
+import { PreferenceService } from '@theia/core/lib/common/preferences';
+import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { COOKLANG_LANGUAGE_ID, CooklangUri } from '../common';
+
+const DEFAULT_NUTRITION_SERVICE_URL = 'https://nutrition.cook.md';
 
 /**
  * Resolves the active recipe/menu URI and assembles the render config from
@@ -40,6 +44,12 @@ export class ReportConfigService {
 
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
+
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    @inject(AuthService)
+    protected readonly authService: AuthService;
 
     /**
      * Resolves the recipe URI from the focused widget, the current main-area
@@ -115,7 +125,19 @@ export class ReportConfigService {
             aislePath?: string;
             pantryPath?: string;
             datastorePath?: string;
-        } = { scale };
+            nutritionApiUrl: string;
+            nutritionToken: string;
+        } = {
+            scale,
+            nutritionApiUrl: this.preferences.get<string>('cooklang.nutrition.serviceUrl', DEFAULT_NUTRITION_SERVICE_URL),
+            nutritionToken: '',
+        };
+        try {
+            config.nutritionToken = (await this.authService.getToken()) ?? '';
+        } catch (err) {
+            console.debug('[cooklang] nutrition token unavailable (logged out?):', err);
+            config.nutritionToken = '';
+        }
         const root = this.workspaceService.tryGetRoots()[0];
         if (root) {
             config.basePath = root.resource.toString();

--- a/packages/cooklang/src/common/cooklang-preferences.ts
+++ b/packages/cooklang/src/common/cooklang-preferences.ts
@@ -26,12 +26,18 @@ export const cooklangPreferencesSchema: PreferenceSchema = {
             'type': 'boolean',
             'description': 'Open .cook files in preview mode by default.',
             'default': true
+        },
+        'cooklang.nutrition.serviceUrl': {
+            'type': 'string',
+            'description': 'Base URL of the Cooklang nutrition service used by report templates.',
+            'default': 'https://nutrition.cook.md'
         }
     }
 };
 
 export interface CooklangConfiguration {
     'cooklang.openInPreviewMode': boolean;
+    'cooklang.nutrition.serviceUrl': string;
 }
 
 export const CooklangPreferenceContribution = Symbol('CooklangPreferenceContribution');


### PR DESCRIPTION
## Summary
Activates the Phase-1 nutrition gate for editor users: report templates can call `nutrition_for()` / `compare()`, backed by the deployed nutrition service using the signed-in user's cook.md token. Non-subscribers get a clear per-call error. cook.md is untouched (reuses `/api/subscription`).

- **cooklang-native** (Rust napi): optional `nutrition` Cargo feature (off by default, **on in CI/release**) with a git dep on the private `cook-md/db` crates; `render_report` registers `NutritionExtension(Client::new(url).with_auth_token(token))` when the feature is compiled in and a URL is supplied.
- **cooklang TS**: new `cooklang.nutrition.serviceUrl` preference (default `https://nutrition.cook.md`); `ReportConfigService.buildConfigJson` injects `nutritionApiUrl` (preference) + `nutritionToken` (`AuthService.getToken()`, empty when logged out) into the config the addon already receives.
- **release CI**: cross-target native-addon build now also passes `--features nutrition` (host build already did via `npm run build`).

Depends on **cook-md/db#26** (the client error-mapping change). The git dep is currently pinned to that PR's branch commit; it will be re-pinned to the merged db `main` SHA before this merges.

Spec/plan live in the db repo (`docs/superpowers/{specs,plans}/2026-06-26-editor-nutrition-integration*`).

## Test Plan
- [x] `cargo test` and `cargo test --features nutrition` in `packages/cooklang-native` (16 each); `cargo clippy --all-targets` clean both ways
- [x] `npm test` in `packages/cooklang` (52 passing); `npm run compile` + `npm run lint` clean
- [x] Feature-on test confirms the extension registers + invokes; feature-off leaves `nutrition_for` unregistered
- [ ] Re-pin git dep to merged db `main` SHA (after cook-md/db#26 merges)
- [ ] Manual smoke: render a `nutrition_for` template with a subscribed vs unsubscribed token

🤖 Generated with [Claude Code](https://claude.com/claude-code)