### PR TITLE
fix(macos): vendor cooklang-rs xcframework via curl to dodge flaky CI download

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -188,19 +188,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.electron_arch || 'host' }}-eb-
 
-      # Cache resolved SwiftPM packages for the Quick Look appex, including the
-      # downloaded CooklangParserFFI.xcframework (~26 MB). Without this, every
-      # macOS build re-fetches it from GitHub release assets during xcodebuild;
-      # a single stalled download previously hung the job for the full 6h budget
-      # (release 0.1.0-alpha.25). Keyed on project.yml, which pins the version.
-      - name: Cache SwiftPM packages (Quick Look, macOS)
+      # Cache the local cooklang-rs package that build-quicklook.sh prepares (source
+      # clone + the curl-fetched CooklangParserFFI.xcframework, ~26 MB, + patched
+      # manifest). On a cache hit the script skips the network entirely. xcodebuild's
+      # own SPM resolver hangs on that xcframework download in CI (tuist/tuist#9967,
+      # actions/runner-images#13175), so we curl it out-of-band and vendor it locally.
+      # Keyed on project.yml, which carries the pinned cooklang-rs version.
+      - name: Cache Quick Look cooklang-rs package (macOS)
         if: runner.os == 'macOS'
         uses: actions/cache@v4
         with:
-          path: macos/QuickLookExtension/build/SourcePackages
-          key: ${{ runner.os }}-spm-quicklook-${{ hashFiles('macos/QuickLookExtension/project.yml') }}
+          path: macos/QuickLookExtension/build/cooklang-rs
+          key: ${{ runner.os }}-ql-cooklang-rs-${{ hashFiles('macos/QuickLookExtension/project.yml') }}
           restore-keys: |
-            ${{ runner.os }}-spm-quicklook-
+            ${{ runner.os }}-ql-cooklang-rs-
 
       # cooklang-native git-depends on the private cook-md/db crates. Mint a
       # short-lived, repo-scoped GitHub App token (Contents: read on cook-md/db)

--- a/macos/QuickLookExtension/project.yml
+++ b/macos/QuickLookExtension/project.yml
@@ -6,9 +6,14 @@ options:
   createIntermediateGroups: true
 
 packages:
+  # cooklang-rs is consumed as a LOCAL package prepared by build-quicklook.sh: it
+  # curls the CooklangParserFFI xcframework and patches out cooklang-rs's remote
+  # binaryTarget, because that GitHub-release-asset download intermittently stalls
+  # and hangs xcodebuild/SwiftPM (which have no download timeout) in CI. The script
+  # parses the version from the comment below — keep it in sync when bumping.
+  # cooklang-rs-version: 0.18.7
   CooklangParser:
-    url: https://github.com/cooklang/cooklang-rs
-    exactVersion: 0.18.7
+    path: build/cooklang-rs
 
 targets:
   CookQuickLook:

--- a/macos/scripts/build-quicklook.sh
+++ b/macos/scripts/build-quicklook.sh
@@ -9,6 +9,90 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 cd "$SCRIPT_DIR/../QuickLookExtension"
 
+# run_with_timeout SECONDS CMD... — run CMD with a hard, portable timeout (macOS
+# ships no `timeout` binary) via a background watchdog. Used to bound git clone.
+run_with_timeout() {
+  local secs="$1"; shift
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null || true
+    sleep 5; kill -KILL "$cmd_pid" 2>/dev/null || true ) &
+  local watch_pid=$!
+  local rc=0
+  wait "$cmd_pid" 2>/dev/null || rc=$?
+  kill -TERM "$watch_pid" 2>/dev/null || true
+  wait "$watch_pid" 2>/dev/null || true
+  return "$rc"
+}
+
+# --- Prepare cooklang-rs as a LOCAL SwiftPM package (dodges a flaky CI download) ---
+# The GitHub release-asset download of CooklangParserFFI.xcframework intermittently
+# produces a STALLED connection on CI runners. SwiftPM/xcodebuild have no download
+# timeout, so `xcodebuild -resolvePackageDependencies` — and even `swift package
+# resolve` — hang until the job dies (alpha.25/alpha.26; tuist/tuist#9967,
+# actions/runner-images#13175). curl, by contrast, aborts a stalled connection
+# (--max-time) and retries with a FRESH one, which reliably dodges the stall. So we
+# fetch the xcframework ourselves, drop cooklang-rs's remote binaryTarget from a
+# local clone, and consume it via USE_LOCAL_XCFRAMEWORK — no SwiftPM tool ever
+# performs the hanging download. The version lives in project.yml (below) as the
+# single source of truth; the checksum comes from cooklang-rs's own manifest.
+CRS_VERSION=$(sed -nE 's/^[[:space:]]*#[[:space:]]*cooklang-rs-version:[[:space:]]*([0-9][0-9.]*).*/\1/p' project.yml | head -1)
+if [[ -z "${CRS_VERSION:-}" ]]; then
+  echo "error: could not read '# cooklang-rs-version:' from project.yml" >&2
+  exit 1
+fi
+CRS_DIR="build/cooklang-rs"
+XCF_DEST="$CRS_DIR/bindings/out/CooklangParserFFI.xcframework"
+if [[ ! -d "$XCF_DEST" ]]; then
+  echo "Preparing local cooklang-rs $CRS_VERSION ..."
+  rm -rf "$CRS_DIR"
+  # Source clone via git (reliable — uses git, not the flaky artifact CDN);
+  # bounded + retried just in case.
+  cloned=0
+  for attempt in 1 2 3; do
+    if run_with_timeout 120 git clone --depth 1 --branch "v$CRS_VERSION" \
+         https://github.com/cooklang/cooklang-rs "$CRS_DIR"; then cloned=1; break; fi
+    echo "warning: cooklang-rs clone attempt $attempt failed; retrying..." >&2
+    rm -rf "$CRS_DIR"; sleep 5
+  done
+  [[ "$cloned" -eq 1 ]] || { echo "error: could not clone cooklang-rs" >&2; exit 1; }
+
+  XCF_SHA=$(sed -nE 's/.*checksum:[[:space:]]*"([a-f0-9]{64})".*/\1/p' "$CRS_DIR/Package.swift" | head -1)
+  [[ -n "$XCF_SHA" ]] || { echo "error: no xcframework checksum in cooklang-rs Package.swift" >&2; exit 1; }
+  XCF_URL="https://github.com/cooklang/cooklang-rs/releases/download/v$CRS_VERSION/CooklangParserFFI.xcframework.zip"
+
+  # SHORT per-attempt timeout + many retries: a stalled connection is aborted at
+  # --max-time and a fresh retry dodges it (unlike SwiftPM's no-timeout single-shot).
+  echo "Downloading $XCF_URL via curl (abort+retry)..."
+  curl -fL --retry 20 --retry-all-errors --retry-delay 10 \
+    --connect-timeout 20 --max-time 120 \
+    -o "$CRS_DIR/xcf.zip" "$XCF_URL"
+
+  GOT_SHA=$(shasum -a 256 "$CRS_DIR/xcf.zip" | awk '{print $1}')
+  if [[ "$GOT_SHA" != "$XCF_SHA" ]]; then
+    echo "error: xcframework checksum mismatch (got $GOT_SHA, want $XCF_SHA)" >&2
+    exit 1
+  fi
+  mkdir -p "$CRS_DIR/bindings/out"
+  unzip -q -o "$CRS_DIR/xcf.zip" -d "$CRS_DIR/bindings/out"
+  rm -f "$CRS_DIR/xcf.zip"
+  [[ -d "$XCF_DEST" ]] || { echo "error: xcframework missing at $XCF_DEST after unzip" >&2; exit 1; }
+
+  # Drop the remote binaryTarget so SwiftPM never tries to download it; the local
+  # CooklangParserFFI_local (added by the manifest when USE_LOCAL_XCFRAMEWORK is
+  # set) is used instead. Fail loudly if the removal didn't take.
+  perl -0777 -pi -e 's/\.binaryTarget\(\s*name:\s*"CooklangParserFFI",\s*url:.*?checksum:[^)]*\),/\/* remote binaryTarget removed for offline build *\//s' "$CRS_DIR/Package.swift"
+  if grep -q 'CooklangParserFFI.xcframework.zip' "$CRS_DIR/Package.swift"; then
+    echo "error: failed to remove remote binaryTarget from cooklang-rs Package.swift" >&2
+    exit 1
+  fi
+else
+  echo "Reusing cached local cooklang-rs at $CRS_DIR"
+fi
+# Tell cooklang-rs's Package.swift to use the local xcframework path. Must be set
+# before both xcodegen (manifest eval) and xcodebuild.
+export USE_LOCAL_XCFRAMEWORK=1
+
 # --- Acquire xcodegen (prefer PATH; else pinned prebuilt binary; brew is unreliable on older Xcode) ---
 XCODEGEN_VERSION="2.43.0"
 if command -v xcodegen >/dev/null 2>&1; then
@@ -42,10 +126,6 @@ APP_VERSION=$(node -p "require('$REPO_ROOT/app/package.json').version" 2>/dev/nu
 VERSION_ARGS=("MARKETING_VERSION=${APP_VERSION}" "CURRENT_PROJECT_VERSION=${APP_VERSION}")
 
 DERIVED="build/DerivedData"
-# Keep resolved SwiftPM checkouts + the downloaded CooklangParserFFI.xcframework
-# (~26 MB, pulled from GitHub release assets) in a fixed, cacheable location. CI
-# caches this dir so the artifact is fetched roughly once per version instead of
-# on every macOS build — see the bounded, retried pre-resolve below.
 SPM_PACKAGES="build/SourcePackages"
 SIGN_ARGS=(CODE_SIGNING_ALLOWED=NO)
 # In CI, QUICKLOOK_SIGN_IDENTITY (a "Developer ID Application" identity hash/name) is
@@ -73,56 +153,14 @@ if [[ -n "${QUICKLOOK_SIGN_IDENTITY:-}" ]]; then
   )
 fi
 
-# --- Pre-resolve SwiftPM dependencies with a bounded timeout + retries ---
-# `xcodebuild build` resolves packages implicitly, but SwiftPM's binary-artifact
-# download (CooklangParserFFI.xcframework) has no internal timeout: a stalled
-# connection makes the build hang indefinitely (alpha.25 burned the entire 6h CI
-# budget right here). Resolving separately lets us cap each attempt and retry.
-# macOS ships no `timeout` binary, so use a small background watchdog.
-run_with_timeout() {
-  local secs="$1"; shift
-  "$@" &
-  local cmd_pid=$!
-  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null || true
-    sleep 5; kill -KILL "$cmd_pid" 2>/dev/null || true ) &
-  local watch_pid=$!
-  local rc=0
-  wait "$cmd_pid" 2>/dev/null || rc=$?
-  kill -TERM "$watch_pid" 2>/dev/null || true
-  wait "$watch_pid" 2>/dev/null || true
-  return "$rc"
-}
-
-resolved=0
-for attempt in 1 2 3; do
-  echo "Resolving SwiftPM dependencies (attempt ${attempt}/3)..."
-  if run_with_timeout 300 xcodebuild \
-      -project CookQuickLook.xcodeproj \
-      -scheme CookQuickLook \
-      -derivedDataPath "$DERIVED" \
-      -clonedSourcePackagesDirPath "$SPM_PACKAGES" \
-      -resolvePackageDependencies; then
-    resolved=1
-    break
-  fi
-  echo "warning: SwiftPM resolution attempt ${attempt} failed or timed out; retrying..." >&2
-  sleep 5
-done
-if [[ "$resolved" -ne 1 ]]; then
-  echo "error: SwiftPM dependency resolution failed after 3 attempts" >&2
-  exit 1
-fi
-
-# Build against the already-resolved packages. -disableAutomaticPackageResolution
-# keeps `build` off the network, so it can never hang on a download — the
-# pre-resolve above (with its timeout/retry) owns all network access.
+# cooklang-rs is now a LOCAL package (prepared above), so xcodebuild's package
+# resolution is fully offline — no binary-artifact download to stall on.
 xcodebuild \
   -project CookQuickLook.xcodeproj \
   -scheme CookQuickLook \
   -configuration Release \
   -derivedDataPath "$DERIVED" \
   -clonedSourcePackagesDirPath "$SPM_PACKAGES" \
-  -disableAutomaticPackageResolution \
   -destination 'generic/platform=macOS' \
   ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
   "${VERSION_ARGS[@]}" \


### PR DESCRIPTION
## Problem

The macOS Quick Look build's SwiftPM resolution intermittently **hangs** on the `CooklangParserFFI.xcframework` download from GitHub release assets, failing macOS release builds (alpha.25 hung 6h; alpha.26 + re-runs failed at 15-min timeout).

## Root cause (evidence-backed)

The flaky element is the **download itself** — a *stalled connection* on CI runners. SwiftPM and `xcodebuild` have **no download timeout**, so any SwiftPM tool hangs. A verification run proved even `swift package resolve` (the commonly-cited workaround) hangs during a stall window. Known Xcode/SwiftPM CI issue: [tuist/tuist#9967](https://github.com/tuist/tuist/issues/9967), [actions/runner-images#13175](https://github.com/actions/runner-images/issues/13175). `curl` and `swift`/`xcodebuild` all work during *good* windows — which is why it looks intermittent.

## Fix

`curl` aborts a stalled connection (`--max-time`) and retries with a fresh one, dodging the stall. So `build-quicklook.sh` now:

1. Clones cooklang-rs **source** (git — reliable).
2. **`curl`s the xcframework** (aggressive abort+retry), **checksum-verified** against cooklang-rs's own manifest.
3. **Patches out** the remote `binaryTarget` and consumes cooklang-rs as a **local package** via `USE_LOCAL_XCFRAMEWORK` — no SwiftPM tool ever performs the hanging download.
4. `project.yml` points at the local package (version in a parseable comment); the workflow caches the prepared package so the fetch happens ~once per version.

## Verification

- **Offline end-to-end locally**: clone → curl → patch → `swift build` with network fully blocked → success.
- **CI (no-publish dispatch, run 28520859590)**: both macOS jobs **green** — `curl` fetched the xcframework, `xcodebuild` resolved the local package offline (no `Downloading binary artifact`), appex built + signed. QL step 1–2 min, no hang.