### PR TITLE
feat: nutrition deps from crates.io (public cooklang-reports-nutrition)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -69,29 +69,6 @@ jobs:
         if: steps.node-modules-cache.outputs.cache-hit == 'true'
         run: npx lerna run afterInstall
 
-      # cooklang-native git-depends on the private cook-md/db crates
-      # (nutrition-client/nutrition-jinja). Mint a short-lived, repo-scoped token
-      # from a GitHub App (Contents: read on cook-md/db) and rewrite the ssh URL
-      # to authenticated https so the `--features nutrition` build can fetch them.
-      # Requires DB_APP_ID + DB_APP_PRIVATE_KEY secrets on this repo.
-      - name: Mint cook-md/db access token
-        id: db_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DB_APP_ID }}
-          private-key: ${{ secrets.DB_APP_PRIVATE_KEY }}
-          owner: cook-md
-          repositories: db
-
-      - name: Configure git for private nutrition crates
-        env:
-          DB_TOKEN: ${{ steps.db_token.outputs.token }}
-        run: |
-          git config --global \
-            url."https://x-access-token:${DB_TOKEN}@github.com/cook-md/db".insteadOf \
-            "ssh://git@github.com/cook-md/db"
-          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
-
       - name: Build native addon
         working-directory: packages/cooklang-native
         run: npm run build

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -203,30 +203,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ql-cooklang-rs-
 
-      # cooklang-native git-depends on the private cook-md/db crates. Mint a
-      # short-lived, repo-scoped GitHub App token (Contents: read on cook-md/db)
-      # and rewrite the ssh URL to authenticated https so the
-      # `--features nutrition` build can fetch them across all targets.
-      # Requires DB_APP_ID + DB_APP_PRIVATE_KEY secrets on this repo.
-      - name: Mint cook-md/db access token
-        id: db_token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.DB_APP_ID }}
-          private-key: ${{ secrets.DB_APP_PRIVATE_KEY }}
-          owner: cook-md
-          repositories: db
-
-      - name: Configure git for private nutrition crates
-        shell: bash
-        env:
-          DB_TOKEN: ${{ steps.db_token.outputs.token }}
-        run: |
-          git config --global \
-            url."https://x-access-token:${DB_TOKEN}@github.com/cook-md/db".insteadOf \
-            "ssh://git@github.com/cook-md/db"
-          echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
-
       - name: Build native addon
         working-directory: packages/cooklang-native
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,9 @@ This is an **Electron-only** application. There is no browser target. Only `app/
 - `cd packages/cooklang-native && cargo build` - Build the NAPI-RS native addon (Rust)
 - `cd packages/cooklang-native && npm run build` - Build native addon for Node.js (requires @napi-rs/cli)
   - The `build`/`build:debug` scripts compile with `--features nutrition`, which
-    git-depends on the private `cook-md/db` crates over SSH. Building the addon
-    therefore requires read access to `cook-md/db` (CI mints a GitHub App token;
-    locally use your own SSH access). A plain `cargo build` with no feature flag
-    builds without nutrition and needs no `cook-md/db` access.
+    pulls the public crates.io crates `cookmd-nutrition-client` and
+    `cooklang-reports-nutrition`. A plain `cargo build` with no feature flag
+    builds without nutrition.
 
 **Package-specific (using lerna):**
 - `npx lerna run compile --scope @theia/package-name` - Build specific package

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -442,12 +442,12 @@ dependencies = [
  "cooklang-find",
  "cooklang-language-server",
  "cooklang-reports",
+ "cooklang-reports-nutrition",
  "cooklang-sync-client",
+ "cookmd-nutrition-client",
  "napi",
  "napi-build",
  "napi-derive",
- "nutrition-client",
- "nutrition-jinja",
  "serde",
  "serde_json",
  "tokio",
@@ -469,6 +469,23 @@ dependencies = [
  "serde_yaml",
  "thiserror 2.0.18",
  "yaml-datastore",
+]
+
+[[package]]
+name = "cooklang-reports-nutrition"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c30b1dda78e184e84649d11f92f046376f8aca9f5cce9fa3ca4fce068369aa"
+dependencies = [
+ "cooklang",
+ "cooklang-reports",
+ "cookmd-nutrition-client",
+ "minijinja",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -499,6 +516,18 @@ dependencies = [
  "tokio-util",
  "uuid",
  "walkdir",
+]
+
+[[package]]
+name = "cookmd-nutrition-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291517bf73e91e62cf571ca84fb69ad5f600ec496104a6fa3117b8e29908029f"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1704,33 +1733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "nutrition-client"
-version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=8af0735#8af073540c64b200995a191544981c17fc640d82"
-dependencies = [
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "nutrition-jinja"
-version = "0.1.0"
-source = "git+ssh://git@github.com/cook-md/db?rev=8af0735#8af073540c64b200995a191544981c17fc640d82"
-dependencies = [
- "cooklang",
- "cooklang-reports",
- "minijinja",
- "nutrition-client",
- "regex",
- "serde",
- "serde_json",
- "serde_yaml",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -20,11 +20,11 @@ tokio = { version = "1", features = ["full"] }
 cooklang-language-server = { path = "../../../cooklang-language-server" }
 cooklang-sync-client = "0.5"
 chrono = "0.4"
-nutrition-client = { git = "ssh://git@github.com/cook-md/db", rev = "8af0735", optional = true }
-nutrition-jinja  = { git = "ssh://git@github.com/cook-md/db", rev = "8af0735", optional = true }
+cookmd-nutrition-client = { version = "0.1", optional = true }
+cooklang-reports-nutrition = { version = "0.1", optional = true }
 
 [features]
-nutrition = ["dep:nutrition-client", "dep:nutrition-jinja"]
+nutrition = ["dep:cookmd-nutrition-client", "dep:cooklang-reports-nutrition"]
 
 [build-dependencies]
 napi-build = "2"

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -953,11 +953,11 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
     #[cfg(feature = "nutrition")]
     let mut config = match cfg.nutrition_api_url {
         Some(url) => {
-            let mut client = nutrition_client::Client::new(url);
+            let mut client = cookmd_nutrition_client::Client::new(url);
             if let Some(tok) = cfg.nutrition_token.filter(|t| !t.is_empty()) {
                 client = client.with_auth_token(tok);
             }
-            let ext = nutrition_jinja::NutritionExtension::new(std::sync::Arc::new(client));
+            let ext = cooklang_reports_nutrition::NutritionExtension::new(std::sync::Arc::new(client));
             config.with_extension(ext)
         }
         None => config,
@@ -971,7 +971,7 @@ pub fn render_report(recipe: String, template: String, config_json: String) -> S
     #[cfg(feature = "nutrition")]
     if cfg.is_menu == Some(true) {
         let base = base_path.clone().unwrap_or_else(|| ".".to_string());
-        let plan = match nutrition_jinja::plan::build_plan_from_source(
+        let plan = match cooklang_reports_nutrition::plan::build_plan_from_source(
             &recipe,
             std::path::Path::new(&base),
             None,


### PR DESCRIPTION
## Summary

The nutrition crates formerly consumed as git deps on the private `cook-md/db` repo are now published publicly (from github.com/cook-md/cooklang-reports-nutrition):

| old (git, private) | new (crates.io) | lib name |
|---|---|---|
| `nutrition-client` | `cookmd-nutrition-client = "0.1"` | `cookmd_nutrition_client` |
| `nutrition-jinja` | `cooklang-reports-nutrition = "0.1"` | `cooklang_reports_nutrition` |

APIs are identical to the rev we pinned (`8af0735`) — only crate/lib names changed. The private repo has dropped its copies (db PR #50).

## Changes

- `packages/cooklang-native/Cargo.toml`: swap ssh git deps for the crates.io versions; the optional `nutrition` feature is wired exactly as before.
- `packages/cooklang-native/src/lib.rs`: rename import paths (`nutrition_client` → `cookmd_nutrition_client`, `nutrition_jinja` → `cooklang_reports_nutrition`). No logic changes.
- `.github/workflows/pr.yml` + `release-please.yml`: remove the GitHub-App token workaround (mint token + git insteadOf rewrite + `CARGO_NET_GIT_FETCH_WITH_CLI`) — it existed solely to fetch the private repo. `DB_APP_ID` / `DB_APP_PRIVATE_KEY` secrets are no longer referenced (they can be deleted from repo settings once this merges).
- `CLAUDE.md`: update build notes — building with `--features nutrition` no longer needs `cook-md/db` access.

## Testing

- `cargo test --features nutrition`: 16 passed (incl. `feature_on_registers_extension_and_attempts_call`)
- `cargo test` (default, no feature): 16 passed (incl. `feature_off_nutrition_for_is_unregistered`)
- `cargo build` green in both configs; `Cargo.lock` no longer references `cook-md/db`.