### PR TITLE
feat(cooklang): render mermaid diagrams in jinja reports

### DIFF
--- a/docs/superpowers/plans/2026-06-30-mermaid-in-jinja-reports.md
+++ b/docs/superpowers/plans/2026-06-30-mermaid-in-jinja-reports.md
@@ -1,0 +1,649 @@
+# Mermaid Diagrams in Jinja Reports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render Mermaid diagrams embedded as ` ```mermaid ` fenced code blocks inside markdown-format Jinja reports, both in the live report widget and in exported PDF/PNG/print output.
+
+**Architecture:** Let Theia's `MarkdownRenderer` produce its normal DOM (a mermaid fence becomes `<pre><code class="language-mermaid">`). A dedicated `MermaidRenderer` service then does a post-render DOM pass to replace each mermaid block with a rendered SVG, using a lazily imported `mermaid` library themed to match the editor. The export path re-renders the stored diagram sources in mermaid's light theme so printed output stays legible on white paper.
+
+**Tech Stack:** TypeScript, React 18, Theia (`MarkdownRenderer`, `Markdown` component, `ThemeService`, InversifyJS), `mermaid` (lazy dynamic import), mocha + chai + jsdom for tests.
+
+---
+
+## File Structure
+
+- **Create** `packages/cooklang/src/browser/mermaid-renderer.ts` — the `MermaidRenderer` service plus pure helpers (`themeTypeToMermaidTheme`, `findMermaidBlocks`, `extractMermaidSource`). Must NOT import `@theia/monaco` (keeps the spec runnable; see project memory `feedback_spec_monaco_css_harness`).
+- **Create** `packages/cooklang/src/browser/mermaid-renderer.spec.ts` — unit tests for the pure helpers (jsdom for the DOM helpers).
+- **Modify** `packages/cooklang/src/browser/report-widget.tsx` — inject `MermaidRenderer` + `ThemeService`, run the post-render pass via the `Markdown` `onRender` callback, re-theme on theme change, make `getExportDocument` async.
+- **Modify** `packages/cooklang/src/browser/cooklang-frontend-module.ts` (or wherever browser services are bound) — bind `MermaidRenderer` in singleton scope.
+- **Modify** `packages/cooklang/src/browser/report-export-contribution.ts` — `await` the now-async `getExportDocument` at its 3 call sites.
+- **Modify** `packages/cooklang/src/browser/report-export-document.ts` — add `.theia-cooklang-mermaid` rules to `REPORT_EXPORT_CSS`.
+- **Modify** `packages/cooklang/src/browser/style/report.css` — add on-screen `.theia-cooklang-mermaid` rules.
+- **Modify** `packages/cooklang/package.json` — add `mermaid` dependency.
+
+---
+
+## Task 1: Add the mermaid dependency
+
+**Files:**
+- Modify: `packages/cooklang/package.json`
+
+- [ ] **Step 1: Add the dependency**
+
+In `packages/cooklang/package.json`, add `mermaid` to the `dependencies` object (keep alphabetical-ish grouping with the other non-`@theia` deps near `tslib`):
+
+```json
+    "@theia/workspace": "1.70.0",
+    "mermaid": "^11.4.0",
+    "tslib": "^2.6.2"
+```
+
+- [ ] **Step 2: Install**
+
+Run: `npm install`
+Expected: completes without error; `node_modules/mermaid/package.json` now exists.
+
+- [ ] **Step 3: Verify install**
+
+Run: `node -e "console.log(require('mermaid/package.json').version)"`
+Expected: prints an `11.x` version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang/package.json package-lock.json
+git commit -m "build(cooklang): add mermaid dependency for report diagrams"
+```
+
+---
+
+## Task 2: Pure helpers in `mermaid-renderer.ts` (TDD)
+
+This task creates the file with ONLY the pure/DOM helper functions and their tests. The `MermaidRenderer` class is added in Task 3.
+
+**Files:**
+- Create: `packages/cooklang/src/browser/mermaid-renderer.ts`
+- Test: `packages/cooklang/src/browser/mermaid-renderer.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/browser/mermaid-renderer.spec.ts`:
+
+```ts
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+// The DOM helpers need `document`; set up jsdom before importing the module.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { themeTypeToMermaidTheme, findMermaidBlocks, extractMermaidSource } from './mermaid-renderer';
+
+after(() => disableJSDOM());
+
+describe('mermaid-renderer helpers', () => {
+
+    it('maps theme types to mermaid themes', () => {
+        expect(themeTypeToMermaidTheme('dark')).to.equal('dark');
+        expect(themeTypeToMermaidTheme('hc')).to.equal('dark');
+        expect(themeTypeToMermaidTheme('light')).to.equal('default');
+        expect(themeTypeToMermaidTheme('hcLight')).to.equal('default');
+    });
+
+    function container(html: string): HTMLElement {
+        const node = document.createElement('div');
+        node.innerHTML = html;
+        return node;
+    }
+
+    it('finds <pre> blocks that wrap a mermaid code fence', () => {
+        const node = container(
+            '<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>' +
+            '<pre><code class="language-js">const x = 1;</code></pre>' +
+            '<p>text</p>'
+        );
+        const blocks = findMermaidBlocks(node);
+        expect(blocks).to.have.lengthOf(1);
+        expect(blocks[0].tagName).to.equal('PRE');
+    });
+
+    it('returns an empty array when there are no mermaid blocks', () => {
+        const node = container('<pre><code class="language-js">x</code></pre><p>none</p>');
+        expect(findMermaidBlocks(node)).to.have.lengthOf(0);
+    });
+
+    it('extracts the diagram source text from a block', () => {
+        const node = container('<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>');
+        const [block] = findMermaidBlocks(node);
+        expect(extractMermaidSource(block)).to.equal('graph TD; A-->B;');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx lerna run compile --scope @theia/cooklang` then `npx lerna run test --scope @theia/cooklang`
+Expected: FAIL — `mermaid-renderer` module / exports not found (compile error or import failure).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `packages/cooklang/src/browser/mermaid-renderer.ts`:
+
+```ts
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { ThemeType } from '@theia/core/lib/common/theme';
+
+/** The subset of mermaid built-in themes this feature uses. */
+export type MermaidTheme = 'default' | 'dark';
+
+/** CSS selector for a mermaid code fence produced by the markdown renderer. */
+export const MERMAID_CODE_SELECTOR = 'code.language-mermaid';
+
+/** Map a Theia theme type to the mermaid theme used for live rendering. */
+export function themeTypeToMermaidTheme(type: ThemeType): MermaidTheme {
+    return (type === 'dark' || type === 'hc') ? 'dark' : 'default';
+}
+
+/**
+ * Find the `<pre>` blocks inside `container` that wrap a mermaid code fence.
+ * Returns the enclosing `<pre>` elements (the nodes we replace with an SVG).
+ */
+export function findMermaidBlocks(container: HTMLElement): HTMLElement[] {
+    const blocks: HTMLElement[] = [];
+    container.querySelectorAll(MERMAID_CODE_SELECTOR).forEach(code => {
+        const pre = code.closest('pre');
+        if (pre instanceof HTMLElement) {
+            blocks.push(pre);
+        }
+    });
+    return blocks;
+}
+
+/** Extract the raw diagram source from a mermaid `<pre>` block. */
+export function extractMermaidSource(block: HTMLElement): string {
+    const code = block.querySelector(MERMAID_CODE_SELECTOR);
+    return (code?.textContent ?? block.textContent ?? '').trim();
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx lerna run compile --scope @theia/cooklang` then `npx lerna run test --scope @theia/cooklang`
+Expected: PASS — all four assertions in `mermaid-renderer helpers` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang/src/browser/mermaid-renderer.ts packages/cooklang/src/browser/mermaid-renderer.spec.ts
+git commit -m "feat(cooklang): add mermaid block detection helpers"
+```
+
+---
+
+## Task 3: `MermaidRenderer` service (lazy load + DOM rendering)
+
+Adds the injectable service to the existing `mermaid-renderer.ts`. Mermaid's actual SVG output depends on a real browser layout engine, so this logic is verified manually (Task 7) rather than via jsdom unit tests; the DOM-structure helpers are already covered in Task 2.
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/mermaid-renderer.ts`
+
+- [ ] **Step 1: Add the service implementation**
+
+Append to `packages/cooklang/src/browser/mermaid-renderer.ts` (and add the `injectable` import at the top):
+
+```ts
+import { injectable } from '@theia/core/shared/inversify';
+```
+
+```ts
+type MermaidModule = typeof import('mermaid');
+
+/**
+ * Renders mermaid diagrams that appear as fenced code blocks in rendered
+ * markdown reports. The `mermaid` library is imported lazily the first time a
+ * diagram is encountered, so reports without diagrams pay no cost.
+ */
+@injectable()
+export class MermaidRenderer {
+
+    protected mermaidPromise: Promise<MermaidModule> | undefined;
+    protected idCounter = 0;
+
+    /** Lazily import and memoize the mermaid module. */
+    protected load(): Promise<MermaidModule> {
+        if (!this.mermaidPromise) {
+            this.mermaidPromise = import('mermaid');
+        }
+        return this.mermaidPromise;
+    }
+
+    protected nextId(): string {
+        return `cooklang-mermaid-${++this.idCounter}`;
+    }
+
+    /**
+     * Replace every mermaid code block in `container` with a rendered SVG.
+     * Each block is rendered independently: a failing diagram is replaced with
+     * an inline error node and does not abort the remaining diagrams. If the
+     * mermaid module fails to load, the raw code blocks are left untouched.
+     */
+    async renderInto(container: HTMLElement, theme: MermaidTheme): Promise<void> {
+        const blocks = findMermaidBlocks(container);
+        if (blocks.length === 0) {
+            return;
+        }
+        let mermaid: MermaidModule['default'];
+        try {
+            mermaid = (await this.load()).default;
+        } catch (error) {
+            console.error('Failed to load mermaid; leaving diagram source as-is.', error);
+            return;
+        }
+        mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+        for (const block of blocks) {
+            const source = extractMermaidSource(block);
+            const wrapper = container.ownerDocument.createElement('div');
+            wrapper.className = 'theia-cooklang-mermaid';
+            wrapper.setAttribute('data-mermaid-src', source);
+            try {
+                const { svg } = await mermaid.render(this.nextId(), source);
+                wrapper.innerHTML = svg;
+            } catch (error) {
+                wrapper.classList.add('theia-cooklang-mermaid-error');
+                wrapper.textContent = String(error instanceof Error ? error.message : error);
+            }
+            block.replaceWith(wrapper);
+        }
+    }
+
+    /**
+     * Re-render diagrams in a (cloned) export container using the given theme.
+     * Operates on `.theia-cooklang-mermaid[data-mermaid-src]` wrappers produced
+     * by {@link renderInto}, so already-rendered live diagrams can be recolored
+     * for print without re-reading the markdown.
+     */
+    async renderExport(container: HTMLElement, theme: MermaidTheme): Promise<void> {
+        const wrappers = Array.from(
+            container.querySelectorAll<HTMLElement>('.theia-cooklang-mermaid[data-mermaid-src]')
+        );
+        if (wrappers.length === 0) {
+            return;
+        }
+        let mermaid: MermaidModule['default'];
+        try {
+            mermaid = (await this.load()).default;
+        } catch (error) {
+            console.error('Failed to load mermaid for export.', error);
+            return;
+        }
+        mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+        for (const wrapper of wrappers) {
+            const source = wrapper.getAttribute('data-mermaid-src') ?? '';
+            try {
+                const { svg } = await mermaid.render(this.nextId(), source);
+                wrapper.innerHTML = svg;
+                wrapper.classList.remove('theia-cooklang-mermaid-error');
+            } catch {
+                // Keep whatever was already rendered for this block.
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Compile to verify it builds**
+
+Run: `npx lerna run compile --scope @theia/cooklang`
+Expected: PASS — no TypeScript errors. (The `import('mermaid')` type resolves now that the dependency is installed.)
+
+- [ ] **Step 3: Re-run the helper tests to confirm no regression**
+
+Run: `npx lerna run test --scope @theia/cooklang`
+Expected: PASS — Task 2 tests still green (the spec imports only the pure helpers, not the class).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang/src/browser/mermaid-renderer.ts
+git commit -m "feat(cooklang): add MermaidRenderer service with lazy mermaid load"
+```
+
+---
+
+## Task 4: Bind `MermaidRenderer` in the frontend module
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/cooklang-frontend-module.ts`
+
+- [ ] **Step 1: Locate the binding site**
+
+Run: `grep -n "ReportWidget\|bind(" packages/cooklang/src/browser/cooklang-frontend-module.ts | head`
+Expected: shows the existing `bind(...)` calls in the container module. (If `ReportWidget` is bound in a different module file, add the new binding in that same file.)
+
+- [ ] **Step 2: Add the import and binding**
+
+At the top of `packages/cooklang/src/browser/cooklang-frontend-module.ts`, add:
+
+```ts
+import { MermaidRenderer } from './mermaid-renderer';
+```
+
+Inside the `ContainerModule` callback (alongside the other `bind(...)` calls), add:
+
+```ts
+    bind(MermaidRenderer).toSelf().inSingletonScope();
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `npx lerna run compile --scope @theia/cooklang`
+Expected: PASS — no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang/src/browser/cooklang-frontend-module.ts
+git commit -m "feat(cooklang): bind MermaidRenderer in frontend module"
+```
+
+---
+
+## Task 5: Wire live rendering + theming into `ReportWidget`
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/report-widget.tsx`
+
+- [ ] **Step 1: Add imports**
+
+In `packages/cooklang/src/browser/report-widget.tsx`, add near the other `@theia/core` imports:
+
+```ts
+import { ThemeService } from '@theia/core/lib/browser/theming';
+```
+
+and near the local imports:
+
+```ts
+import { MermaidRenderer, themeTypeToMermaidTheme } from './mermaid-renderer';
+```
+
+- [ ] **Step 2: Inject the new services**
+
+After the existing `@inject(MarkdownRenderer) ... markdownRenderer;` field, add:
+
+```ts
+    @inject(MermaidRenderer)
+    protected readonly mermaidRenderer: MermaidRenderer;
+
+    @inject(ThemeService)
+    protected readonly themeService: ThemeService;
+```
+
+- [ ] **Step 3: Re-render on theme change**
+
+In the `@postConstruct() init()` method, after the existing `this.toDispose.push(this.monacoWorkspace.onDidChangeTextDocument(...))` block, add:
+
+```ts
+        this.toDispose.push(
+            this.themeService.onDidColorThemeChange(() => this.update())
+        );
+```
+
+- [ ] **Step 4: Add the stable post-render handler**
+
+Add this arrow-property method to the class (e.g. just below `render()`), using a stable reference so the `Markdown` `onRender` effect does not loop:
+
+```ts
+    protected onMarkdownRendered = (element: HTMLElement | undefined): void => {
+        if (!element) {
+            return;
+        }
+        const theme = themeTypeToMermaidTheme(this.themeService.getCurrentTheme().type);
+        // Fire-and-forget: a stale render is harmless because the next update
+        // re-runs this against fresh DOM.
+        this.mermaidRenderer.renderInto(element, theme).catch(error =>
+            console.error('Mermaid rendering failed', error)
+        );
+    };
+```
+
+- [ ] **Step 5: Pass the handler to the markdown branch**
+
+In `render()`, change the `default` (markdown) case to pass `onRender`:
+
+```tsx
+            default:
+                return (
+                    <Markdown
+                        markdown={this.output}
+                        markdownRenderer={this.markdownRenderer}
+                        className='theia-cooklang-report-content'
+                        onRender={this.onMarkdownRendered}
+                    />
+                );
+```
+
+- [ ] **Step 6: Compile**
+
+Run: `npx lerna run compile --scope @theia/cooklang`
+Expected: PASS — no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cooklang/src/browser/report-widget.tsx
+git commit -m "feat(cooklang): render mermaid diagrams in live report preview"
+```
+
+---
+
+## Task 6: Print-friendly diagrams in export
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/report-widget.tsx`
+- Modify: `packages/cooklang/src/browser/report-export-contribution.ts`
+- Modify: `packages/cooklang/src/browser/report-export-document.ts`
+
+- [ ] **Step 1: Make `getExportDocument` async + re-theme diagrams**
+
+In `report-widget.tsx`, replace the existing `getExportDocument()` method body so it clones the content node, recolors diagrams to the light theme, and serializes the clone:
+
+```ts
+    async getExportDocument(): Promise<{ html: string; defaultFileName: string } | undefined> {
+        if (this.errorMessage !== undefined || this.output === undefined) {
+            return undefined;
+        }
+        const contentNode = this.node.querySelector(
+            '.theia-cooklang-report-content, .theia-cooklang-report-text'
+        );
+        if (!contentNode) {
+            return undefined;
+        }
+        const clone = contentNode.cloneNode(true) as HTMLElement;
+        // Re-render diagrams in the light theme so they print legibly on white.
+        await this.mermaidRenderer.renderExport(clone, 'default');
+        const html = buildReportExportDocument({
+            contentHtml: clone.outerHTML,
+            title: this.title.label,
+        });
+        const defaultFileName = `${this.uri.path.name} - ${this.options.templateLabel}`;
+        return { html, defaultFileName };
+    }
+```
+
+- [ ] **Step 2: Update the JSDoc**
+
+Change the doc comment above `getExportDocument` so it reads (replace the existing comment):
+
+```ts
+    /**
+     * Build a self-contained, print-friendly HTML document from the currently
+     * rendered report, plus a sensible default file name. Mermaid diagrams are
+     * re-rendered in the light theme so they stay legible on white paper.
+     * Resolves to `undefined` while the report is still loading or in an error
+     * state.
+     */
+```
+
+- [ ] **Step 3: Await the async call in the export contribution**
+
+In `packages/cooklang/src/browser/report-export-contribution.ts`, update all three call sites (`print`, `exportPdf`, `exportPng`) from:
+
+```ts
+        const document = this.getReportWidget(arg)?.getExportDocument();
+```
+
+to:
+
+```ts
+        const document = await this.getReportWidget(arg)?.getExportDocument();
+```
+
+(All three methods are already `async`.)
+
+- [ ] **Step 4: Add export CSS for diagrams**
+
+In `packages/cooklang/src/browser/report-export-document.ts`, append to the `REPORT_EXPORT_CSS` template string (before the closing backtick):
+
+```css
+.theia-cooklang-mermaid {
+    margin: 1.4em 0;
+    text-align: center;
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+.theia-cooklang-mermaid svg { max-width: 100%; height: auto; }
+.theia-cooklang-mermaid-error {
+    text-align: left;
+    color: #b00020;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    white-space: pre-wrap;
+}
+```
+
+- [ ] **Step 5: Compile**
+
+Run: `npx lerna run compile --scope @theia/cooklang`
+Expected: PASS — no errors (the `await` on a possibly-`undefined` receiver is valid because `?.` short-circuits to `undefined`, and `await undefined` is fine).
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx lerna run test --scope @theia/cooklang`
+Expected: PASS — existing report/export specs still green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cooklang/src/browser/report-widget.tsx packages/cooklang/src/browser/report-export-contribution.ts packages/cooklang/src/browser/report-export-document.ts
+git commit -m "feat(cooklang): include mermaid diagrams in report export"
+```
+
+---
+
+## Task 7: On-screen styling + manual verification
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/style/report.css`
+
+- [ ] **Step 1: Add on-screen diagram styles**
+
+Append to `packages/cooklang/src/browser/style/report.css`:
+
+```css
+/* --- Mermaid diagrams ------------------------------------ */
+
+.theia-cooklang-mermaid {
+    margin: 1.4em 0;
+    text-align: center;
+}
+
+.theia-cooklang-mermaid svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.theia-cooklang-mermaid-error {
+    text-align: left;
+    color: var(--theia-errorForeground);
+    font-family: var(--theia-code-font-family);
+    font-size: 0.85em;
+    white-space: pre-wrap;
+}
+```
+
+- [ ] **Step 2: Build the app**
+
+Run: `cd app && npm run bundle`
+Expected: completes; confirm a separate webpack chunk is emitted for the lazy mermaid import (look for a `mermaid` / vendor chunk in the bundle output).
+
+- [ ] **Step 3: Create a test recipe + template**
+
+Create a recipe file (e.g. `app/scratch-mermaid.cook`) with simple Cooklang content, and an inline/workspace markdown Jinja template that emits a mermaid block, e.g. a template body containing:
+
+````
+# Flow
+
+```mermaid
+graph TD; Prep-->Cook; Cook-->Serve;
+```
+````
+
+- [ ] **Step 4: Run the app and verify live rendering**
+
+Run: `npm run start:electron`
+Manual checks:
+- Open the recipe, generate the report with the mermaid template.
+- The mermaid block renders as a diagram (not raw text) in the report widget.
+- Toggle the editor color theme (light ↔ dark); the diagram re-themes.
+- Introduce a syntax error in the mermaid block; confirm an inline error appears and the rest of the report still renders.
+
+- [ ] **Step 5: Verify export**
+
+From the rendered report, run Export → PDF and Export → PNG (and Print preview).
+Manual checks:
+- The diagram appears in the exported output.
+- The exported diagram uses the light theme (dark text/strokes on white), even when the editor is in a dark theme.
+
+- [ ] **Step 6: Lint**
+
+Run: `npm run lint`
+Expected: PASS — no lint errors in the changed files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cooklang/src/browser/style/report.css
+git commit -m "feat(cooklang): style mermaid diagrams in report preview"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** live preview (Tasks 3–5), export with light re-theme (Task 6), lazy import (Task 3 `load()`), follow-editor-theme + re-render on change (Task 5), markdown-only scope (only the markdown branch of `render()` is touched), monaco-free testable helpers (Task 2), styling (Tasks 6–7), packaging (Task 1). Error handling per-block (Task 3) and graceful load failure (Task 3) covered.
+- **Type consistency:** `MermaidTheme = 'default' | 'dark'` used consistently; `themeTypeToMermaidTheme`, `findMermaidBlocks`, `extractMermaidSource`, `MermaidRenderer.renderInto`, `MermaidRenderer.renderExport`, `onMarkdownRendered` names match across tasks; `getExportDocument` consumers updated to `await` in the same task that makes it async.
+- **Known limitation (acceptable):** if a user triggers export in the brief window before live diagrams finish their first async render, the cloned wrappers may not yet carry `data-mermaid-src`; `renderExport` no-ops on those and the raw block is exported. In practice the report is rendered before the user reaches the export action.

--- a/docs/superpowers/plans/2026-06-30-mermaid-in-jinja-reports.md
+++ b/docs/superpowers/plans/2026-06-30-mermaid-in-jinja-reports.md
@@ -4,7 +4,9 @@
 
 **Goal:** Render Mermaid diagrams embedded as ` ```mermaid ` fenced code blocks inside markdown-format Jinja reports, both in the live report widget and in exported PDF/PNG/print output.
 
-**Architecture:** Let Theia's `MarkdownRenderer` produce its normal DOM (a mermaid fence becomes `<pre><code class="language-mermaid">`). A dedicated `MermaidRenderer` service then does a post-render DOM pass to replace each mermaid block with a rendered SVG, using a lazily imported `mermaid` library themed to match the editor. The export path re-renders the stored diagram sources in mermaid's light theme so printed output stays legible on white paper.
+> **Correction (applied during execution).** Tasks 2/3/5 below assume Theia's markdown renderer emits `<pre><code class="language-mermaid">` and that a post-render DOM scan can replace it. That is wrong: the bound renderer is Monaco's `MarkdownRendererService`, which feeds fenced code blocks to a `codeBlockRenderer(languageId, value)` callback. The shipped code (commit `fix(cooklang): render mermaid via markdown codeBlockRenderer`) replaces `findMermaidBlocks`/`extractMermaidSource`/`renderInto` with `MermaidRenderer.renderDiagram(source, theme)` and a `MermaidMarkdown` component (`report-markdown.tsx`) that renders markdown imperatively with a mermaid-aware `codeBlockRenderer`. Read this note alongside Tasks 2/3/5. Tasks 1, 4, 6, 7 are unchanged.
+
+**Architecture:** Theia's Monaco-backed `MarkdownRenderer` feeds fenced code blocks to a `codeBlockRenderer(languageId, value)` callback. A `MermaidMarkdown` component renders report markdown imperatively and supplies a `codeBlockRenderer` that delegates `mermaid` blocks to a `MermaidRenderer` service (lazily importing the `mermaid` library, themed to match the editor) and falls back to `<pre><code>` for other languages. The export path re-renders the stored diagram sources in mermaid's light theme so printed output stays legible on white paper.
 
 **Tech Stack:** TypeScript, React 18, Theia (`MarkdownRenderer`, `Markdown` component, `ThemeService`, InversifyJS), `mermaid` (lazy dynamic import), mocha + chai + jsdom for tests.
 

--- a/docs/superpowers/specs/2026-06-29-mermaid-in-jinja-reports-design.md
+++ b/docs/superpowers/specs/2026-06-29-mermaid-in-jinja-reports-design.md
@@ -1,0 +1,175 @@
+# Mermaid Diagrams in Jinja Reports
+
+**Date:** 2026-06-29
+**Status:** Approved design
+**Package:** `packages/cooklang`
+
+## Goal
+
+Render [Mermaid](https://mermaid.js.org/) diagrams that appear inside the
+**markdown** output of Jinja reports. A report template that emits a fenced
+` ```mermaid ` code block should display the rendered diagram both in the live
+report widget and in exported PDF/PNG/print output.
+
+## Scope
+
+- **In scope:** markdown-format report output only.
+- **Out of scope:** `html` and `text` report output formats (untouched);
+  diagram editing/authoring UI; mermaid support anywhere outside the report
+  widget.
+
+## Background
+
+Report rendering lives in `packages/cooklang/src/browser/report-widget.tsx`:
+
+- The Jinja output string is rendered by Theia's `Markdown` React component
+  using `MarkdownRenderer` (`report-widget.tsx:233`).
+- A ` ```mermaid ` fence becomes `<pre><code class="language-mermaid">…</code></pre>`
+  in the rendered DOM — inert by default.
+- Export (`getExportDocument`, `report-widget.tsx:123`) grabs the rendered
+  content node's `outerHTML` and hands it to an offscreen BrowserWindow
+  (`report-export-document.ts` → `buildReportExportDocument`) for PDF/PNG/print.
+- `mermaid` already exists in the repo, but only bundled inside the sandboxed
+  `app/plugins/vscode.mermaid-chat-features` webview — **not** reusable from the
+  cooklang package.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Render targets | Live preview **and** export | Consistent output; export works because the rendered SVG is captured in the DOM. |
+| Library loading | **Lazy** `import('mermaid')`, memoized | Mermaid is ~3MB; only pay the cost when a report actually contains a diagram. Webpack splits the dynamic import into its own chunk. |
+| Live theme | **Follow editor theme** | Dark editor → mermaid `dark` theme; otherwise `default`. Re-render on theme change. |
+| Export theme | **Always `default` (light)** | Print-friendly on white paper regardless of editor theme. |
+
+## Architecture
+
+Approach: **post-render DOM pass**. Let `MarkdownRenderer` produce its normal
+output, then replace mermaid code blocks with rendered SVG immediately after the
+markdown mounts/updates.
+
+Rejected alternatives:
+- **Pre-process the markdown string** (substitute inline SVG before
+  `MarkdownRenderer`): fights the renderer's sanitization and async rendering.
+- **Server/native render**: mermaid requires a browser DOM; cannot run in the
+  Rust layer.
+
+### Components
+
+#### New: `packages/cooklang/src/browser/mermaid-renderer.ts`
+
+Kept free of any `@theia/monaco` import so it can be unit-tested without the
+"configuration is already set" monaco/CSS failure (see project memory
+`feedback_spec_monaco_css_harness`).
+
+- `@injectable() class MermaidRenderer`
+  - `protected async load(): Promise<typeof import('mermaid')>` — lazy,
+    memoized dynamic import.
+  - `async renderInto(container: HTMLElement, theme: MermaidTheme): Promise<void>`
+    - Find all mermaid code blocks in `container`.
+    - For each: call `mermaid.render(uniqueId, source)`; on success replace the
+      enclosing `<pre>` with
+      `<div class="theia-cooklang-mermaid" data-mermaid-src="<source>">` wrapping
+      the produced SVG.
+    - Per-block `try/catch`: a failing diagram renders an inline error node and
+      does **not** abort the remaining blocks or the report.
+    - Initialize mermaid with `startOnLoad: false` and the requested `theme`
+      before rendering.
+  - `async renderSource(source: string, theme: MermaidTheme, id: string): Promise<string>`
+    — render a single source string to SVG markup (used by the export path).
+- Exported pure helper(s) for the spec to test without a DOM-heavy import, e.g.
+  `findMermaidBlocks(container)` and/or a source-extraction function.
+- `type MermaidTheme = 'default' | 'dark'` and a `themeTypeToMermaidTheme(...)`
+  mapping helper.
+
+#### Changed: `report-widget.tsx`
+
+- Inject `MermaidRenderer` and `ThemeService`
+  (`@theia/core/lib/browser/theming`).
+- Extract a small functional component `MermaidMarkdown` that:
+  - renders `<Markdown markdown=… markdownRenderer=… className='theia-cooklang-report-content'/>`
+    inside a container with a `ref`.
+  - in a `useEffect` keyed on `[output, themeType]`, calls
+    `mermaidRenderer.renderInto(ref.current, theme)`.
+  - guards against races (ignore the effect result if a newer render started /
+    the node unmounted).
+- The markdown branch of `render()` returns `<MermaidMarkdown … />` instead of
+  the bare `<Markdown>`.
+- Subscribe to `themeService.onDidColorThemeChange` in `init()` →
+  `this.update()` so diagrams re-theme live. Dispose the listener with
+  `this.toDispose`.
+
+#### Changed: export path
+
+- `getExportDocument()` becomes `async` (returns a `Promise`).
+  - Clone the rendered content node.
+  - For each `.theia-cooklang-mermaid[data-mermaid-src]` in the clone, re-render
+    the stored source with the **`default`** (light) theme and swap in the
+    light SVG.
+  - Serialize the clone's `outerHTML` into `buildReportExportDocument`.
+  - Continue to return `undefined` while loading or in an error state.
+- `report-export-contribution.ts`: update the 3 call sites (`print`,
+  `exportPdf`, `exportPng`) to `await getReportWidget(arg)?.getExportDocument()`.
+  All three are already `async` methods.
+- `report-export-document.ts`: add `.theia-cooklang-mermaid` rules to
+  `REPORT_EXPORT_CSS` (centered, `max-width: 100%`, page-break avoidance,
+  neutral background).
+
+#### Changed: styling
+
+- `packages/cooklang/src/browser/style/report.css`: add
+  `.theia-cooklang-mermaid` rules — centered block, constrained width, and an
+  error style for failed diagrams.
+
+#### Changed: packaging
+
+- Add `"mermaid"` to `dependencies` in `packages/cooklang/package.json`. Pin to
+  the same major version already vendored by
+  `app/plugins/vscode.mermaid-chat-features` where practical, to avoid pulling a
+  second major.
+
+## Data flow
+
+```
+Jinja output (markdown string)
+  → MarkdownRenderer  → DOM: <pre><code class="language-mermaid">…</code></pre>
+  → MermaidMarkdown useEffect → MermaidRenderer.renderInto(node, liveTheme)
+      → mermaid.render() → <div.theia-cooklang-mermaid data-mermaid-src> + <svg>
+  (live preview shows themed SVG)
+
+Export:
+  getExportDocument() → clone content node
+    → re-render each data-mermaid-src with default(light) theme
+    → buildReportExportDocument(outerHTML) → offscreen BrowserWindow → PDF/PNG/print
+```
+
+## Error handling
+
+- A malformed mermaid diagram renders an inline, styled error block in place of
+  that diagram; other diagrams and the surrounding report render normally.
+- If the lazy `import('mermaid')` fails, `renderInto` leaves the raw code block
+  in place (graceful degradation) and logs via `console`.
+- Export with diagrams still loading: `getExportDocument` operates on the
+  current DOM clone; any block whose source is unavailable falls back to the
+  current node content rather than throwing.
+
+## Testing
+
+- `packages/cooklang/src/browser/mermaid-renderer.spec.ts` (monaco-free):
+  - `findMermaidBlocks` / source-extraction over a sample DOM fragment
+    (built with `jsdom`-style fixtures or a parsed string) returns the expected
+    mermaid sources and ignores non-mermaid code blocks.
+  - `themeTypeToMermaidTheme` mapping for light/dark/hc theme types.
+- Manual verification (per `/run`): a report template emitting a mermaid block
+  renders a diagram in the widget; toggling editor theme re-themes it; PDF/PNG
+  export shows the diagram in light theme.
+
+## Risks & notes
+
+- **Bundle size:** mitigated by lazy import; verify the dynamic import lands in
+  its own webpack chunk after `cd app && npm run bundle`.
+- **Monaco/CSS spec trap:** keep all unit-tested logic in `mermaid-renderer.ts`,
+  which must not transitively import `@theia/monaco`.
+- **mermaid major alignment:** two majors of mermaid in the tree is acceptable
+  (the plugin copy is sandboxed in its own webview), but prefer matching majors
+  to limit install weight.

--- a/docs/superpowers/specs/2026-06-29-mermaid-in-jinja-reports-design.md
+++ b/docs/superpowers/specs/2026-06-29-mermaid-in-jinja-reports-design.md
@@ -1,8 +1,22 @@
 # Mermaid Diagrams in Jinja Reports
 
 **Date:** 2026-06-29
-**Status:** Approved design
+**Status:** Implemented (with a mid-flight correction — see below)
 **Package:** `packages/cooklang`
+
+> **Implementation correction (2026-06-30).** This design assumed Theia's
+> markdown renderer emits `<pre><code class="language-mermaid">` nodes that a
+> post-render DOM scan could replace. Running the real app showed that the
+> bound renderer is Monaco's `MarkdownRendererService`, which surfaces fenced
+> code blocks through a `codeBlockRenderer(languageId, value)` callback and
+> emits empty `<div data-code>` placeholders otherwise. The shipped
+> implementation therefore renders report markdown imperatively (the core
+> `Markdown` component does not forward render options) via a dedicated
+> `MermaidMarkdown` component that supplies a `codeBlockRenderer`: it delegates
+> `mermaid` blocks to `MermaidRenderer.renderDiagram(source, theme)` and falls
+> back to `<pre><code>` for other languages. The `MermaidRenderer.renderExport`
+> light re-theme for print, the lazy import, and the theme-follow behaviour are
+> all unchanged from this design.
 
 ## Goal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -469,6 +469,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@azure/abort-controller": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
@@ -2217,6 +2230,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@cook-md/editor-app": {
       "resolved": "app",
       "link": true
@@ -3110,6 +3135,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
@@ -3958,6 +4000,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.2"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -6276,6 +6327,259 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -6361,6 +6665,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "8.1.0",
@@ -7227,6 +7537,16 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@virtuoso.dev/react-urx": {
       "version": "0.2.13",
@@ -10975,6 +11295,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -11179,6 +11508,514 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/dargs": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -11293,6 +12130,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
@@ -11803,6 +12646,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -13085,6 +13937,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-error": {
       "version": "4.1.1",
@@ -14943,6 +15805,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -15523,6 +16391,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -15636,6 +16514,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/interpret": {
@@ -17023,6 +17910,31 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keytar": {
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
@@ -17049,6 +17961,11 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -17066,6 +17983,12 @@
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lazy-val": {
       "version": "1.0.5",
@@ -17548,6 +18471,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -18230,6 +19159,60 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.16.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.2",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.2.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.3",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.20",
+        "dompurify": "^3.3.3",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.45",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mermaid/node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/methods": {
@@ -20877,6 +21860,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/pacote": {
       "version": "21.0.1",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.0.1.tgz",
@@ -21315,6 +22304,12 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -21668,6 +22663,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/portfinder": {
@@ -23484,6 +24495,24 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/route-parser": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/route-parser/-/route-parser-0.0.5.tgz",
@@ -23545,6 +24574,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rx": {
       "version": "2.3.24",
@@ -25006,6 +26041,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -25483,6 +26524,15 @@
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
@@ -25782,6 +26832,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-md5": {
@@ -28035,6 +29094,7 @@
         "@theia/monaco-editor-core": "1.108.201",
         "@theia/navigator": "1.70.0",
         "@theia/workspace": "1.70.0",
+        "mermaid": "^11.4.0",
         "tslib": "^2.6.2"
       },
       "devDependencies": {

--- a/packages/cooklang/package.json
+++ b/packages/cooklang/package.json
@@ -14,6 +14,7 @@
     "@theia/cooklang-native": "0.1.0",
     "@theia/cooklang-account": "1.70.0",
     "@theia/workspace": "1.70.0",
+    "mermaid": "^11.4.0",
     "tslib": "^2.6.2"
   },
   "main": "lib/common",

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -41,6 +41,7 @@ import { ReportExportContribution } from './report-export-contribution';
 import { ReportConfigService } from './report-config-service';
 import { ReportPresenter } from './report-presenter';
 import { ReportWidgetPresenter } from './report-widget-presenter';
+import { MermaidRenderer } from './mermaid-renderer';
 import { bindToolProvider } from '@theia/ai-core/lib/common';
 import { RenderTemplateTool } from './render-template-tool';
 import { bindCooklangPreferences } from '../common';
@@ -100,6 +101,9 @@ export default new ContainerModule(bind => {
     bind(ReportConfigService).toSelf().inSingletonScope();
     bind(ReportWidgetPresenter).toSelf().inSingletonScope();
     bind(ReportPresenter).toService(ReportWidgetPresenter);
+
+    // Mermaid renderer for rendering diagrams in reports
+    bind(MermaidRenderer).toSelf().inSingletonScope();
 
     // AI render tool (picked up by the cookbot agent via ToolInvocationRegistry)
     bindToolProvider(RenderTemplateTool, bind);

--- a/packages/cooklang/src/browser/mermaid-renderer.spec.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.spec.ts
@@ -11,8 +11,19 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+// `renderDiagram` builds DOM, so set up jsdom before importing the module.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
 import { expect } from 'chai';
-import { themeTypeToMermaidTheme } from './mermaid-renderer';
+import {
+    themeTypeToMermaidTheme,
+    MermaidRenderer,
+    MERMAID_WRAPPER_CLASS,
+    MERMAID_ERROR_CLASS
+} from './mermaid-renderer';
+
+after(() => disableJSDOM());
 
 describe('mermaid-renderer helpers', () => {
 
@@ -21,5 +32,27 @@ describe('mermaid-renderer helpers', () => {
         expect(themeTypeToMermaidTheme('hc')).to.equal('dark');
         expect(themeTypeToMermaidTheme('light')).to.equal('default');
         expect(themeTypeToMermaidTheme('hcLight')).to.equal('default');
+    });
+});
+
+describe('MermaidRenderer.renderDiagram', () => {
+
+    // Subclass that forces the mermaid module to fail to load, exercising the
+    // graceful-degradation branch without depending on the real (browser-only)
+    // mermaid runtime.
+    class FailingMermaidRenderer extends MermaidRenderer {
+        protected override load(): Promise<typeof import('mermaid')> {
+            return Promise.reject(new Error('boom'));
+        }
+    }
+
+    it('falls back to the raw source when mermaid fails to load', async () => {
+        const renderer = new FailingMermaidRenderer();
+        const source = 'graph TD; A-->B;';
+        const wrapper = await renderer.renderDiagram(source, 'default');
+        expect(wrapper.classList.contains(MERMAID_WRAPPER_CLASS)).to.equal(true);
+        expect(wrapper.classList.contains(MERMAID_ERROR_CLASS)).to.equal(false);
+        expect(wrapper.getAttribute('data-mermaid-src')).to.equal(source);
+        expect(wrapper.textContent).to.equal(source);
     });
 });

--- a/packages/cooklang/src/browser/mermaid-renderer.spec.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.spec.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+// The DOM helpers need `document`; set up jsdom before importing the module.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { themeTypeToMermaidTheme, findMermaidBlocks, extractMermaidSource } from './mermaid-renderer';
+
+after(() => disableJSDOM());
+
+describe('mermaid-renderer helpers', () => {
+
+    it('maps theme types to mermaid themes', () => {
+        expect(themeTypeToMermaidTheme('dark')).to.equal('dark');
+        expect(themeTypeToMermaidTheme('hc')).to.equal('dark');
+        expect(themeTypeToMermaidTheme('light')).to.equal('default');
+        expect(themeTypeToMermaidTheme('hcLight')).to.equal('default');
+    });
+
+    function container(html: string): HTMLElement {
+        const node = document.createElement('div');
+        node.innerHTML = html;
+        return node;
+    }
+
+    it('finds <pre> blocks that wrap a mermaid code fence', () => {
+        const node = container(
+            '<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>' +
+            '<pre><code class="language-js">const x = 1;</code></pre>' +
+            '<p>text</p>'
+        );
+        const blocks = findMermaidBlocks(node);
+        expect(blocks).to.have.lengthOf(1);
+        expect(blocks[0].tagName).to.equal('PRE');
+    });
+
+    it('returns an empty array when there are no mermaid blocks', () => {
+        const node = container('<pre><code class="language-js">x</code></pre><p>none</p>');
+        expect(findMermaidBlocks(node)).to.have.lengthOf(0);
+    });
+
+    it('extracts the diagram source text from a block', () => {
+        const node = container('<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>');
+        const [block] = findMermaidBlocks(node);
+        expect(extractMermaidSource(block)).to.equal('graph TD; A-->B;');
+    });
+});

--- a/packages/cooklang/src/browser/mermaid-renderer.spec.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.spec.ts
@@ -11,14 +11,8 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
-// The DOM helpers need `document`; set up jsdom before importing the module.
-import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
-const disableJSDOM = enableJSDOM();
-
 import { expect } from 'chai';
-import { themeTypeToMermaidTheme, findMermaidBlocks, extractMermaidSource } from './mermaid-renderer';
-
-after(() => disableJSDOM());
+import { themeTypeToMermaidTheme } from './mermaid-renderer';
 
 describe('mermaid-renderer helpers', () => {
 
@@ -27,33 +21,5 @@ describe('mermaid-renderer helpers', () => {
         expect(themeTypeToMermaidTheme('hc')).to.equal('dark');
         expect(themeTypeToMermaidTheme('light')).to.equal('default');
         expect(themeTypeToMermaidTheme('hcLight')).to.equal('default');
-    });
-
-    function container(html: string): HTMLElement {
-        const node = document.createElement('div');
-        node.innerHTML = html;
-        return node;
-    }
-
-    it('finds <pre> blocks that wrap a mermaid code fence', () => {
-        const node = container(
-            '<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>' +
-            '<pre><code class="language-js">const x = 1;</code></pre>' +
-            '<p>text</p>'
-        );
-        const blocks = findMermaidBlocks(node);
-        expect(blocks).to.have.lengthOf(1);
-        expect(blocks[0].tagName).to.equal('PRE');
-    });
-
-    it('returns an empty array when there are no mermaid blocks', () => {
-        const node = container('<pre><code class="language-js">x</code></pre><p>none</p>');
-        expect(findMermaidBlocks(node)).to.have.lengthOf(0);
-    });
-
-    it('extracts the diagram source text from a block', () => {
-        const node = container('<pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>');
-        const [block] = findMermaidBlocks(node);
-        expect(extractMermaidSource(block)).to.equal('graph TD; A-->B;');
     });
 });

--- a/packages/cooklang/src/browser/mermaid-renderer.spec.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.spec.ts
@@ -35,6 +35,21 @@ describe('mermaid-renderer helpers', () => {
     });
 });
 
+// A stand-in for the mermaid module's default export. `render` either returns
+// an SVG string or throws, depending on `shouldThrow`, so the spec can exercise
+// the success/error branches without the real (browser-only) mermaid runtime.
+function mockMermaid(options: { shouldThrow?: boolean } = {}): import('mermaid').Mermaid {
+    return {
+        initialize: () => { /* no-op */ },
+        render: async (id: string, source: string) => {
+            if (options.shouldThrow) {
+                throw new Error(`Parse error: ${source}`);
+            }
+            return { svg: `<svg data-id="${id}">${source}</svg>` };
+        }
+    } as unknown as import('mermaid').Mermaid;
+}
+
 describe('MermaidRenderer.renderDiagram', () => {
 
     // Subclass that forces the mermaid module to fail to load, exercising the
@@ -46,6 +61,17 @@ describe('MermaidRenderer.renderDiagram', () => {
         }
     }
 
+    // Subclass backed by a mock mermaid module so the success/error render
+    // branches can be tested in jsdom.
+    class MockMermaidRenderer extends MermaidRenderer {
+        constructor(protected readonly mermaid: import('mermaid').Mermaid) {
+            super();
+        }
+        protected override load(): Promise<typeof import('mermaid')> {
+            return Promise.resolve({ default: this.mermaid } as typeof import('mermaid'));
+        }
+    }
+
     it('falls back to the raw source when mermaid fails to load', async () => {
         const renderer = new FailingMermaidRenderer();
         const source = 'graph TD; A-->B;';
@@ -54,5 +80,75 @@ describe('MermaidRenderer.renderDiagram', () => {
         expect(wrapper.classList.contains(MERMAID_ERROR_CLASS)).to.equal(false);
         expect(wrapper.getAttribute('data-mermaid-src')).to.equal(source);
         expect(wrapper.textContent).to.equal(source);
+    });
+
+    it('wraps a successful render as an SVG with the source recorded', async () => {
+        const module = mockMermaid();
+        const renderer = new MockMermaidRenderer(module);
+        const wrapper = await renderer.renderDiagram('graph TD; A-->B;', 'default');
+        expect(wrapper.classList.contains(MERMAID_WRAPPER_CLASS)).to.equal(true);
+        expect(wrapper.classList.contains(MERMAID_ERROR_CLASS)).to.equal(false);
+        expect(wrapper.getAttribute('data-mermaid-src')).to.equal('graph TD; A-->B;');
+        expect(wrapper.querySelector('svg')).to.exist;
+    });
+
+    it('shows an inline error block when a diagram fails to parse', async () => {
+        const module = mockMermaid({ shouldThrow: true });
+        const renderer = new MockMermaidRenderer(module);
+        const wrapper = await renderer.renderDiagram('graph TD; A--(', 'default');
+        expect(wrapper.classList.contains(MERMAID_ERROR_CLASS)).to.equal(true);
+        expect(wrapper.getAttribute('data-mermaid-src')).to.equal('graph TD; A--(');
+        expect(wrapper.textContent).to.contain('Parse error');
+    });
+
+    it('initializes mermaid only once across diagrams sharing a theme', async () => {
+        let initializeCalls = 0;
+        const module = {
+            initialize: () => { initializeCalls++; },
+            render: async (id: string, source: string) => ({ svg: `<svg>${source}</svg>` })
+        } as unknown as import('mermaid').Mermaid;
+        const renderer = new MockMermaidRenderer(module);
+        await renderer.renderDiagram('graph TD; A-->B;', 'default');
+        await renderer.renderDiagram('graph TD; C-->D;', 'default');
+        expect(initializeCalls).to.equal(1);
+        await renderer.renderDiagram('graph TD; E-->F;', 'dark');
+        expect(initializeCalls).to.equal(2);
+    });
+});
+
+describe('MermaidRenderer.renderExport', () => {
+
+    class MockMermaidRenderer extends MermaidRenderer {
+        constructor(protected readonly mermaid: import('mermaid').Mermaid) {
+            super();
+        }
+        protected override load(): Promise<typeof import('mermaid')> {
+            return Promise.resolve({ default: this.mermaid } as typeof import('mermaid'));
+        }
+    }
+
+    it('re-renders wrappers from their recorded source', async () => {
+        const rendered: string[] = [];
+        const module = {
+            initialize: () => { /* no-op */ },
+            render: async (id: string, source: string) => {
+                rendered.push(source);
+                return { svg: `<svg data-export="1">${source}</svg>` };
+            }
+        } as unknown as import('mermaid').Mermaid;
+
+        const container = document.createElement('div');
+        container.innerHTML =
+            '<div class="theia-cooklang-mermaid theia-cooklang-mermaid-error" data-mermaid-src="graph TD; A-->B;">old</div>' +
+            '<div class="theia-cooklang-mermaid" data-mermaid-src="graph TD; C-->D;"><svg>old</svg></div>' +
+            '<p>not a diagram</p>';
+
+        await new MockMermaidRenderer(module).renderExport(container, 'default');
+
+        expect(rendered).to.deep.equal(['graph TD; A-->B;', 'graph TD; C-->D;']);
+        const wrappers = container.querySelectorAll('.theia-cooklang-mermaid');
+        expect(wrappers[0].querySelector('svg[data-export="1"]')).to.exist;
+        // The stale error class is cleared once the diagram renders successfully.
+        expect(wrappers[0].classList.contains(MERMAID_ERROR_CLASS)).to.equal(false);
     });
 });

--- a/packages/cooklang/src/browser/mermaid-renderer.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.ts
@@ -11,6 +11,7 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+import { injectable } from '@theia/core/shared/inversify';
 import { ThemeType } from '@theia/core/lib/common/theme';
 
 /** The subset of mermaid built-in themes this feature uses. */
@@ -43,4 +44,98 @@ export function findMermaidBlocks(container: HTMLElement): HTMLElement[] {
 export function extractMermaidSource(block: HTMLElement): string {
     const code = block.querySelector(MERMAID_CODE_SELECTOR);
     return (code?.textContent ?? block.textContent ?? '').trim();
+}
+
+type MermaidModule = typeof import('mermaid');
+
+/**
+ * Renders mermaid diagrams that appear as fenced code blocks in rendered
+ * markdown reports. The `mermaid` library is imported lazily the first time a
+ * diagram is encountered, so reports without diagrams pay no cost.
+ */
+@injectable()
+export class MermaidRenderer {
+
+    protected mermaidPromise: Promise<MermaidModule> | undefined;
+    protected idCounter = 0;
+
+    /** Lazily import and memoize the mermaid module. */
+    protected load(): Promise<MermaidModule> {
+        if (!this.mermaidPromise) {
+            this.mermaidPromise = import('mermaid');
+        }
+        return this.mermaidPromise;
+    }
+
+    protected nextId(): string {
+        return `cooklang-mermaid-${++this.idCounter}`;
+    }
+
+    /**
+     * Replace every mermaid code block in `container` with a rendered SVG.
+     * Each block is rendered independently: a failing diagram is replaced with
+     * an inline error node and does not abort the remaining diagrams. If the
+     * mermaid module fails to load, the raw code blocks are left untouched.
+     */
+    async renderInto(container: HTMLElement, theme: MermaidTheme): Promise<void> {
+        const blocks = findMermaidBlocks(container);
+        if (blocks.length === 0) {
+            return;
+        }
+        let mermaid: MermaidModule['default'];
+        try {
+            mermaid = (await this.load()).default;
+        } catch (error) {
+            console.error('Failed to load mermaid; leaving diagram source as-is.', error);
+            return;
+        }
+        mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+        for (const block of blocks) {
+            const source = extractMermaidSource(block);
+            const wrapper = container.ownerDocument.createElement('div');
+            wrapper.className = 'theia-cooklang-mermaid';
+            wrapper.setAttribute('data-mermaid-src', source);
+            try {
+                const { svg } = await mermaid.render(this.nextId(), source);
+                wrapper.innerHTML = svg;
+            } catch (error) {
+                wrapper.classList.add('theia-cooklang-mermaid-error');
+                wrapper.textContent = String(error instanceof Error ? error.message : error);
+            }
+            block.replaceWith(wrapper);
+        }
+    }
+
+    /**
+     * Re-render diagrams in a (cloned) export container using the given theme.
+     * Operates on `.theia-cooklang-mermaid[data-mermaid-src]` wrappers produced
+     * by {@link renderInto}, so already-rendered live diagrams can be recolored
+     * for print without re-reading the markdown.
+     */
+    async renderExport(container: HTMLElement, theme: MermaidTheme): Promise<void> {
+        const wrappers = Array.from(
+            container.querySelectorAll<HTMLElement>('.theia-cooklang-mermaid[data-mermaid-src]')
+        );
+        if (wrappers.length === 0) {
+            return;
+        }
+        let mermaid: MermaidModule['default'];
+        try {
+            mermaid = (await this.load()).default;
+        } catch (error) {
+            console.error('Failed to load mermaid for export.', error);
+            return;
+        }
+        mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+        for (const wrapper of wrappers) {
+            const source = wrapper.getAttribute('data-mermaid-src') ?? '';
+            try {
+                const { svg } = await mermaid.render(this.nextId(), source);
+                wrapper.innerHTML = svg;
+                wrapper.classList.remove('theia-cooklang-mermaid-error');
+            } catch {
+                // Keep whatever was already rendered for this block.
+            }
+        }
+    }
 }

--- a/packages/cooklang/src/browser/mermaid-renderer.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.ts
@@ -44,6 +44,7 @@ export class MermaidRenderer {
 
     protected mermaidPromise: Promise<MermaidModule> | undefined;
     protected idCounter = 0;
+    protected initializedTheme: MermaidTheme | undefined;
 
     /** Lazily import and memoize the mermaid module. */
     protected load(): Promise<MermaidModule> {
@@ -55,6 +56,19 @@ export class MermaidRenderer {
 
     protected nextId(): string {
         return `cooklang-mermaid-${++this.idCounter}`;
+    }
+
+    /**
+     * Initialize the (singleton) mermaid module for `theme`, skipping the call
+     * when the last initialization already used that theme. A report with N
+     * diagrams fires N concurrent renders; without this guard each one would
+     * redundantly re-initialize with identical options.
+     */
+    protected ensureInitialized(mermaid: MermaidModule['default'], theme: MermaidTheme): void {
+        if (this.initializedTheme !== theme) {
+            mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+            this.initializedTheme = theme;
+        }
     }
 
     /**
@@ -76,7 +90,7 @@ export class MermaidRenderer {
             wrapper.textContent = source;
             return wrapper;
         }
-        mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+        this.ensureInitialized(mermaid, theme);
         try {
             const { svg } = await mermaid.render(this.nextId(), source);
             wrapper.innerHTML = svg;
@@ -107,13 +121,13 @@ export class MermaidRenderer {
             console.error('Failed to load mermaid for export.', error);
             return;
         }
-        mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
+        this.ensureInitialized(mermaid, theme);
         for (const wrapper of wrappers) {
             const source = wrapper.getAttribute('data-mermaid-src') ?? '';
             try {
                 const { svg } = await mermaid.render(this.nextId(), source);
                 wrapper.innerHTML = svg;
-                wrapper.classList.remove('theia-cooklang-mermaid-error');
+                wrapper.classList.remove(MERMAID_ERROR_CLASS);
             } catch {
                 // Keep whatever was already rendered for this block.
             }

--- a/packages/cooklang/src/browser/mermaid-renderer.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.ts
@@ -17,41 +17,27 @@ import { ThemeType } from '@theia/core/lib/common/theme';
 /** The subset of mermaid built-in themes this feature uses. */
 export type MermaidTheme = 'default' | 'dark';
 
-/** CSS selector for a mermaid code fence produced by the markdown renderer. */
-export const MERMAID_CODE_SELECTOR = 'code.language-mermaid';
+/** Class on the wrapper element produced for each rendered diagram. */
+export const MERMAID_WRAPPER_CLASS = 'theia-cooklang-mermaid';
+
+/** Class added to a wrapper whose diagram failed to render. */
+export const MERMAID_ERROR_CLASS = 'theia-cooklang-mermaid-error';
 
 /** Map a Theia theme type to the mermaid theme used for live rendering. */
 export function themeTypeToMermaidTheme(type: ThemeType): MermaidTheme {
     return (type === 'dark' || type === 'hc') ? 'dark' : 'default';
 }
 
-/**
- * Find the `<pre>` blocks inside `container` that wrap a mermaid code fence.
- * Returns the enclosing `<pre>` elements (the nodes we replace with an SVG).
- */
-export function findMermaidBlocks(container: HTMLElement): HTMLElement[] {
-    const blocks: HTMLElement[] = [];
-    container.querySelectorAll(MERMAID_CODE_SELECTOR).forEach(code => {
-        const pre = code.closest('pre');
-        if (pre instanceof HTMLElement) {
-            blocks.push(pre);
-        }
-    });
-    return blocks;
-}
-
-/** Extract the raw diagram source from a mermaid `<pre>` block. */
-export function extractMermaidSource(block: HTMLElement): string {
-    const code = block.querySelector(MERMAID_CODE_SELECTOR);
-    return (code?.textContent ?? block.textContent ?? '').trim();
-}
-
 type MermaidModule = typeof import('mermaid');
 
 /**
- * Renders mermaid diagrams that appear as fenced code blocks in rendered
- * markdown reports. The `mermaid` library is imported lazily the first time a
- * diagram is encountered, so reports without diagrams pay no cost.
+ * Renders mermaid diagrams for fenced ` ```mermaid ` code blocks in markdown
+ * reports. The markdown renderer surfaces code blocks through a
+ * `codeBlockRenderer(languageId, value)` callback (it does not emit
+ * `<code class="language-*">` nodes), so this service produces a ready-to-mount
+ * element per block rather than scanning the rendered DOM. The `mermaid`
+ * library is imported lazily the first time a diagram is rendered, so reports
+ * without diagrams pay no cost.
  */
 @injectable()
 export class MermaidRenderer {
@@ -72,45 +58,40 @@ export class MermaidRenderer {
     }
 
     /**
-     * Replace every mermaid code block in `container` with a rendered SVG.
-     * Each block is rendered independently: a failing diagram is replaced with
-     * an inline error node and does not abort the remaining diagrams. If the
-     * mermaid module fails to load, the raw code blocks are left untouched.
+     * Render a single mermaid `source` to a wrapper element containing the SVG.
+     * The wrapper carries the original source in `data-mermaid-src` so it can be
+     * re-themed later (see {@link renderExport}). On a diagram error the wrapper
+     * shows the error message; if the mermaid module fails to load entirely, the
+     * wrapper falls back to the raw source text.
      */
-    async renderInto(container: HTMLElement, theme: MermaidTheme): Promise<void> {
-        const blocks = findMermaidBlocks(container);
-        if (blocks.length === 0) {
-            return;
-        }
+    async renderDiagram(source: string, theme: MermaidTheme): Promise<HTMLElement> {
+        const wrapper = document.createElement('div');
+        wrapper.className = MERMAID_WRAPPER_CLASS;
+        wrapper.setAttribute('data-mermaid-src', source);
         let mermaid: MermaidModule['default'];
         try {
             mermaid = (await this.load()).default;
         } catch (error) {
-            console.error('Failed to load mermaid; leaving diagram source as-is.', error);
-            return;
+            console.error('Failed to load mermaid; showing diagram source as-is.', error);
+            wrapper.textContent = source;
+            return wrapper;
         }
         mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' });
-        for (const block of blocks) {
-            const source = extractMermaidSource(block);
-            const wrapper = container.ownerDocument.createElement('div');
-            wrapper.className = 'theia-cooklang-mermaid';
-            wrapper.setAttribute('data-mermaid-src', source);
-            try {
-                const { svg } = await mermaid.render(this.nextId(), source);
-                wrapper.innerHTML = svg;
-            } catch (error) {
-                wrapper.classList.add('theia-cooklang-mermaid-error');
-                wrapper.textContent = String(error instanceof Error ? error.message : error);
-            }
-            block.replaceWith(wrapper);
+        try {
+            const { svg } = await mermaid.render(this.nextId(), source);
+            wrapper.innerHTML = svg;
+        } catch (error) {
+            wrapper.classList.add(MERMAID_ERROR_CLASS);
+            wrapper.textContent = String(error instanceof Error ? error.message : error);
         }
+        return wrapper;
     }
 
     /**
      * Re-render diagrams in a (cloned) export container using the given theme.
      * Operates on `.theia-cooklang-mermaid[data-mermaid-src]` wrappers produced
-     * by {@link renderInto}, so already-rendered live diagrams can be recolored
-     * for print without re-reading the markdown.
+     * by {@link renderDiagram}, so already-rendered live diagrams can be
+     * recolored for print without re-reading the markdown.
      */
     async renderExport(container: HTMLElement, theme: MermaidTheme): Promise<void> {
         const wrappers = Array.from(

--- a/packages/cooklang/src/browser/mermaid-renderer.ts
+++ b/packages/cooklang/src/browser/mermaid-renderer.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { ThemeType } from '@theia/core/lib/common/theme';
+
+/** The subset of mermaid built-in themes this feature uses. */
+export type MermaidTheme = 'default' | 'dark';
+
+/** CSS selector for a mermaid code fence produced by the markdown renderer. */
+export const MERMAID_CODE_SELECTOR = 'code.language-mermaid';
+
+/** Map a Theia theme type to the mermaid theme used for live rendering. */
+export function themeTypeToMermaidTheme(type: ThemeType): MermaidTheme {
+    return (type === 'dark' || type === 'hc') ? 'dark' : 'default';
+}
+
+/**
+ * Find the `<pre>` blocks inside `container` that wrap a mermaid code fence.
+ * Returns the enclosing `<pre>` elements (the nodes we replace with an SVG).
+ */
+export function findMermaidBlocks(container: HTMLElement): HTMLElement[] {
+    const blocks: HTMLElement[] = [];
+    container.querySelectorAll(MERMAID_CODE_SELECTOR).forEach(code => {
+        const pre = code.closest('pre');
+        if (pre instanceof HTMLElement) {
+            blocks.push(pre);
+        }
+    });
+    return blocks;
+}
+
+/** Extract the raw diagram source from a mermaid `<pre>` block. */
+export function extractMermaidSource(block: HTMLElement): string {
+    const code = block.querySelector(MERMAID_CODE_SELECTOR);
+    return (code?.textContent ?? block.textContent ?? '').trim();
+}

--- a/packages/cooklang/src/browser/report-export-contribution.ts
+++ b/packages/cooklang/src/browser/report-export-contribution.ts
@@ -98,7 +98,7 @@ export class ReportExportContribution implements CommandContribution, TabBarTool
     }
 
     protected async print(arg?: unknown): Promise<void> {
-        const document = this.getReportWidget(arg)?.getExportDocument();
+        const document = await this.getReportWidget(arg)?.getExportDocument();
         if (!document) {
             return;
         }
@@ -110,7 +110,7 @@ export class ReportExportContribution implements CommandContribution, TabBarTool
     }
 
     protected async exportPdf(arg?: unknown): Promise<void> {
-        const document = this.getReportWidget(arg)?.getExportDocument();
+        const document = await this.getReportWidget(arg)?.getExportDocument();
         if (!document) {
             return;
         }
@@ -118,7 +118,7 @@ export class ReportExportContribution implements CommandContribution, TabBarTool
     }
 
     protected async exportPng(arg?: unknown): Promise<void> {
-        const document = this.getReportWidget(arg)?.getExportDocument();
+        const document = await this.getReportWidget(arg)?.getExportDocument();
         if (!document) {
             return;
         }

--- a/packages/cooklang/src/browser/report-export-document.ts
+++ b/packages/cooklang/src/browser/report-export-document.ts
@@ -87,6 +87,20 @@ body {
     font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
     font-size: 13px; padding: 24px; color: #1a1a1a;
 }
+.theia-cooklang-mermaid {
+    margin: 1.4em 0;
+    text-align: center;
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+.theia-cooklang-mermaid svg { max-width: 100%; height: auto; }
+.theia-cooklang-mermaid-error {
+    text-align: left;
+    color: #b00020;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 0.85em;
+    white-space: pre-wrap;
+}
 `;
 
 export interface ReportExportDocumentOptions {

--- a/packages/cooklang/src/browser/report-export-document.ts
+++ b/packages/cooklang/src/browser/report-export-document.ts
@@ -110,12 +110,14 @@ export interface ReportExportDocumentOptions {
     title: string;
 }
 
-/** Escape a string for safe insertion into HTML text/attribute content. */
+/** Escape a string for safe insertion into HTML text or attribute content. */
 function escapeHtml(value: string): string {
     return value
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;');
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
 }
 
 /**

--- a/packages/cooklang/src/browser/report-markdown.tsx
+++ b/packages/cooklang/src/browser/report-markdown.tsx
@@ -1,0 +1,90 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { MarkdownRenderer, MarkdownRenderResult } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { MermaidRenderer, MermaidTheme } from './mermaid-renderer';
+
+export interface MermaidMarkdownProps {
+    /** The markdown source to render. */
+    markdown: string;
+    /** The shared markdown renderer (Monaco-backed). */
+    markdownRenderer: MarkdownRenderer;
+    /** The mermaid renderer used for ` ```mermaid ` code blocks. */
+    mermaidRenderer: MermaidRenderer;
+    /** Mermaid theme to render diagrams with; re-renders when it changes. */
+    theme: MermaidTheme;
+    /** CSS class for the container element. */
+    className?: string;
+}
+
+/**
+ * Renders report markdown and turns fenced ` ```mermaid ` code blocks into
+ * rendered diagrams.
+ *
+ * Theia's Monaco-backed markdown renderer surfaces code blocks through a
+ * `codeBlockRenderer(languageId, value)` callback rather than emitting
+ * `<code class="language-*">` nodes, so we render imperatively here (the core
+ * `Markdown` component does not forward that option) and supply a renderer that
+ * delegates mermaid blocks to {@link MermaidRenderer} and falls back to a plain
+ * `<pre><code>` for every other language.
+ */
+export const MermaidMarkdown: React.FC<MermaidMarkdownProps> = ({
+    markdown,
+    markdownRenderer,
+    mermaidRenderer,
+    theme,
+    className
+}) => {
+    // eslint-disable-next-line no-null/no-null
+    const containerRef = React.useRef<HTMLDivElement>(null);
+    const resultRef = React.useRef<MarkdownRenderResult | undefined>();
+
+    React.useEffect(() => {
+        resultRef.current?.dispose();
+        resultRef.current = undefined;
+        const container = containerRef.current;
+        if (!container) {
+            return;
+        }
+        if (!markdown || markdown.trim() === '') {
+            container.replaceChildren();
+            return;
+        }
+        const rendered = markdownRenderer.render(new MarkdownStringImpl(markdown), {
+            codeBlockRenderer: async (languageId: string, value: string): Promise<HTMLElement> => {
+                if (languageId === 'mermaid') {
+                    return mermaidRenderer.renderDiagram(value, theme);
+                }
+                const pre = document.createElement('pre');
+                const code = document.createElement('code');
+                if (languageId) {
+                    code.className = `language-${languageId}`;
+                }
+                code.textContent = value;
+                pre.appendChild(code);
+                return pre;
+            }
+        });
+        resultRef.current = rendered;
+        container.replaceChildren(rendered.element);
+        return () => {
+            resultRef.current?.dispose();
+            resultRef.current = undefined;
+        };
+    }, [markdown, markdownRenderer, mermaidRenderer, theme]);
+
+    return <div className={className} ref={containerRef} />;
+};
+MermaidMarkdown.displayName = 'MermaidMarkdown';

--- a/packages/cooklang/src/browser/report-markdown.tsx
+++ b/packages/cooklang/src/browser/report-markdown.tsx
@@ -79,6 +79,10 @@ export const MermaidMarkdown: React.FC<MermaidMarkdownProps> = ({
         });
         resultRef.current = rendered;
         container.replaceChildren(rendered.element);
+        // The mermaid `codeBlockRenderer` promises may still be in flight when a
+        // re-render disposes this result. Those late fills land on the old,
+        // now-detached element and are harmless: the next render owns the
+        // container's children via `replaceChildren`.
         return () => {
             resultRef.current?.dispose();
             resultRef.current = undefined;

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -16,7 +16,6 @@ import { Message } from '@theia/core/shared/@lumino/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
-import { Markdown } from '@theia/core/lib/browser/markdown-rendering/markdown';
 import { ThemeService } from '@theia/core/lib/browser/theming';
 import { nls } from '@theia/core/lib/common/nls';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
@@ -28,6 +27,7 @@ import { CooklangLanguageService, COOKLANG_LANGUAGE_ID, ReportOutputFormat, Repo
 import { ReportWidgetOptions, createReportWidgetId } from './report-widget-types';
 import { buildReportExportDocument } from './report-export-document';
 import { MermaidRenderer, themeTypeToMermaidTheme } from './mermaid-renderer';
+import { MermaidMarkdown } from './report-markdown';
 
 import '../../src/browser/style/report.css';
 
@@ -246,27 +246,16 @@ export class ReportWidget extends ReactWidget implements Navigatable {
                 return <pre className='theia-cooklang-report-text'>{this.output}</pre>;
             default:
                 return (
-                    <Markdown
+                    <MermaidMarkdown
                         markdown={this.output}
                         markdownRenderer={this.markdownRenderer}
+                        mermaidRenderer={this.mermaidRenderer}
+                        theme={themeTypeToMermaidTheme(this.themeService.getCurrentTheme().type)}
                         className='theia-cooklang-report-content'
-                        onRender={this.onMarkdownRendered}
                     />
                 );
         }
     }
-
-    protected onMarkdownRendered = (element: HTMLElement | undefined): void => {
-        if (!element) {
-            return;
-        }
-        const theme = themeTypeToMermaidTheme(this.themeService.getCurrentTheme().type);
-        // Fire-and-forget: a stale render is harmless because the next update
-        // re-runs this against fresh DOM.
-        this.mermaidRenderer.renderInto(element, theme).catch(error =>
-            console.error('Mermaid rendering failed', error)
-        );
-    };
 
     /**
      * Workspace templates declare their output format via the inner file

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -17,6 +17,7 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { Markdown } from '@theia/core/lib/browser/markdown-rendering/markdown';
+import { ThemeService } from '@theia/core/lib/browser/theming';
 import { nls } from '@theia/core/lib/common/nls';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -26,6 +27,7 @@ import * as DOMPurify from '@theia/core/shared/dompurify';
 import { CooklangLanguageService, COOKLANG_LANGUAGE_ID, ReportOutputFormat, ReportTemplates } from '../common';
 import { ReportWidgetOptions, createReportWidgetId } from './report-widget-types';
 import { buildReportExportDocument } from './report-export-document';
+import { MermaidRenderer, themeTypeToMermaidTheme } from './mermaid-renderer';
 
 import '../../src/browser/style/report.css';
 
@@ -55,6 +57,12 @@ export class ReportWidget extends ReactWidget implements Navigatable {
     @inject(MarkdownRenderer)
     protected readonly markdownRenderer: MarkdownRenderer;
 
+    @inject(MermaidRenderer)
+    protected readonly mermaidRenderer: MermaidRenderer;
+
+    @inject(ThemeService)
+    protected readonly themeService: ThemeService;
+
     protected uri: URI;
     protected options: ReportWidgetOptions;
     protected output: string | undefined;
@@ -81,6 +89,9 @@ export class ReportWidget extends ReactWidget implements Navigatable {
                     this.debouncedRender();
                 }
             })
+        );
+        this.toDispose.push(
+            this.themeService.onDidColorThemeChange(() => this.update())
         );
     }
 
@@ -234,10 +245,23 @@ export class ReportWidget extends ReactWidget implements Navigatable {
                         markdown={this.output}
                         markdownRenderer={this.markdownRenderer}
                         className='theia-cooklang-report-content'
+                        onRender={this.onMarkdownRendered}
                     />
                 );
         }
     }
+
+    protected onMarkdownRendered = (element: HTMLElement | undefined): void => {
+        if (!element) {
+            return;
+        }
+        const theme = themeTypeToMermaidTheme(this.themeService.getCurrentTheme().type);
+        // Fire-and-forget: a stale render is harmless because the next update
+        // re-runs this against fresh DOM.
+        this.mermaidRenderer.renderInto(element, theme).catch(error =>
+            console.error('Mermaid rendering failed', error)
+        );
+    };
 
     /**
      * Workspace templates declare their output format via the inner file

--- a/packages/cooklang/src/browser/report-widget.tsx
+++ b/packages/cooklang/src/browser/report-widget.tsx
@@ -128,10 +128,12 @@ export class ReportWidget extends ReactWidget implements Navigatable {
 
     /**
      * Build a self-contained, print-friendly HTML document from the currently
-     * rendered report, plus a sensible default file name. Returns `undefined`
-     * while the report is still loading or in an error state.
+     * rendered report, plus a sensible default file name. Mermaid diagrams are
+     * re-rendered in the light theme so they stay legible on white paper.
+     * Resolves to `undefined` while the report is still loading or in an error
+     * state.
      */
-    getExportDocument(): { html: string; defaultFileName: string } | undefined {
+    async getExportDocument(): Promise<{ html: string; defaultFileName: string } | undefined> {
         if (this.errorMessage !== undefined || this.output === undefined) {
             return undefined;
         }
@@ -141,8 +143,11 @@ export class ReportWidget extends ReactWidget implements Navigatable {
         if (!contentNode) {
             return undefined;
         }
+        const clone = contentNode.cloneNode(true) as HTMLElement;
+        // Re-render diagrams in the light theme so they print legibly on white.
+        await this.mermaidRenderer.renderExport(clone, 'default');
         const html = buildReportExportDocument({
-            contentHtml: contentNode.outerHTML,
+            contentHtml: clone.outerHTML,
             title: this.title.label,
         });
         const defaultFileName = `${this.uri.path.name} - ${this.options.templateLabel}`;

--- a/packages/cooklang/src/browser/style/report.css
+++ b/packages/cooklang/src/browser/style/report.css
@@ -225,6 +225,8 @@
 .theia-cooklang-mermaid {
     margin: 1.4em 0;
     text-align: center;
+    break-inside: avoid;
+    page-break-inside: avoid;
 }
 
 .theia-cooklang-mermaid svg {

--- a/packages/cooklang/src/browser/style/report.css
+++ b/packages/cooklang/src/browser/style/report.css
@@ -219,3 +219,23 @@
     border-top: 1px solid var(--report-rule-strong);
     margin: 2.6em 0;
 }
+
+/* --- Mermaid diagrams ------------------------------------ */
+
+.theia-cooklang-mermaid {
+    margin: 1.4em 0;
+    text-align: center;
+}
+
+.theia-cooklang-mermaid svg {
+    max-width: 100%;
+    height: auto;
+}
+
+.theia-cooklang-mermaid-error {
+    text-align: left;
+    color: var(--theia-errorForeground);
+    font-family: var(--theia-code-font-family);
+    font-size: 0.85em;
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
## What

Renders [Mermaid](https://mermaid.js.org/) diagrams embedded as fenced
` ```mermaid ` code blocks in the **markdown** output of Jinja reports — both
in the live report widget and in exported PDF/PNG/print output.

A report template that emits:

    ```mermaid
    graph TD; Prep --> Cook --> Serve;
    ```

now shows a rendered diagram instead of an inert code block.

## How

- **`MermaidRenderer`** (`mermaid-renderer.ts`) — lazily imports the `mermaid`
  library (its own webpack chunk; reports without diagrams pay no cost) and
  exposes `renderDiagram(source, theme)` → an SVG wrapper, plus
  `renderExport(container, theme)` to re-theme diagrams for print.
- **`MermaidMarkdown`** (`report-markdown.tsx`) — renders report markdown and
  supplies a `codeBlockRenderer` that delegates `mermaid` blocks to
  `MermaidRenderer` and falls back to `<pre><code>` for other languages.
- **Theme-follow** — diagrams use mermaid's dark theme in dark editor themes,
  default otherwise, and re-render on theme change.
- **Export** — `getExportDocument` clones the report and re-renders diagrams in
  the **light** theme so they print legibly on white paper regardless of the
  editor theme.

Scope: markdown report output only; `html`/`text` formats are untouched.

## Design note (caught by running the app)

The original plan assumed Theia's markdown renderer emits
`<pre><code class="language-mermaid">` that a post-render DOM scan could
replace. Running the real Electron app showed the bound renderer is Monaco's
`MarkdownRendererService`, which feeds fenced code blocks to a
`codeBlockRenderer(languageId, value)` callback and emits empty
`<div data-code>` placeholders otherwise — so the DOM scan matched nothing and
**zero diagrams rendered**. The integration was reworked to use the
`codeBlockRenderer` hook (commit `fix(cooklang): render mermaid via markdown
codeBlockRenderer`). Spec/plan docs updated with the correction.

## Verification

Built the app and drove the running Electron instance (CDP) against a test
recipe + a template emitting a flowchart, a sequence diagram, and a
deliberately-malformed diagram:

- ✅ Flowchart (generated from the recipe's ingredients) and sequence diagram
  render to SVG.
- ✅ Toggling the editor light↔dark theme re-renders diagrams with the matching
  mermaid theme (verified label fill `#333` ↔ `#ccc`).
- ✅ The malformed diagram shows an inline parse error; the other diagrams are
  unaffected (per-block error isolation).
- ✅ With the editor in **dark** theme, `getExportDocument` produces **light**
  diagrams (SVG fill `#333`) — print-friendly.
- ✅ `mermaid` lands in its own lazy webpack chunk, not the main bundle.
- ✅ `compile`, unit tests, and `lint` all pass.

## Notes

- Adds a direct `mermaid` (^11) dependency to `@theia/cooklang`. The existing
  `vscode.mermaid-chat-features` plugin is **not** reusable here — it renders in
  a sandboxed chat webview iframe, a different surface from the report widget's
  main-DOM markdown + export pipeline.
