### PR TITLE
feat(reports): expose expanded plan context when rendering .menu reports

### DIFF
--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "cooklang-language-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "cooklang",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "nutrition-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=aeabf6af121c483a866f8e8f536a7a0e397ccb3d#aeabf6af121c483a866f8e8f536a7a0e397ccb3d"
+source = "git+ssh://git@github.com/cook-md/db?rev=41a3727#41a3727771f73b4543fbf69936ed9696bc32532c"
 dependencies = [
  "reqwest",
  "serde",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "nutrition-jinja"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=aeabf6af121c483a866f8e8f536a7a0e397ccb3d#aeabf6af121c483a866f8e8f536a7a0e397ccb3d"
+source = "git+ssh://git@github.com/cook-md/db?rev=41a3727#41a3727771f73b4543fbf69936ed9696bc32532c"
 dependencies = [
  "cooklang",
  "cooklang-reports",

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -20,8 +20,8 @@ tokio = { version = "1", features = ["full"] }
 cooklang-language-server = { path = "../../../cooklang-language-server" }
 cooklang-sync-client = "0.5"
 chrono = "0.4"
-nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "aeabf6af121c483a866f8e8f536a7a0e397ccb3d", optional = true }
-nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "aeabf6af121c483a866f8e8f536a7a0e397ccb3d", optional = true }
+nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "41a3727", optional = true }
+nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "41a3727", optional = true }
 
 [features]
 nutrition = ["dep:nutrition-client", "dep:nutrition-jinja"]

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -915,6 +915,10 @@ struct ReportConfig {
     // the TS layer sends an identical config shape regardless of build features.
     nutrition_api_url: Option<String>,
     nutrition_token: Option<String>,
+    // True when the source is a `.menu` plan. Under `nutrition` the plan is
+    // expanded (recipe refs -> ingredients) and exposed as `plan.*` template
+    // context; the menu source itself is not rendered as a recipe.
+    is_menu: Option<bool>,
 }
 
 /// Render a Jinja2 report template against a recipe via cooklang-reports
@@ -930,6 +934,7 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
         eprintln!("[cooklang-native] invalid report config JSON, using defaults: {e}");
         ReportConfig::default()
     });
+    let base_path = cfg.base_path.clone();
     let mut builder = cooklang_reports::config::Config::builder();
     builder.scale(cfg.scale.unwrap_or(1.0));
     if let Some(p) = cfg.base_path {
@@ -946,7 +951,7 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
     }
     let config = builder.build();
     #[cfg(feature = "nutrition")]
-    let config = match cfg.nutrition_api_url {
+    let mut config = match cfg.nutrition_api_url {
         Some(url) => {
             let mut client = nutrition_client::Client::new(url);
             if let Some(tok) = cfg.nutrition_token.filter(|t| !t.is_empty()) {
@@ -957,6 +962,33 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
         }
         None => config,
     };
+    // `.menu` plans additionally get `plan.*` context (recipe refs expanded
+    // into days/meals/ingredients, dangling refs surfaced). The menu source
+    // still renders as a recipe, so templates built on the recipe-shaped
+    // `ingredients` (e.g. shopping lists via get_ingredient_list) keep
+    // working; plan-aware templates check `plan is defined`. Without the
+    // nutrition feature the menu renders as a plain recipe, as before.
+    #[cfg(feature = "nutrition")]
+    if cfg.is_menu == Some(true) {
+        let base = base_path.clone().unwrap_or_else(|| ".".to_string());
+        let plan = match nutrition_jinja::plan::build_plan_from_source(
+            &recipe,
+            std::path::Path::new(&base),
+            None,
+        ) {
+            Ok(p) => p,
+            Err(e) => return serde_json::json!({ "error": format!("plan error: {e}") }).to_string(),
+        };
+        match serde_json::to_value(&plan) {
+            Ok(v) => config = config.with_context("plan", v),
+            Err(e) => {
+                return serde_json::json!({ "error": format!("plan serialize error: {e}") })
+                    .to_string();
+            }
+        }
+    }
+    #[cfg(not(feature = "nutrition"))]
+    let _ = &base_path;
     match cooklang_reports::render_template_with_config(&recipe, &template, &config) {
         Ok(output) => serde_json::json!({ "output": output }).to_string(),
         Err(err) => serde_json::json!({ "error": err.format_with_source() }).to_string(),

--- a/packages/cooklang/src/browser/render-template-tool.ts
+++ b/packages/cooklang/src/browser/render-template-tool.ts
@@ -130,7 +130,7 @@ export class RenderTemplateTool implements ToolProvider {
         } catch (e) {
             return this.fail(`Could not read recipe ${recipeUri.toString()}: ${this.message(e)}`);
         }
-        const configJson = await this.reportConfigService.buildConfigJson(args.scale ?? 1);
+        const configJson = await this.reportConfigService.buildConfigJson(args.scale ?? 1, recipeUri);
         let resultJson: string;
         try {
             resultJson = await this.languageService.renderReport(recipeContent, args.templateContent, configJson);

--- a/packages/cooklang/src/browser/report-config-service.spec.ts
+++ b/packages/cooklang/src/browser/report-config-service.spec.ts
@@ -89,6 +89,16 @@ describe('ReportConfigService#buildConfigJson', () => {
         expect(config.scale).to.equal(2.5);
     });
 
+    it('sets isMenu for .menu sources and omits it otherwise', async () => {
+        const { service } = createService(undefined);
+        const menuConfig = JSON.parse(await service.buildConfigJson(1, new URI('file:///ws/Plans/Week.menu')));
+        expect(menuConfig.isMenu).to.equal(true);
+        const cookConfig = JSON.parse(await service.buildConfigJson(1, new URI('file:///ws/Borsch.cook')));
+        expect(cookConfig.isMenu).to.equal(undefined);
+        const noUriConfig = JSON.parse(await service.buildConfigJson(1));
+        expect(noUriConfig.isMenu).to.equal(undefined);
+    });
+
     it('includes basePath but omits optional paths when files are absent', async () => {
         const root = new URI('file:///ws');
         const { service } = createService(root, []);

--- a/packages/cooklang/src/browser/report-config-service.ts
+++ b/packages/cooklang/src/browser/report-config-service.ts
@@ -116,9 +116,11 @@ export class ReportConfigService {
 
     /**
      * Builds the render config from workspace conventions. Paths are sent as
-     * URI strings; the backend converts them to filesystem paths.
+     * URI strings; the backend converts them to filesystem paths. Pass the
+     * source `recipeUri` so `.menu` plans render through the plan expander
+     * (recipe refs → `plan.*` context) instead of as a bare recipe.
      */
-    async buildConfigJson(scale: number = 1): Promise<string> {
+    async buildConfigJson(scale: number = 1, recipeUri?: URI): Promise<string> {
         const config: {
             scale: number;
             basePath?: string;
@@ -127,11 +129,15 @@ export class ReportConfigService {
             datastorePath?: string;
             nutritionApiUrl: string;
             nutritionToken: string;
+            isMenu?: boolean;
         } = {
             scale,
             nutritionApiUrl: this.preferences.get<string>('cooklang.nutrition.serviceUrl', DEFAULT_NUTRITION_SERVICE_URL),
             nutritionToken: '',
         };
+        if (recipeUri?.path.ext === '.menu') {
+            config.isMenu = true;
+        }
         try {
             config.nutritionToken = (await this.authService.getToken()) ?? '';
         } catch (err) {

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -102,7 +102,7 @@ export class ReportContribution implements CommandContribution, MenuContribution
             templateId: template.id,
             templateLabel: template.label,
             templateUri: template.uri,
-            configJson: await this.reportConfigService.buildConfigJson(),
+            configJson: await this.reportConfigService.buildConfigJson(1, uri),
         };
         await this.reportPresenter.show(options);
     }


### PR DESCRIPTION
## Problem

Nutrition reports rendered against a `.menu` file silently omitted every referenced recipe — totals covered only loose menu items (snacks), because `aggregate_nutrition(ingredients)` does not expand recipe references. Shopping-list templates never noticed since `get_ingredient_list` does its own expansion.

## Changes

- **TS**: `buildConfigJson` takes the source URI and sets `isMenu: true` for `.menu` files; both callers (report widget command + renderTemplate AI tool) pass it. Spec added.
- **Native** (`render_report`, nutrition feature only): when `isMenu`, build the expanded plan via `nutrition_jinja::plan::build_plan_from_source` against `basePath` and inject it as `plan.*` template context — days/meals/recipes with scaled ingredients, `plan.all_ingredients`, `plan.servings` (menu frontmatter), and `plan.missing_recipes` (dangling refs, surfaced instead of fatal).
- **Back-compat**: the menu source still renders as a recipe, so recipe-shaped templates (shopping lists) are unchanged. Plan-aware templates opt in with `plan is defined`. Non-nutrition builds: no behavior change.
- Bumps `cook-md/db` to `41a3727` (plan expansion fixes: subdirectory refs, bundled timer units, loose menu items, collapsed meal headers, non-fatal missing recipes).

## Verification

- `cargo check` clean with and without `--features nutrition`; `tsc` clean; `@theia/cooklang` suite 62 passing (incl. new isMenu spec).
- The underlying plan expansion is E2E-verified in cook-md/db#46 against a real 3-day menu: 68/71 ingredients resolved (previously 13), missing recipe surfaced.