### PR TITLE
fix(electron): actually ship + resolve bundled plugins in the release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -242,6 +242,19 @@ jobs:
       - name: Compile TypeScript
         run: npm run compile
 
+      # Download the bundled VS Code plugins into `plugins/` (theiaPluginsDir).
+      # `plugins/` is gitignored (downloaded artifacts, not committed) and the
+      # node_modules cache doesn't cover it, so this must run every build.
+      # electron-builder's `extraResources` (../plugins -> app/plugins) copies
+      # this dir into the package; without it the release ships zero plugins and
+      # every bundled language (YAML, Jinja, Markdown, ...) has no highlighting.
+      - name: Download builtin plugins
+        run: npm run download:plugins
+        env:
+          # theiaPlugins pulls a GitHub release tarball (vscode-builtin-extensions);
+          # a token avoids anonymous rate limits (403).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Bundle Electron app
         working-directory: app
         run: npm run bundle

--- a/packages/cooklang-branding/src/electron-main/cooklang-branding-electron-main-module.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-branding-electron-main-module.ts
@@ -11,6 +11,7 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+import * as fs from 'fs';
 import * as path from 'path';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { ElectronMainApplication, ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
@@ -22,16 +23,26 @@ import { CooklangBrandingElectronMainContribution } from './cooklang-branding-el
 // an explicitly set VSX_REGISTRY_URL still wins for dev overrides.
 process.env.VSX_REGISTRY_URL ??= 'https://plugins.cook.md';
 
-// Load the built-in VS Code plugins we bundle in `plugins/` (shipped into the
-// packaged app at `<THEIA_APP_PROJECT_PATH>/plugins` via electron-builder's
-// extraResources). The dev `start` script also points here. Without this, the
+// Load the built-in VS Code plugins we bundle in `plugins/`. Without this the
 // packaged backend is forked with no `--plugins` argument, so it only deploys
 // marketplace/drop-in plugins and every bundled language plugin (YAML, Jinja,
 // Markdown, ...) silently provides no grammar/highlighting in the release.
-// THEIA_APP_PROJECT_PATH is set by the generated electron-main entry before
-// this module is required; the forked backend inherits THEIA_DEFAULT_PLUGINS.
-if (process.env.THEIA_APP_PROJECT_PATH) {
-    process.env.THEIA_DEFAULT_PLUGINS ??= `local-dir:${path.resolve(process.env.THEIA_APP_PROJECT_PATH, 'plugins')}`;
+//
+// The plugins live in different places in dev vs the packaged app, so probe
+// both (most-specific first) and use whichever exists:
+//   - packaged: electron-builder ships them via extraResources to
+//     `<resourcesPath>/app/plugins`, OUTSIDE app.asar. THEIA_APP_PROJECT_PATH
+//     resolves INSIDE app.asar, so it would miss them.
+//   - dev: `<THEIA_APP_PROJECT_PATH>/plugins` (i.e. app/plugins, populated by
+//     the `copy:plugins` script). In dev `resourcesPath` points at Electron's
+//     own resources dir, which has no app/plugins, so the probe falls through.
+// The forked backend inherits THEIA_DEFAULT_PLUGINS.
+const bundledPluginsDir = [
+    process.resourcesPath && path.join(process.resourcesPath, 'app', 'plugins'),
+    process.env.THEIA_APP_PROJECT_PATH && path.resolve(process.env.THEIA_APP_PROJECT_PATH, 'plugins')
+].find((dir): dir is string => !!dir && fs.existsSync(dir));
+if (bundledPluginsDir) {
+    process.env.THEIA_DEFAULT_PLUGINS ??= `local-dir:${bundledPluginsDir}`;
 }
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {


### PR DESCRIPTION
Follow-up to #64, which was necessary but not sufficient — the release still shipped **zero** plugins, so YAML/Jinja/Markdown/… had no syntax highlighting (worked in dev only).

## Two remaining bugs

**1. CI never populated `plugins/`.** It's gitignored (downloaded artifacts — `theiaPluginsDir: plugins`, `theiaPlugins` = a vscode-builtins tarball + toml + jinja → ~35 dirs). The build job ran `npm install → compile → bundle → electron-builder` with **no `download:plugins`**, so `extraResources: from: ../plugins` copied an empty/absent dir. Added a **Download builtin plugins** step before packaging.

**2. `THEIA_DEFAULT_PLUGINS` pointed inside `app.asar`.** `extraResources` (`to: app/plugins`) lands plugins at `<resourcesPath>/app/plugins` (outside the asar), but `THEIA_APP_PROJECT_PATH` resolves inside `app.asar`. The module now probes `resourcesPath/app/plugins` first, then `THEIA_APP_PROJECT_PATH/plugins`, and uses whichever `existsSync` — correct in both dev and packaged.

## Verification

Real packaged `electron-builder --dir` build, launched with an isolated `--user-data-dir`:
- `Found the list of default plugins ID on env: local-dir:…/Cook Editor.app/Contents/Resources/app/plugins`
- `Resolved "samuelcolvin.jinjahtml" to … jinjahtml@0.20.0`
- `Resolved "vscode.yaml" to … yaml@1.104.0`, `vscode.markdown … markdown@1.104.0`
- `Start of 36 plugins`

Also confirmed the packaged `Resources/app/plugins` dir now contains all 35 plugins, and `app.asar/plugins` (the old fix's target) correctly does not exist.