### PR TITLE
feat(nutrition): allergen support — bump nutrition crates to db 8af0735

### DIFF
--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "cooklang-language-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "cooklang",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "nutrition-client"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=41a3727#41a3727771f73b4543fbf69936ed9696bc32532c"
+source = "git+ssh://git@github.com/cook-md/db?rev=8af0735#8af073540c64b200995a191544981c17fc640d82"
 dependencies = [
  "reqwest",
  "serde",
@@ -1720,7 +1720,7 @@ dependencies = [
 [[package]]
 name = "nutrition-jinja"
 version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=41a3727#41a3727771f73b4543fbf69936ed9696bc32532c"
+source = "git+ssh://git@github.com/cook-md/db?rev=8af0735#8af073540c64b200995a191544981c17fc640d82"
 dependencies = [
  "cooklang",
  "cooklang-reports",

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -20,8 +20,8 @@ tokio = { version = "1", features = ["full"] }
 cooklang-language-server = { path = "../../../cooklang-language-server" }
 cooklang-sync-client = "0.5"
 chrono = "0.4"
-nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "41a3727", optional = true }
-nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "41a3727", optional = true }
+nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "8af0735", optional = true }
+nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "8af0735", optional = true }
 
 [features]
 nutrition = ["dep:nutrition-client", "dep:nutrition-jinja"]


### PR DESCRIPTION
## Summary
- Bumps `nutrition-client` / `nutrition-jinja` git deps from db `41a3727` → `8af0735` (allergen support, cook-md/db#47 + #48).
- No editor code changes needed: the client structs are backward-compatible additions, and `NutritionExtension` now auto-registers an `allergens` jinja template so user reports can render the standard Contains / incomplete lines via `{% include "allergens" %}`.
- `cargo check --features nutrition` clean.

## Test Plan
- [ ] CI (private-dep fetch via GitHub-App token)
- [ ] With nutrition.cook.md deployed: render a report with `{% set alg = agg.allergen_summary %}{% if alg %}{% include "allergens" %}{% endif %}` → Contains line appears