### PR TITLE
fix(electron): unpack native executables from asar

### DIFF
--- a/app/electron-builder.yml
+++ b/app/electron-builder.yml
@@ -15,6 +15,17 @@ electronVersion: 38.4.0
 asar: true
 asarUnpack:
   - "**/*.node"
+  # Native *executables* invoked via child_process.spawn cannot run from
+  # inside the asar archive. The bundled backend copies them into lib/**
+  # (see @theia/native-webpack-plugin), where electron-builder's smart-unpack
+  # does not reach (only node_modules are auto-unpacked). Unlike the *.node
+  # addons above they are extensionless, so "**/*.node" misses them. Leaving
+  # them packed silently breaks ripgrep-backed file search (report templates,
+  # quick open, find-in-files), move-to-trash, and the terminal.
+  - "**/backend/native/**"    # ripgrep `rg`
+  - "**/backend/*trash*"      # trash helper (macos-trash / windows-trash.exe)
+  - "**/prebuilds/**"         # node-pty `spawn-helper`
+  - "**/build/Release/**"     # node-pty `spawn-helper` (alternate copy)
 nodeGypRebuild: false
 npmRebuild: false
 


### PR DESCRIPTION
## Problem

On released builds, user Jinja report templates from the workspace (e.g. `~/recipes/*.jinja`) were never discovered — the template picker showed only the two built-in templates. Works fine in dev.

## Root cause

Template discovery goes through `FileSearchService`, which spawns ripgrep (`rg`). The bundled backend (`@theia/native-webpack-plugin`) copies native executables into `lib/**` and rewrites their requires to point there, so at runtime `rgPath` = `app.asar/lib/backend/native/rg`.

`asarUnpack` only listed `**/*.node`. `rg` is **extensionless**, so it stayed packed *inside* `app.asar` — and `child_process.spawn` cannot execute a binary inside an asar archive. The spawn fails with ENOENT, `findWorkspaceTemplates()`'s `try/catch` swallows it, and returns `[]`.

Proven by inspecting an installed build:

```
app.asar list                      → /lib/backend/native/rg          (inside asar)
app.asar.unpacked/lib/backend/native/ → drivelist/keymapping/keytar/watcher.node
                                        (rg MISSING)
```

The `node_modules/@vscode/ripgrep/bin/rg` that electron-builder auto-unpacks is a decoy — the bundled backend uses the webpack-copied `lib/backend/native/rg`, not that one.

## Fix

Add asarUnpack globs for the extensionless native executables. This covers the reported ripgrep bug plus `spawn-helper` (node-pty terminal) and `macos-trash`, which have the identical root cause and were also silently broken in the release:

- `**/backend/native/**` — ripgrep `rg`
- `**/backend/*trash*` — trash helper
- `**/prebuilds/**` — node-pty `spawn-helper`
- `**/build/Release/**` — node-pty `spawn-helper` (alt copy)

## Impact of what was broken

Report templates, quick open, find-in-files, move-to-trash, and the integrated terminal in packaged builds.

## Verification

- Root cause proven against the installed app's asar (above).
- New globs match the confirmed packaged paths; the existing `**/*.node` glob already demonstrates minimatch reaches into `lib/`.
- Final confirmation requires a fresh packaged build — CI produces the release artifacts; verify `app.asar.unpacked/lib/backend/native/rg` exists in the built app.