### PR TITLE
fix(macos): stop Quick Look build hanging on SwiftPM artifact download

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -188,6 +188,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-eb-
 
+      # Cache resolved SwiftPM packages for the Quick Look appex, including the
+      # downloaded CooklangParserFFI.xcframework (~26 MB). Without this, every
+      # macOS build re-fetches it from GitHub release assets during xcodebuild;
+      # a single stalled download previously hung the job for the full 6h budget
+      # (release 0.1.0-alpha.25). Keyed on project.yml, which pins the version.
+      - name: Cache SwiftPM packages (Quick Look, macOS)
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: macos/QuickLookExtension/build/SourcePackages
+          key: ${{ runner.os }}-spm-quicklook-${{ hashFiles('macos/QuickLookExtension/project.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-quicklook-
+
       # cooklang-native git-depends on the private cook-md/db crates. Mint a
       # short-lived, repo-scoped GitHub App token (Contents: read on cook-md/db)
       # and rewrite the ssh URL to authenticated https so the
@@ -266,6 +280,10 @@ jobs:
 
       - name: Build & sign Quick Look extension (macOS)
         if: runner.os == 'macOS'
+        # Hard backstop: the script bounds SwiftPM resolution itself, but cap the
+        # whole step too so any unexpected hang (xcodebuild, keychain, codesign)
+        # fails fast and re-runnable instead of consuming the 6h job budget.
+        timeout-minutes: 25
         shell: bash
         env:
           MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
@@ -311,6 +329,10 @@ jobs:
 
       - name: Package & Publish
         working-directory: app
+        # Notarization round-trips to Apple can stall; bound the step so a hang
+        # fails fast rather than eating the 6h job budget. Generous because
+        # notarization legitimately takes a while.
+        timeout-minutes: 60
         shell: bash
         run: |
           PUBLISH="${{ (needs.release-please.outputs.release_created == 'true' || github.event.inputs.publish == 'true') && 'always' || 'never' }}"

--- a/macos/scripts/build-quicklook.sh
+++ b/macos/scripts/build-quicklook.sh
@@ -42,6 +42,11 @@ APP_VERSION=$(node -p "require('$REPO_ROOT/app/package.json').version" 2>/dev/nu
 VERSION_ARGS=("MARKETING_VERSION=${APP_VERSION}" "CURRENT_PROJECT_VERSION=${APP_VERSION}")
 
 DERIVED="build/DerivedData"
+# Keep resolved SwiftPM checkouts + the downloaded CooklangParserFFI.xcframework
+# (~26 MB, pulled from GitHub release assets) in a fixed, cacheable location. CI
+# caches this dir so the artifact is fetched roughly once per version instead of
+# on every macOS build — see the bounded, retried pre-resolve below.
+SPM_PACKAGES="build/SourcePackages"
 SIGN_ARGS=(CODE_SIGNING_ALLOWED=NO)
 # In CI, QUICKLOOK_SIGN_IDENTITY (a "Developer ID Application" identity hash/name) is
 # provided so xcodebuild signs the appex AND its embedded CooklangParserFFI.framework
@@ -68,11 +73,56 @@ if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
   )
 fi
 
+# --- Pre-resolve SwiftPM dependencies with a bounded timeout + retries ---
+# `xcodebuild build` resolves packages implicitly, but SwiftPM's binary-artifact
+# download (CooklangParserFFI.xcframework) has no internal timeout: a stalled
+# connection makes the build hang indefinitely (alpha.25 burned the entire 6h CI
+# budget right here). Resolving separately lets us cap each attempt and retry.
+# macOS ships no `timeout` binary, so use a small background watchdog.
+run_with_timeout() {
+  local secs="$1"; shift
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null || true
+    sleep 5; kill -KILL "$cmd_pid" 2>/dev/null || true ) &
+  local watch_pid=$!
+  local rc=0
+  wait "$cmd_pid" 2>/dev/null || rc=$?
+  kill -TERM "$watch_pid" 2>/dev/null || true
+  wait "$watch_pid" 2>/dev/null || true
+  return "$rc"
+}
+
+resolved=0
+for attempt in 1 2 3; do
+  echo "Resolving SwiftPM dependencies (attempt ${attempt}/3)..."
+  if run_with_timeout 300 xcodebuild \
+      -project CookQuickLook.xcodeproj \
+      -scheme CookQuickLook \
+      -derivedDataPath "$DERIVED" \
+      -clonedSourcePackagesDirPath "$SPM_PACKAGES" \
+      -resolvePackageDependencies; then
+    resolved=1
+    break
+  fi
+  echo "warning: SwiftPM resolution attempt ${attempt} failed or timed out; retrying..." >&2
+  sleep 5
+done
+if [[ "$resolved" -ne 1 ]]; then
+  echo "error: SwiftPM dependency resolution failed after 3 attempts" >&2
+  exit 1
+fi
+
+# Build against the already-resolved packages. -disableAutomaticPackageResolution
+# keeps `build` off the network, so it can never hang on a download — the
+# pre-resolve above (with its timeout/retry) owns all network access.
 xcodebuild \
   -project CookQuickLook.xcodeproj \
   -scheme CookQuickLook \
   -configuration Release \
   -derivedDataPath "$DERIVED" \
+  -clonedSourcePackagesDirPath "$SPM_PACKAGES" \
+  -disableAutomaticPackageResolution \
   -destination 'generic/platform=macOS' \
   ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
   "${VERSION_ARGS[@]}" \


### PR DESCRIPTION
## Root cause

In release **0.1.0-alpha.25**, both macOS release jobs (arm64 **and** x64) hung for **5h47m** and were killed only by the 6h job limit (Linux/Windows finished in ~20 min). Evidence from run [28455057893](https://github.com/cook-md/editor/actions/runs/28455057893): step 20 (`build-quicklook.sh`) produced these as its final log lines, then went silent until cancellation:

```
Resolve Package Graph
Fetching from https://github.com/cooklang/cooklang-rs
Checking out 0.18.7 of package 'cooklang-rs'
⟨ 5h47m silence ⟩
##[error]The operation was canceled.
Terminate orphan process: pid (35579) (xcodebuild)
```

`xcodebuild` was resolving the `CooklangParser` SwiftPM dependency, whose `CooklangParserFFI` is a `.binaryTarget` that downloads a ~26 MB xcframework from GitHub release assets. **SwiftPM's artifact download has no timeout** — a stalled connection hangs the build forever, and nothing bounded the step.

**This is transient, not a config bug:** the identical step took **1m44s in alpha.24** with the same `v0.18.7` and no `macos/` changes since. The asset is valid and downloadable.

## Fix (defense-in-depth)

**`macos/scripts/build-quicklook.sh`**
- Pre-resolve packages into a fixed `build/SourcePackages` with a **bounded timeout + 3× retry** (portable background-PID watchdog — macOS has no `timeout` binary).
- Build with `-disableAutomaticPackageResolution` so `xcodebuild build` never touches the network; the pre-resolve owns all downloads.

**`.github/workflows/release-please.yml`**
- Cache resolved SwiftPM packages (keyed on `project.yml`) → xcframework fetched ~once per version, not every build.
- `timeout-minutes` backstops: Quick Look step (25m), Package & Publish (60m) → any future hang fails fast and re-runnable instead of eating the 6h budget.

## Verification
- `bash -n` on the script ✅, YAML parse on the workflow ✅
- Unit-tested the watchdog+retry in isolation: passes fast commands, propagates exit codes, kills a hung command in ~2s (rc=143), and recovers via retry ✅
- ⚠️ Full appex build + real SPM download is CI-only (needs xcodegen + signing) — definitive check is the release build on this branch.