### PR TITLE
fix(electron): load bundled VS Code plugins in packaged app

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -84,7 +84,7 @@
     "copy:plugins": "rm -rf ./plugins && cp -r ../plugins ./plugins",
     "lint": "theiaext lint",
     "rebuild": "theia rebuild:electron --cacheRoot ..",
-    "start": "npm run -s copy:plugins && theia start --plugins=local-dir:./plugins",
+    "start": "npm run -s copy:plugins && theia start",
     "start:debug": "npm run -s start -- --log-level=debug --remote-debugging-port=9222",
     "start:watch": "concurrently --kill-others -n tsc,bundle,run -c red,yellow,green \"tsc -b -w --preserveWatchOutput\" \"npm run -s watch:bundle\" \"npm run -s start\"",
     "test": "electron-mocha --timeout 60000 \"./lib/test/**/*.espec.js\"",

--- a/packages/cooklang-branding/src/electron-main/cooklang-branding-electron-main-module.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-branding-electron-main-module.ts
@@ -11,6 +11,7 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+import * as path from 'path';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ElectronMainApplication, ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
 import { CooklangElectronMainApplication } from './cooklang-electron-main-application';
@@ -20,6 +21,18 @@ import { CooklangBrandingElectronMainContribution } from './cooklang-branding-el
 // process inherits this env var (read by @theia/vsx-registry's VSXEnvironment);
 // an explicitly set VSX_REGISTRY_URL still wins for dev overrides.
 process.env.VSX_REGISTRY_URL ??= 'https://plugins.cook.md';
+
+// Load the built-in VS Code plugins we bundle in `plugins/` (shipped into the
+// packaged app at `<THEIA_APP_PROJECT_PATH>/plugins` via electron-builder's
+// extraResources). The dev `start` script also points here. Without this, the
+// packaged backend is forked with no `--plugins` argument, so it only deploys
+// marketplace/drop-in plugins and every bundled language plugin (YAML, Jinja,
+// Markdown, ...) silently provides no grammar/highlighting in the release.
+// THEIA_APP_PROJECT_PATH is set by the generated electron-main entry before
+// this module is required; the forked backend inherits THEIA_DEFAULT_PLUGINS.
+if (process.env.THEIA_APP_PROJECT_PATH) {
+    process.env.THEIA_DEFAULT_PLUGINS ??= `local-dir:${path.resolve(process.env.THEIA_APP_PROJECT_PATH, 'plugins')}`;
+}
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(CooklangElectronMainApplication).toSelf().inSingletonScope();


### PR DESCRIPTION
## Problem

Bundled VS Code plugins in `plugins/` (YAML, Jinja, Markdown, …) provided syntax highlighting in dev but **nothing in the packaged release**. Not per-plugin — the whole bundled dir wasn't loaded in prod. (`.cook`/`.menu` were unaffected because they're the build-time `@theia/cooklang` extension, not a plugin, which masked the cause.)

## Root cause

- **Dev**: `app/package.json` `start` used `theia start --plugins=local-dir:./plugins`, so the backend scanned `app/plugins`.
- **Prod**: the packaged Electron app forks the backend with only the app's own argv — no `--plugins` — and `THEIA_DEFAULT_PLUGINS` was never set. `electron-builder.yml` still ships `plugins/` via `extraResources`, but nothing scanned it. Prod only deployed from `configDir/deployedPlugins` + `configDir/extensions`.

## Fix

Set `THEIA_DEFAULT_PLUGINS` to `<THEIA_APP_PROJECT_PATH>/plugins` in the electron-main entry (next to the existing `VSX_REGISTRY_URL` set). `THEIA_APP_PROJECT_PATH` resolves to `app/` in dev and `resources/app/` in prod, and `extraResources` lands the plugins at `<that>/plugins` in both — so one env-driven code path deploys bundled plugins as built-ins everywhere. Removed the now-redundant `--plugins` flag from the dev `start` script so dev exercises the same path as prod.

The `plugins.cook.md` marketplace flow (`VSX_REGISTRY_URL`) is untouched — that's for user-installed extensions.

## Verification

Ran Electron against the rebuilt backend with debug logging:
- `Found the list of default plugins ID on env: local-dir:.../app/plugins`
- `Resolved "samuelcolvin.jinjahtml" to ... jinjahtml@0.20.0`
- `Resolved "vscode.yaml" to ... yaml@1.104.0`
- `Start of 36 plugins` — full bundled set deploys and activates