### PR TITLE
fix(electron): point bundled rgPath at app.asar.unpacked

### DIFF
--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -190,7 +190,12 @@ async function buildFile(root: string, name: string, content: string): Promise<s
 const ripgrepReplacement = (nativePath: string = '.'): string => `
 const path = require('path');
 
-exports.rgPath = path.join(__dirname, \`./${nativePath}/rg\${process.platform === 'win32' ? '.exe' : ''}\`);
+const rgPath = path.join(__dirname, \`./${nativePath}/rg\${process.platform === 'win32' ? '.exe' : ''}\`);
+// A native binary cannot be spawned from inside an asar archive (ENOTDIR):
+// child_process is not asar-aware, unlike fs. When packaged, __dirname lives
+// under app.asar, so redirect to the unpacked copy on disk (the binary must be
+// listed in electron-builder asarUnpack). No-op in dev where there is no asar.
+exports.rgPath = rgPath.replace(/([\\\\/])app\\.asar([\\\\/])/, '$1app.asar.unpacked$2');
 `;
 
 const bindingsReplacement = (issuer: string, entries: [string, string][]): string => {


### PR DESCRIPTION
## Follow-up to #60 — the real fix

#60 (alpha.28) unpacked the ripgrep binary via `asarUnpack`, but the user still saw only built-in report templates. Root cause went one level deeper.

## Root cause

The bundled backend computes `rgPath = path.join(__dirname, './native/rg')` (native-webpack-plugin). When packaged, `__dirname` is under `app.asar`, so `rgPath` = `app.asar/lib/backend/native/rg`.

`child_process` is **not** asar-aware (only `fs` is patched by Electron), and the Theia backend runs as a forked `ELECTRON_RUN_AS_NODE` process. Spawning a binary at an `app.asar/…` path fails with **ENOTDIR** — the archive isn't a real directory. Unpacking (#60) put the file on disk at `app.asar.unpacked/…`, but nothing rewrote the *path string*.

Proven against the installed alpha.28 build:

```
spawn(app.asar/…/rg)            -> error ENOTDIR
spawn(app.asar.unpacked/…/rg)   -> status 0, ripgrep 15.0.0
cp.spawn is stock Node (not Electron-wrapped) -> no asar redirect
backend process = Cook Editor Helper (ELECTRON_RUN_AS_NODE) app.asar/lib/backend/main.js
```

So ripgrep-backed file search returned nothing: `findWorkspaceTemplates()` swallowed the spawn error and returned `[]`. Same failure hit quick-open and find-in-files.

## Fix

Rewrite the generated `rgPath` from `app.asar` to `app.asar.unpacked` (idempotent; no-op in dev where the path has no asar). The binary is already unpacked by #60's `asarUnpack`.

## Verification

- Regex unit-tested: asar→unpacked, dev unchanged, already-unpacked unchanged, Windows backslash handled.
- Rebuilt backend bundle; `main.js` carries the rewrite.
- Simulated the exact backend env (Electron `RUN_AS_NODE`, `__dirname` under `app.asar`): resolved path is `app.asar.unpacked/lib/backend/native/rg` and spawns → `ripgrep 15.0.0`, status 0.

Note: node-pty's `spawn-helper` and the trash helper share this class of issue and may need the same treatment for terminal / move-to-trash in packaged builds; not addressed here to keep this focused on the reported bug.