### PR TITLE
feat: recipe import (URL, text, images, clipping browser)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ license-check-summary.txt*
 .playwright-mcp/*
 /.theia/chatSessions
 /app/dist/
+.worktrees/

--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,7 @@
     "@theia/cooklang-account": "1.70.0",
     "@theia/cooklang-ai": "1.70.0",
     "@theia/cooklang-branding": "1.70.0",
+    "@theia/cooklang-import": "1.70.0",
     "@theia/core": "1.70.0",
     "@theia/editor": "1.70.0",
     "@theia/editor-preview": "1.70.0",

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -36,6 +36,9 @@
       "path": "../packages/cooklang-branding"
     },
     {
+      "path": "../packages/cooklang-import"
+    },
+    {
       "path": "../packages/core"
     },
     {

--- a/docs/superpowers/plans/2026-07-24-recipe-import.md
+++ b/docs/superpowers/plans/2026-07-24-recipe-import.md
@@ -1,0 +1,1844 @@
+# Recipe Import Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A main-area "Import Recipe" widget that converts recipes from URL / pasted text / images / an internal clipping browser into Cooklang via the cook.md REST cookify API and saves them into `Drafts/` in the workspace.
+
+**Architecture:** New Theia extension package `@theia/cooklang-import`. A node-side `CookifyApiClient` (RPC service at `/services/cooklang-import`) calls `POST https://cook.md/api/cookify/{url,text,images}` with the cook.md JWT from `@theia/cooklang-account`'s `AuthService`. A browser-side `ImportWidget` (ReactWidget, 4 tabs) collects input and hands successful conversions to `DraftSaver`, which writes `Drafts/<Title>.cook` and opens it. The clipping browser is an Electron `<webview>` (requires enabling `webviewTag` in `cooklang-branding`).
+
+**Tech Stack:** TypeScript ~5.4, InversifyJS (property injection), React 18 via `ReactWidget`, mocha+chai specs (`theiaext test`), Node `https` for HTTP (matches `subscription-service.ts`), Electron `<webview>`.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-recipe-import-design.md` — read it first.
+
+**Conventions that apply to every task:**
+
+- Every new `.ts`/`.tsx` file starts with the standard license header used across custom packages (copy verbatim from `packages/cooklang-account/src/common/auth-protocol.ts` lines 1–12: `Copyright (C) 2024-2026 cook.md and contributors`, AGPL-3.0-only with linking exception).
+- 4-space indent, single quotes, explicit return types, `undefined` not `null`, property injection, `nls.localize` for all user-facing strings.
+- Compile: `npx lerna run compile --scope @theia/cooklang-import`
+- Test: `npx lerna run test --scope @theia/cooklang-import` (tests run against compiled `lib/`, so compile first).
+
+## File structure
+
+```
+packages/cooklang-import/
+  package.json                            (Task 1)
+  tsconfig.json                           (Task 1)
+  src/common/recipe-import-protocol.ts    (Task 2)  RPC path, symbol, ConvertResult union
+  src/node/cookify-api-client.ts          (Task 3)  REST client, implements RecipeImportService
+  src/node/cookify-api-client.spec.ts     (Task 3)
+  src/node/cooklang-import-backend-module.ts (Task 1 stub, Task 3 bindings)
+  src/browser/recipe-payload.ts           (Task 4)  JSON-LD Recipe extraction (pure)
+  src/browser/recipe-payload.spec.ts      (Task 4)
+  src/browser/draft-name.ts               (Task 5)  title/frontmatter/filename helpers (pure)
+  src/browser/draft-name.spec.ts          (Task 5)
+  src/browser/draft-saver.ts              (Task 6)  writes Drafts/<name>.cook, opens editor
+  src/browser/import-widget.tsx           (Task 7 shell; Tasks 8–10 fill tabs)
+  src/browser/import-contribution.ts      (Task 7)  command + File menu + view contribution
+  src/browser/style/index.css             (Task 7)
+  src/browser/cooklang-import-frontend-module.ts (Task 1 stub, Tasks 6–7 bindings)
+app/package.json                          (Task 1: add dependency)
+app/tsconfig.json                         (Task 1: add reference)
+packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts (Task 10: webviewTag)
+docs/superpowers/specs/…                  (already committed)
+```
+
+---
+
+### Task 1: Scaffold `@theia/cooklang-import` and wire it into the app
+
+**Files:**
+- Create: `packages/cooklang-import/package.json`
+- Create: `packages/cooklang-import/tsconfig.json`
+- Create: `packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts`
+- Create: `packages/cooklang-import/src/node/cooklang-import-backend-module.ts`
+- Modify: `app/package.json` (dependencies)
+- Modify: `app/tsconfig.json` (references)
+
+- [ ] **Step 1: Create a feature branch**
+
+```bash
+git checkout -b feature/recipe-import
+```
+
+- [ ] **Step 2: Create `packages/cooklang-import/package.json`**
+
+Model: `packages/cooklang-account/package.json`.
+
+```json
+{
+  "name": "@theia/cooklang-import",
+  "version": "1.70.0",
+  "description": "Theia - Cooklang Recipe Import (URL, text, images, clipping browser)",
+  "dependencies": {
+    "@theia/core": "1.70.0",
+    "@theia/filesystem": "1.70.0",
+    "@theia/workspace": "1.70.0",
+    "@theia/cooklang-account": "1.70.0",
+    "tslib": "^2.6.2"
+  },
+  "main": "lib/common",
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/cooklang-import-frontend-module",
+      "backend": "lib/node/cooklang-import-backend-module"
+    }
+  ],
+  "keywords": ["theia-extension"],
+  "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
+  "files": ["lib", "src"],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.70.0"
+  }
+}
+```
+
+- [ ] **Step 3: Create `packages/cooklang-import/tsconfig.json`**
+
+```json
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../core" },
+    { "path": "../filesystem" },
+    { "path": "../workspace" },
+    { "path": "../cooklang-account" }
+  ]
+}
+```
+
+- [ ] **Step 4: Create empty container modules** (so the package compiles)
+
+`src/browser/cooklang-import-frontend-module.ts` (license header, then):
+
+```ts
+import { ContainerModule } from '@theia/core/shared/inversify';
+
+export default new ContainerModule(bind => {
+});
+```
+
+`src/node/cooklang-import-backend-module.ts`: same content.
+
+- [ ] **Step 5: Wire into the app**
+
+In `app/package.json`, add to dependencies (alphabetical, next to the other cooklang packages):
+
+```json
+    "@theia/cooklang-import": "1.70.0",
+```
+
+In `app/tsconfig.json`, add to references (alphabetical):
+
+```json
+    { "path": "../packages/cooklang-import" },
+```
+
+- [ ] **Step 6: Install (creates the workspace symlink) and compile**
+
+```bash
+npm install
+npx lerna run compile --scope @theia/cooklang-import
+```
+
+Expected: compiles with no errors (an ESLint "empty function" warning on the modules is fine at this stage; the modules gain bindings in Tasks 3 and 6–7).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cooklang-import app/package.json app/tsconfig.json package-lock.json
+git commit -m "feat(import): scaffold @theia/cooklang-import package"
+```
+
+---
+
+### Task 2: Protocol — `RecipeImportService`
+
+**Files:**
+- Create: `packages/cooklang-import/src/common/recipe-import-protocol.ts`
+
+Pure types — no unit test.
+
+- [ ] **Step 1: Write the protocol**
+
+Design note: conversion failures are returned as a **result union**, not thrown. Theia's RPC proxy does not preserve custom fields on thrown Errors, so a typed `error` code in the return value is the reliable way to get the failure kind across the wire. (Theia RPC has other serialization pitfalls too — see the `on*`-property warning in `packages/cooklang-account/src/common/auth-protocol.ts`.)
+
+```ts
+export const RecipeImportServicePath = '/services/cooklang-import';
+export const RecipeImportService = Symbol('RecipeImportService');
+
+export type ImportErrorCode = 'unauthorized' | 'rate-limited' | 'conversion-failed' | 'network';
+
+export interface ConvertSuccess {
+    cooklang: string;
+    name?: string;
+    error?: undefined;
+}
+
+export interface ConvertFailure {
+    error: ImportErrorCode;
+    cooklang?: undefined;
+    name?: undefined;
+}
+
+export type ConvertResult = ConvertSuccess | ConvertFailure;
+
+/**
+ * Converts recipes to Cooklang via the cook.md cookify REST API.
+ * Remote service: interface + symbol (used from both frontend and backend).
+ */
+export interface RecipeImportService {
+    convertUrl(url: string): Promise<ConvertResult>;
+    convertText(text: string): Promise<ConvertResult>;
+    /** Base64-encoded JPEGs, max 5. Requires a signed-in user. */
+    convertImages(imagesBase64: string[]): Promise<ConvertResult>;
+}
+```
+
+- [ ] **Step 2: Compile and commit**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+git add packages/cooklang-import/src/common
+git commit -m "feat(import): add RecipeImportService protocol"
+```
+
+---
+
+### Task 3: `CookifyApiClient` (node) — TDD
+
+**Files:**
+- Create: `packages/cooklang-import/src/node/cookify-api-client.ts`
+- Test: `packages/cooklang-import/src/node/cookify-api-client.spec.ts`
+- Modify: `packages/cooklang-import/src/node/cooklang-import-backend-module.ts`
+
+The client mirrors the iOS contract (see spec "Background"). HTTP goes through a protected `httpPost` method (Node `https`/`http`, same style as `subscription-service.ts:262`) so tests subclass and stub it — no network in tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/node/cookify-api-client.spec.ts` (license header, then):
+
+```ts
+import { expect } from 'chai';
+import { CookifyApiClient, HttpResponse } from './cookify-api-client';
+import { ConvertResult } from '../common/recipe-import-protocol';
+
+class TestClient extends CookifyApiClient {
+    requests: Array<{ url: string; body: string; headers: Record<string, string> }> = [];
+    nextResponse: HttpResponse = { status: 200, body: '{"cooklang": "recipe"}' };
+    failWith: Error | undefined;
+
+    protected override httpPost(url: URL, body: string, headers: Record<string, string>): Promise<HttpResponse> {
+        this.requests.push({ url: url.toString(), body, headers });
+        return this.failWith ? Promise.reject(this.failWith) : Promise.resolve(this.nextResponse);
+    }
+}
+
+function createClient(token: string | undefined): TestClient {
+    const client = new TestClient();
+    // Property injection: assign the injected services directly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (client as any).authService = { getToken: () => Promise.resolve(token) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (client as any).applicationServer = { getApplicationInfo: () => Promise.resolve({ name: 'cook-editor', version: '0.1.0' }) };
+    return client;
+}
+
+describe('CookifyApiClient', () => {
+
+    it('POSTs the url and returns cooklang + name on 200', async () => {
+        const client = createClient(undefined);
+        client.nextResponse = { status: 200, body: '{"cooklang": "---\\ntitle: Pancakes\\n---\\n", "name": "Pancakes"}' };
+        const result = await client.convertUrl('https://example.com/pancakes');
+        expect(result.cooklang).to.contain('Pancakes');
+        expect(result.name).to.equal('Pancakes');
+        expect(client.requests[0].url).to.equal('https://cook.md/api/cookify/url');
+        expect(JSON.parse(client.requests[0].body)).to.deep.equal({ url: 'https://example.com/pancakes' });
+    });
+
+    it('omits the Authorization header when logged out and adds it when a token exists', async () => {
+        const anonymous = createClient(undefined);
+        await anonymous.convertText('some recipe text');
+        expect(anonymous.requests[0].headers).to.not.have.property('Authorization');
+
+        const signedIn = createClient('jwt-token');
+        await signedIn.convertText('some recipe text');
+        expect(signedIn.requests[0].headers.Authorization).to.equal('Bearer jwt-token');
+    });
+
+    it('sends JSON and client-version headers', async () => {
+        const client = createClient(undefined);
+        await client.convertText('text');
+        const headers = client.requests[0].headers;
+        expect(headers['Content-Type']).to.equal('application/json');
+        expect(headers.Accept).to.equal('application/json');
+        expect(headers['X-Client-Version']).to.equal('editor/0.1.0');
+    });
+
+    it('rejects convertImages locally when no token is present', async () => {
+        const client = createClient(undefined);
+        const result = await client.convertImages(['base64data']);
+        expect(result.error).to.equal('unauthorized');
+        expect(client.requests).to.have.length(0);
+    });
+
+    it('sends images with the bearer token when signed in', async () => {
+        const client = createClient('jwt-token');
+        const result = await client.convertImages(['aaa', 'bbb']);
+        expect(result.error).to.equal(undefined);
+        expect(client.requests[0].url).to.equal('https://cook.md/api/cookify/images');
+        expect(JSON.parse(client.requests[0].body)).to.deep.equal({ images: ['aaa', 'bbb'] });
+    });
+
+    const statusCases: Array<[number, string]> = [
+        [401, 'unauthorized'],
+        [422, 'conversion-failed'],
+        [429, 'rate-limited'],
+        [500, 'network'],
+    ];
+    for (const [status, code] of statusCases) {
+        it(`maps HTTP ${status} to '${code}'`, async () => {
+            const client = createClient(undefined);
+            client.nextResponse = { status, body: '' };
+            const result: ConvertResult = await client.convertUrl('https://example.com');
+            expect(result.error).to.equal(code);
+        });
+    }
+
+    it('maps transport failures to network error', async () => {
+        const client = createClient(undefined);
+        client.failWith = new Error('ECONNREFUSED');
+        const result = await client.convertUrl('https://example.com');
+        expect(result.error).to.equal('network');
+    });
+
+    it('maps a 200 with unparseable body to conversion-failed', async () => {
+        const client = createClient(undefined);
+        client.nextResponse = { status: 200, body: 'not json' };
+        const result = await client.convertUrl('https://example.com');
+        expect(result.error).to.equal('conversion-failed');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+```
+
+Expected: compile FAILS — `cookify-api-client` module does not exist. (Compile failure is this stage's "red".)
+
+- [ ] **Step 3: Implement `src/node/cookify-api-client.ts`**
+
+```ts
+import * as http from 'http';
+import * as https from 'https';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
+import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
+import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
+
+export interface HttpResponse {
+    status: number;
+    body: string;
+}
+
+/**
+ * REST client for the cook.md cookify API. Mirrors the contract used by the
+ * iOS app: POST /api/cookify/{url,text,images}; Bearer token optional for
+ * url/text, required for images; 401/422/429 map to typed error codes.
+ */
+@injectable()
+export class CookifyApiClient implements RecipeImportService {
+
+    @inject(AuthService)
+    protected readonly authService: AuthService;
+
+    @inject(ApplicationServer)
+    protected readonly applicationServer: ApplicationServer;
+
+    protected get baseUrl(): string {
+        return process.env.WEB_BASE_URL || 'https://cook.md';
+    }
+
+    convertUrl(url: string): Promise<ConvertResult> {
+        return this.post('/api/cookify/url', { url }, false);
+    }
+
+    convertText(text: string): Promise<ConvertResult> {
+        return this.post('/api/cookify/text', { text }, false);
+    }
+
+    convertImages(imagesBase64: string[]): Promise<ConvertResult> {
+        return this.post('/api/cookify/images', { images: imagesBase64 }, true);
+    }
+
+    protected async post(path: string, payload: object, requireAuth: boolean): Promise<ConvertResult> {
+        const token = await this.authService.getToken();
+        if (requireAuth && !token) {
+            return { error: 'unauthorized' };
+        }
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Client-Version': `editor/${await this.clientVersion()}`,
+        };
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+        let response: HttpResponse;
+        try {
+            response = await this.httpPost(new URL(path, this.baseUrl), JSON.stringify(payload), headers);
+        } catch (err) {
+            console.warn('cookify request failed:', err instanceof Error ? err.message : String(err));
+            return { error: 'network' };
+        }
+        if (response.status >= 200 && response.status < 300) {
+            try {
+                const data = JSON.parse(response.body);
+                if (typeof data.cooklang !== 'string') {
+                    return { error: 'conversion-failed' };
+                }
+                return { cooklang: data.cooklang, name: typeof data.name === 'string' ? data.name : undefined };
+            } catch {
+                return { error: 'conversion-failed' };
+            }
+        }
+        return { error: this.errorForStatus(response.status) };
+    }
+
+    protected errorForStatus(status: number): ImportErrorCode {
+        switch (status) {
+            case 401: return 'unauthorized';
+            case 422: return 'conversion-failed';
+            case 429: return 'rate-limited';
+            default: return 'network';
+        }
+    }
+
+    protected async clientVersion(): Promise<string> {
+        try {
+            const info = await this.applicationServer.getApplicationInfo();
+            return info?.version ?? 'dev';
+        } catch {
+            return 'dev';
+        }
+    }
+
+    protected httpPost(url: URL, body: string, headers: Record<string, string>): Promise<HttpResponse> {
+        const lib = url.protocol === 'https:' ? https : http;
+        return new Promise((resolve, reject) => {
+            const req = lib.request(url, { method: 'POST', headers }, (res: http.IncomingMessage) => {
+                let data = '';
+                res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+            });
+            req.on('error', reject);
+            req.end(body);
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Bind it in the backend module**
+
+Replace the body of `src/node/cooklang-import-backend-module.ts`:
+
+```ts
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common/messaging';
+import { RecipeImportService, RecipeImportServicePath } from '../common/recipe-import-protocol';
+import { CookifyApiClient } from './cookify-api-client';
+
+export default new ContainerModule(bind => {
+    bind(CookifyApiClient).toSelf().inSingletonScope();
+    bind(RecipeImportService).toService(CookifyApiClient);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(RecipeImportServicePath, () =>
+            ctx.container.get(RecipeImportService)
+        )
+    ).inSingletonScope();
+});
+```
+
+- [ ] **Step 5: Compile and run the tests — verify they pass**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+npx lerna run test --scope @theia/cooklang-import
+```
+
+Expected: all `CookifyApiClient` specs PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cooklang-import/src/node
+git commit -m "feat(import): cookify REST client with typed error mapping"
+```
+
+---
+
+### Task 4: JSON-LD Recipe extraction — TDD
+
+**Files:**
+- Create: `packages/cooklang-import/src/browser/recipe-payload.ts`
+- Test: `packages/cooklang-import/src/browser/recipe-payload.spec.ts`
+
+Pure function used by the clipping browser: given the raw `<script type="application/ld+json">` block contents and the page's rendered text, return the best payload for `/api/cookify/text` — the serialized schema.org Recipe if one exists, otherwise the page text. No DOM access here (the in-page script that *collects* blocks/text lives in the widget, Task 10).
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/browser/recipe-payload.spec.ts`:
+
+```ts
+import { expect } from 'chai';
+import { RecipePayload } from './recipe-payload';
+
+const RECIPE = { '@type': 'Recipe', name: 'Pancakes', recipeIngredient: ['2 eggs'] };
+
+describe('RecipePayload.extract', () => {
+
+    it('returns the serialized Recipe from a plain JSON-LD block', () => {
+        const result = RecipePayload.extract([JSON.stringify(RECIPE)], 'page text');
+        expect(JSON.parse(result)).to.deep.equal(RECIPE);
+    });
+
+    it('finds a Recipe inside a top-level array', () => {
+        const block = JSON.stringify([{ '@type': 'WebSite' }, RECIPE]);
+        expect(JSON.parse(RecipePayload.extract([block], ''))).to.deep.equal(RECIPE);
+    });
+
+    it('finds a Recipe inside an @graph', () => {
+        const block = JSON.stringify({ '@context': 'https://schema.org', '@graph': [{ '@type': 'WebPage' }, RECIPE] });
+        expect(JSON.parse(RecipePayload.extract([block], ''))).to.deep.equal(RECIPE);
+    });
+
+    it('matches @type arrays containing Recipe', () => {
+        const recipe = { '@type': ['Thing', 'Recipe'], name: 'Soup' };
+        expect(JSON.parse(RecipePayload.extract([JSON.stringify(recipe)], ''))).to.deep.equal(recipe);
+    });
+
+    it('skips malformed blocks and still finds a Recipe in a later block', () => {
+        const result = RecipePayload.extract(['{not json', JSON.stringify(RECIPE)], '');
+        expect(JSON.parse(result)).to.deep.equal(RECIPE);
+    });
+
+    it('falls back to trimmed page text when no Recipe is present', () => {
+        const block = JSON.stringify({ '@type': 'NewsArticle' });
+        expect(RecipePayload.extract([block], '  Grandma’s stew: brown the beef…  ')).to.equal('Grandma’s stew: brown the beef…');
+    });
+
+    it('falls back to page text when there are no blocks at all', () => {
+        expect(RecipePayload.extract([], 'just text')).to.equal('just text');
+    });
+});
+```
+
+- [ ] **Step 2: Compile — verify red** (module missing → compile error)
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+```
+
+- [ ] **Step 3: Implement `src/browser/recipe-payload.ts`**
+
+```ts
+/**
+ * Chooses the payload sent to /api/cookify/text when clipping a page:
+ * the schema.org Recipe from JSON-LD when present, otherwise the page text.
+ */
+export namespace RecipePayload {
+
+    export function extract(jsonLdBlocks: string[], pageText: string): string {
+        for (const block of jsonLdBlocks) {
+            let parsed: unknown;
+            try {
+                parsed = JSON.parse(block);
+            } catch {
+                continue;
+            }
+            const recipe = findRecipe(parsed);
+            if (recipe) {
+                return JSON.stringify(recipe);
+            }
+        }
+        return pageText.trim();
+    }
+
+    function findRecipe(node: unknown): object | undefined {
+        if (Array.isArray(node)) {
+            for (const item of node) {
+                const found = findRecipe(item);
+                if (found) {
+                    return found;
+                }
+            }
+            return undefined;
+        }
+        if (node && typeof node === 'object') {
+            const type = (node as { '@type'?: unknown })['@type'];
+            if (type === 'Recipe' || (Array.isArray(type) && type.includes('Recipe'))) {
+                return node;
+            }
+            const graph = (node as { '@graph'?: unknown })['@graph'];
+            if (Array.isArray(graph)) {
+                return findRecipe(graph);
+            }
+        }
+        return undefined;
+    }
+}
+```
+
+- [ ] **Step 4: Compile, run tests — verify green**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+npx lerna run test --scope @theia/cooklang-import
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang-import/src/browser/recipe-payload.ts packages/cooklang-import/src/browser/recipe-payload.spec.ts
+git commit -m "feat(import): JSON-LD Recipe extraction for page clipping"
+```
+
+---
+
+### Task 5: Draft naming helpers — TDD
+
+**Files:**
+- Create: `packages/cooklang-import/src/browser/draft-name.ts`
+- Test: `packages/cooklang-import/src/browser/draft-name.spec.ts`
+
+Pure helpers for title resolution (API `name` → frontmatter `title:` → caller's fallback), frontmatter injection (iOS parity), filename sanitization, and collision-free naming.
+
+- [ ] **Step 1: Write the failing tests**
+
+`src/browser/draft-name.spec.ts`:
+
+```ts
+import { expect } from 'chai';
+import { DraftName } from './draft-name';
+
+describe('DraftName', () => {
+
+    describe('resolveTitle', () => {
+        it('prefers the API-provided name', () => {
+            expect(DraftName.resolveTitle('---\ntitle: Other\n---\n', 'Pancakes')).to.equal('Pancakes');
+        });
+        it('ignores a blank API name and reads the frontmatter title', () => {
+            expect(DraftName.resolveTitle('---\ntitle: Pancakes\n---\nMix @eggs{2}.', '  ')).to.equal('Pancakes');
+        });
+        it('returns undefined when neither source has a title', () => {
+            expect(DraftName.resolveTitle('Mix @eggs{2}.', undefined)).to.equal(undefined);
+            expect(DraftName.resolveTitle('---\nservings: 4\n---\nMix.', undefined)).to.equal(undefined);
+        });
+    });
+
+    describe('ensureTitleFrontmatter', () => {
+        it('leaves content with a titled frontmatter unchanged', () => {
+            const src = '---\ntitle: Pancakes\n---\nMix @eggs{2}.';
+            expect(DraftName.ensureTitleFrontmatter(src, 'Pancakes')).to.equal(src);
+        });
+        it('inserts title into an existing frontmatter without one', () => {
+            expect(DraftName.ensureTitleFrontmatter('---\nservings: 4\n---\nMix.', 'Pancakes'))
+                .to.equal('---\ntitle: Pancakes\nservings: 4\n---\nMix.');
+        });
+        it('prepends frontmatter when there is none', () => {
+            expect(DraftName.ensureTitleFrontmatter('Mix @eggs{2}.', 'Pancakes'))
+                .to.equal('---\ntitle: Pancakes\n---\n\nMix @eggs{2}.');
+        });
+    });
+
+    describe('sanitizeFilename', () => {
+        it('strips characters that are unsafe in filenames', () => {
+            expect(DraftName.sanitizeFilename('Mom’s "Best" Soup: a/b\\c?')).to.equal('Mom’s Best Soup ab c');
+        });
+        it('collapses whitespace and trims leading/trailing dots and spaces', () => {
+            expect(DraftName.sanitizeFilename('  .Fancy   Bread.  ')).to.equal('Fancy Bread');
+        });
+        it('falls back for names that sanitize to nothing', () => {
+            expect(DraftName.sanitizeFilename('::""//')).to.equal('Imported Recipe');
+        });
+    });
+
+    describe('uniqueBaseName', () => {
+        it('returns the base name when it is free', async () => {
+            const name = await DraftName.uniqueBaseName('Pancakes', async () => false);
+            expect(name).to.equal('Pancakes');
+        });
+        it('appends an incrementing counter until the name is free', async () => {
+            const taken = new Set(['Pancakes', 'Pancakes-2']);
+            const name = await DraftName.uniqueBaseName('Pancakes', async candidate => taken.has(candidate));
+            expect(name).to.equal('Pancakes-3');
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Compile — verify red**
+
+- [ ] **Step 3: Implement `src/browser/draft-name.ts`**
+
+```ts
+/**
+ * Naming helpers for imported drafts: title resolution, frontmatter
+ * injection (parity with the iOS app's clipping flow), and safe,
+ * collision-free file names.
+ */
+export namespace DraftName {
+
+    export function resolveTitle(cooklang: string, apiName: string | undefined): string | undefined {
+        if (apiName && apiName.trim().length > 0) {
+            return apiName.trim();
+        }
+        return frontmatterTitle(cooklang);
+    }
+
+    export function ensureTitleFrontmatter(cooklang: string, title: string): string {
+        const lines = cooklang.split('\n');
+        if (lines[0]?.trim() === '---') {
+            if (frontmatterTitle(cooklang) !== undefined) {
+                return cooklang;
+            }
+            return [lines[0], `title: ${title}`, ...lines.slice(1)].join('\n');
+        }
+        return `---\ntitle: ${title}\n---\n\n${cooklang}`;
+    }
+
+    export function sanitizeFilename(title: string): string {
+        const cleaned = title
+            .replace(/[/\\:*?"<>|]/g, '')
+            .replace(/\s+/g, ' ')
+            .replace(/^[. ]+|[. ]+$/g, '');
+        return cleaned.length > 0 ? cleaned : 'Imported Recipe';
+    }
+
+    export async function uniqueBaseName(base: string, exists: (candidate: string) => Promise<boolean>): Promise<string> {
+        if (!await exists(base)) {
+            return base;
+        }
+        for (let i = 2; ; i++) {
+            const candidate = `${base}-${i}`;
+            if (!await exists(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    function frontmatterTitle(cooklang: string): string | undefined {
+        const lines = cooklang.split('\n');
+        if (lines[0]?.trim() !== '---') {
+            return undefined;
+        }
+        for (let i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '---') {
+                return undefined;
+            }
+            const match = lines[i].match(/^title:\s*(.+)$/);
+            if (match) {
+                return match[1].trim();
+            }
+        }
+        return undefined;
+    }
+}
+```
+
+- [ ] **Step 4: Compile, run tests — verify green**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang-import/src/browser/draft-name.ts packages/cooklang-import/src/browser/draft-name.spec.ts
+git commit -m "feat(import): draft naming and frontmatter helpers"
+```
+
+---
+
+### Task 6: `DraftSaver` service
+
+**Files:**
+- Create: `packages/cooklang-import/src/browser/draft-saver.ts`
+- Modify: `packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts`
+
+Thin orchestration over the tested helpers + Theia services; no unit test (covered by manual verification in Task 11).
+
+- [ ] **Step 1: Implement `src/browser/draft-saver.ts`**
+
+```ts
+import { injectable, inject } from '@theia/core/shared/inversify';
+import URI from '@theia/core/lib/common/uri';
+import { nls } from '@theia/core/lib/common/nls';
+import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { ConvertSuccess } from '../common/recipe-import-protocol';
+import { DraftName } from './draft-name';
+
+export const DRAFTS_FOLDER_NAME = 'Drafts';
+
+/**
+ * Writes a converted recipe into <workspace root>/Drafts/<Title>.cook
+ * (creating the folder and de-duplicating the name) and opens it.
+ */
+@injectable()
+export class DraftSaver {
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
+
+    async save(result: ConvertSuccess): Promise<URI> {
+        const roots = await this.workspaceService.roots;
+        if (roots.length === 0) {
+            throw new Error(nls.localize('theia/cooklang-import/noWorkspace', 'Open a folder before importing recipes.'));
+        }
+        const draftsDir = roots[0].resource.resolve(DRAFTS_FOLDER_NAME);
+        if (!await this.fileService.exists(draftsDir)) {
+            await this.fileService.createFolder(draftsDir);
+        }
+        const title = DraftName.resolveTitle(result.cooklang, result.name)
+            ?? nls.localize('theia/cooklang-import/importedRecipe', 'Imported Recipe');
+        const content = DraftName.ensureTitleFrontmatter(result.cooklang, title);
+        const base = await DraftName.uniqueBaseName(
+            DraftName.sanitizeFilename(title),
+            candidate => this.fileService.exists(draftsDir.resolve(`${candidate}.cook`))
+        );
+        const uri = draftsDir.resolve(`${base}.cook`);
+        await this.fileService.create(uri, content);
+        await open(this.openerService, uri);
+        return uri;
+    }
+}
+```
+
+- [ ] **Step 2: Bind it** — in `cooklang-import-frontend-module.ts` add:
+
+```ts
+import { DraftSaver } from './draft-saver';
+// inside the ContainerModule callback:
+bind(DraftSaver).toSelf().inSingletonScope();
+```
+
+- [ ] **Step 3: Compile, commit**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+git add packages/cooklang-import/src/browser
+git commit -m "feat(import): DraftSaver writes converted recipes to Drafts/"
+```
+
+---
+
+### Task 7: Widget shell, contribution, frontend wiring, styles
+
+**Files:**
+- Create: `packages/cooklang-import/src/browser/import-widget.tsx`
+- Create: `packages/cooklang-import/src/browser/import-contribution.ts`
+- Create: `packages/cooklang-import/src/browser/style/index.css`
+- Modify: `packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts`
+
+This task produces a working main-area widget with a tab bar and placeholder tab bodies; Tasks 8–10 fill the tabs. Model: `AccountWidget` / `AccountContribution`.
+
+- [ ] **Step 1: Create `src/browser/import-widget.tsx`**
+
+```tsx
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { CommandService } from '@theia/core/lib/common/command';
+import { nls } from '@theia/core/lib/common/nls';
+import * as React from '@theia/core/shared/react';
+import { AuthService, AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
+import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
+import { ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
+import { DraftSaver } from './draft-saver';
+
+export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
+
+export type ImportTab = 'url' | 'text' | 'images' | 'browser';
+
+@injectable()
+export class ImportWidget extends ReactWidget {
+
+    static readonly ID = IMPORT_WIDGET_ID;
+    static readonly LABEL = nls.localize('theia/cooklang-import/widgetLabel', 'Import Recipe');
+
+    @inject(RecipeImportService)
+    protected readonly importService: RecipeImportService;
+
+    @inject(DraftSaver)
+    protected readonly draftSaver: DraftSaver;
+
+    @inject(AuthService)
+    protected readonly authService: AuthService;
+
+    @inject(AuthContribution)
+    protected readonly authContribution: AuthContribution;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    protected activeTab: ImportTab = 'url';
+    protected authState: AuthState = { status: 'logged-out' };
+    protected busy = false;
+    protected errorMessage: string | undefined;
+    protected errorShowsSignIn = false;
+    protected successMessage: string | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = ImportWidget.ID;
+        this.title.label = ImportWidget.LABEL;
+        this.title.caption = ImportWidget.LABEL;
+        this.title.iconClass = 'codicon codicon-cloud-download';
+        this.title.closable = true;
+        this.addClass('cooklang-import-widget');
+        this.refreshAuthState();
+        this.toDispose.push(this.authContribution.onDidChangeAuth(() => this.refreshAuthState()));
+    }
+
+    protected refreshAuthState(): void {
+        this.authService.getAuthState().then(state => {
+            this.authState = state;
+            this.update();
+        });
+    }
+
+    protected get signedIn(): boolean {
+        return this.authState.status === 'logged-in';
+    }
+
+    protected signIn = (): void => {
+        this.commandService.executeCommand(CookmdLoginCommand.id);
+    };
+
+    protected selectTab(tab: ImportTab): void {
+        this.activeTab = tab;
+        this.errorMessage = undefined;
+        this.successMessage = undefined;
+        this.update();
+    }
+
+    // Shared conversion pipeline used by all tabs (Tasks 8-10 call this).
+    protected async runImport(convert: () => Promise<import('../common/recipe-import-protocol').ConvertResult>): Promise<void> {
+        this.busy = true;
+        this.errorMessage = undefined;
+        this.successMessage = undefined;
+        this.update();
+        try {
+            const result = await convert();
+            if (result.error !== undefined) {
+                this.showError(result.error);
+                return;
+            }
+            const uri = await this.draftSaver.save(result);
+            this.successMessage = nls.localize('theia/cooklang-import/savedTo', 'Saved to {0}', `Drafts/${uri.path.base}`);
+        } catch (err) {
+            this.errorMessage = err instanceof Error ? err.message : String(err);
+            this.errorShowsSignIn = false;
+        } finally {
+            this.busy = false;
+            this.update();
+        }
+    }
+
+    protected showError(code: ImportErrorCode): void {
+        this.errorShowsSignIn = false;
+        switch (code) {
+            case 'rate-limited':
+                if (this.signedIn) {
+                    this.errorMessage = nls.localize('theia/cooklang-import/rateLimited', 'Import limit reached. Please try again later.');
+                } else {
+                    this.errorMessage = nls.localize('theia/cooklang-import/rateLimitedAnon', 'Import limit reached — sign in to increase your limits.');
+                    this.errorShowsSignIn = true;
+                }
+                break;
+            case 'unauthorized':
+                this.errorMessage = nls.localize('theia/cooklang-import/unauthorized', 'Please sign in to continue.');
+                this.errorShowsSignIn = true;
+                break;
+            case 'conversion-failed':
+                this.errorMessage = nls.localize('theia/cooklang-import/conversionFailed', 'Couldn’t extract a recipe from this source. Try another one.');
+                break;
+            default:
+                this.errorMessage = nls.localize('theia/cooklang-import/networkError', 'Connection problem. Please try again.');
+        }
+    }
+
+    protected render(): React.ReactNode {
+        return (
+            <div className='cooklang-import-content'>
+                {this.renderTabBar()}
+                {!this.signedIn && this.activeTab !== 'images' && this.renderLimitsBanner()}
+                {this.renderStatus()}
+                <div className='cooklang-import-tab-body'>
+                    {this.renderActiveTab()}
+                </div>
+            </div>
+        );
+    }
+
+    protected renderTabBar(): React.ReactNode {
+        const tabs: Array<{ id: ImportTab; label: string }> = [
+            { id: 'url', label: nls.localize('theia/cooklang-import/tabUrl', 'URL') },
+            { id: 'text', label: nls.localize('theia/cooklang-import/tabText', 'Text') },
+            { id: 'images', label: nls.localize('theia/cooklang-import/tabImages', 'Images') },
+            { id: 'browser', label: nls.localize('theia/cooklang-import/tabBrowser', 'Web Browser') },
+        ];
+        return (
+            <div className='cooklang-import-tabbar' role='tablist'>
+                {tabs.map(tab => (
+                    <TabButton key={tab.id} tab={tab.id} label={tab.label}
+                        active={this.activeTab === tab.id}
+                        onSelect={this.onTabSelected} />
+                ))}
+            </div>
+        );
+    }
+
+    protected onTabSelected = (tab: ImportTab): void => {
+        this.selectTab(tab);
+    };
+
+    protected renderLimitsBanner(): React.ReactNode {
+        return (
+            <div className='cooklang-import-banner'>
+                <span>{nls.localize('theia/cooklang-import/limitsBanner', 'Sign in for higher import limits.')}</span>
+                <a onClick={this.signIn}>{nls.localize('theia/cooklang-import/signIn', 'Sign in')}</a>
+            </div>
+        );
+    }
+
+    protected renderStatus(): React.ReactNode {
+        if (this.busy) {
+            return <div className='cooklang-import-status'>
+                <i className='codicon codicon-loading codicon-modifier-spin' />
+                {nls.localize('theia/cooklang-import/importing', 'Importing…')}
+            </div>;
+        }
+        if (this.errorMessage) {
+            return <div className='cooklang-import-status cooklang-import-error'>
+                <span>{this.errorMessage}</span>
+                {this.errorShowsSignIn && !this.signedIn &&
+                    <button className='theia-button' onClick={this.signIn}>
+                        {nls.localize('theia/cooklang-import/signIn', 'Sign in')}
+                    </button>}
+            </div>;
+        }
+        if (this.successMessage) {
+            return <div className='cooklang-import-status cooklang-import-success'>{this.successMessage}</div>;
+        }
+        return undefined;
+    }
+
+    protected renderActiveTab(): React.ReactNode {
+        // Tabs are implemented in Tasks 8-10; placeholders until then.
+        switch (this.activeTab) {
+            case 'url': return this.renderUrlTab();
+            case 'text': return this.renderTextTab();
+            case 'images': return this.renderImagesTab();
+            case 'browser': return this.renderBrowserTab();
+        }
+    }
+
+    protected renderUrlTab(): React.ReactNode {
+        return <div />;
+    }
+
+    protected renderTextTab(): React.ReactNode {
+        return <div />;
+    }
+
+    protected renderImagesTab(): React.ReactNode {
+        return <div />;
+    }
+
+    protected renderBrowserTab(): React.ReactNode {
+        return <div />;
+    }
+}
+
+interface TabButtonProps {
+    tab: ImportTab;
+    label: string;
+    active: boolean;
+    onSelect: (tab: ImportTab) => void;
+}
+
+class TabButton extends React.Component<TabButtonProps> {
+    override render(): React.ReactNode {
+        const { label, active } = this.props;
+        return <div role='tab' aria-selected={active}
+            className={'cooklang-import-tab' + (active ? ' cooklang-import-tab-active' : '')}
+            onClick={this.handleClick}>{label}</div>;
+    }
+    protected handleClick = (): void => {
+        this.props.onSelect(this.props.tab);
+    };
+}
+```
+
+Note: event handlers are class-property arrow functions and per-tab state is a child component — no `bind()`/inline lambdas in JSX (see `doc/coding-guidelines.md` React rules). Keep this discipline in Tasks 8–10.
+
+- [ ] **Step 2: Create `src/browser/import-contribution.ts`**
+
+```ts
+import { injectable } from '@theia/core/shared/inversify';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
+import { Command, CommandRegistry } from '@theia/core/lib/common/command';
+import { MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
+
+export namespace ImportCommands {
+    export const OPEN: Command = Command.toLocalizedCommand({
+        id: 'cooklang.import.open',
+        label: 'Import Recipe…',
+    }, 'theia/cooklang-import/openCommand');
+}
+
+@injectable()
+export class ImportContribution extends AbstractViewContribution<ImportWidget> {
+
+    constructor() {
+        super({
+            widgetId: IMPORT_WIDGET_ID,
+            widgetName: ImportWidget.LABEL,
+            defaultWidgetOptions: { area: 'main' },
+        });
+    }
+
+    override registerCommands(registry: CommandRegistry): void {
+        super.registerCommands(registry);
+        registry.registerCommand(ImportCommands.OPEN, {
+            execute: () => this.openView({ activate: true, reveal: true }),
+        });
+    }
+
+    override registerMenus(menus: MenuModelRegistry): void {
+        super.registerMenus(menus);
+        menus.registerMenuAction(CommonMenus.FILE, {
+            commandId: ImportCommands.OPEN.id,
+            order: 'z10',
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Create `src/browser/style/index.css`**
+
+```css
+.cooklang-import-widget {
+    display: flex;
+    flex-direction: column;
+}
+
+.cooklang-import-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: var(--theia-ui-padding);
+}
+
+.cooklang-import-tabbar {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--theia-panel-border);
+    margin-bottom: var(--theia-ui-padding);
+}
+
+.cooklang-import-tab {
+    padding: 4px 12px;
+    cursor: pointer;
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-tab-active {
+    color: var(--theia-foreground);
+    border-bottom: 2px solid var(--theia-focusBorder);
+}
+
+.cooklang-import-banner {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 8px;
+    margin-bottom: var(--theia-ui-padding);
+    background-color: var(--theia-editorWidget-background);
+    border: 1px solid var(--theia-panel-border);
+    border-radius: 3px;
+}
+
+.cooklang-import-banner a {
+    cursor: pointer;
+    color: var(--theia-textLink-foreground);
+}
+
+.cooklang-import-status {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 0;
+}
+
+.cooklang-import-error {
+    color: var(--theia-errorForeground);
+}
+
+.cooklang-import-success {
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-tab-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.cooklang-import-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--theia-ui-padding);
+    max-width: 640px;
+}
+
+.cooklang-import-form textarea {
+    min-height: 200px;
+    resize: vertical;
+}
+
+.cooklang-import-dropzone {
+    border: 2px dashed var(--theia-panel-border);
+    border-radius: 4px;
+    padding: 32px;
+    text-align: center;
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-dropzone.cooklang-import-dropzone-active {
+    border-color: var(--theia-focusBorder);
+}
+
+.cooklang-import-thumbs {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.cooklang-import-thumbs img {
+    max-width: 96px;
+    max-height: 96px;
+    object-fit: cover;
+    border-radius: 3px;
+}
+
+.cooklang-import-signin-gate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--theia-ui-padding);
+    padding: 48px 16px;
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-browser {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: 4px;
+}
+
+.cooklang-import-browser-toolbar {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.cooklang-import-browser-toolbar input {
+    flex: 1;
+}
+
+.cooklang-import-browser webview {
+    flex: 1;
+    border: 1px solid var(--theia-panel-border);
+}
+```
+
+- [ ] **Step 4: Wire the frontend module**
+
+Replace `src/browser/cooklang-import-frontend-module.ts` content:
+
+```ts
+import '../../src/browser/style/index.css';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
+import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
+import { bindViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { RecipeImportService, RecipeImportServicePath } from '../common/recipe-import-protocol';
+import { DraftSaver } from './draft-saver';
+import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
+import { ImportContribution } from './import-contribution';
+
+export default new ContainerModule(bind => {
+    bind(RecipeImportService).toDynamicValue(ctx =>
+        ServiceConnectionProvider.createProxy<RecipeImportService>(ctx.container, RecipeImportServicePath)
+    ).inSingletonScope();
+
+    bind(DraftSaver).toSelf().inSingletonScope();
+
+    bind(ImportWidget).toSelf().inSingletonScope();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: IMPORT_WIDGET_ID,
+        createWidget: () => ctx.container.get(ImportWidget),
+    })).inSingletonScope();
+
+    bindViewContribution(bind, ImportContribution);
+});
+```
+
+- [ ] **Step 5: Compile and lint**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import
+npx lerna run lint --scope @theia/cooklang-import
+```
+
+Expected: clean. If `AuthContribution`'s `onDidChangeAuth` name differs, check `packages/cooklang-account/src/browser/auth-contribution.ts` and use the actual event name (the account widget subscribes to it at `account-widget.tsx:72`).
+
+- [ ] **Step 6: Smoke-run the app** (verifies the widget opens; tabs are empty placeholders)
+
+```bash
+cd app && npm run bundle && npm run start:electron
+```
+
+Open a workspace folder, run "Import Recipe…" from the command palette (and File menu). Expected: main-area tab with 4 tab headers; signed-out banner visible on URL/Text/Browser tabs when logged out.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cooklang-import/src/browser
+git commit -m "feat(import): Import Recipe widget shell, command and menu entry"
+```
+
+---
+
+### Task 8: URL and Text tabs
+
+**Files:**
+- Modify: `packages/cooklang-import/src/browser/import-widget.tsx`
+
+- [ ] **Step 1: Add tab state fields to `ImportWidget`**
+
+```ts
+protected urlValue = '';
+protected textValue = '';
+```
+
+- [ ] **Step 2: Replace `renderUrlTab` / `renderTextTab` and add handlers**
+
+```tsx
+protected renderUrlTab(): React.ReactNode {
+    return (
+        <div className='cooklang-import-form'>
+            <label>{nls.localize('theia/cooklang-import/urlLabel', 'Recipe page URL')}</label>
+            <input className='theia-input' type='text' value={this.urlValue}
+                placeholder='https://example.com/best-pancakes'
+                onChange={this.onUrlChanged} onKeyDown={this.onUrlKeyDown} disabled={this.busy} />
+            <button className='theia-button main' onClick={this.importFromUrl}
+                disabled={this.busy || this.urlValue.trim().length === 0}>
+                {nls.localize('theia/cooklang-import/importButton', 'Import')}
+            </button>
+        </div>
+    );
+}
+
+protected onUrlChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    this.urlValue = event.target.value;
+    this.update();
+};
+
+protected onUrlKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'Enter' && this.urlValue.trim().length > 0 && !this.busy) {
+        this.importFromUrl();
+    }
+};
+
+protected importFromUrl = (): void => {
+    const url = this.urlValue.trim();
+    this.runImport(() => this.importService.convertUrl(url));
+};
+
+protected renderTextTab(): React.ReactNode {
+    return (
+        <div className='cooklang-import-form'>
+            <label>{nls.localize('theia/cooklang-import/textLabel', 'Paste the recipe text')}</label>
+            <textarea className='theia-input' value={this.textValue}
+                onChange={this.onTextChanged} disabled={this.busy} />
+            <button className='theia-button main' onClick={this.importFromText}
+                disabled={this.busy || this.textValue.trim().length === 0}>
+                {nls.localize('theia/cooklang-import/importButton', 'Import')}
+            </button>
+        </div>
+    );
+}
+
+protected onTextChanged = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+    this.textValue = event.target.value;
+    this.update();
+};
+
+protected importFromText = (): void => {
+    const text = this.textValue.trim();
+    this.runImport(() => this.importService.convertText(text));
+};
+```
+
+- [ ] **Step 3: Compile, lint, smoke-test**
+
+Compile + lint as before, then run the app. Import a real recipe URL (e.g. a public recipe page) while signed out: expect a new `Drafts/<Title>.cook` opened in the editor, success message in the widget. Paste plain recipe text in the Text tab and import: same. Break the network (or use an invalid URL like `https://invalid.invalid`): expect the network/conversion error message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-import/src/browser/import-widget.tsx
+git commit -m "feat(import): URL and text import tabs"
+```
+
+---
+
+### Task 9: Images tab (auth-gated, drag-and-drop, compression)
+
+**Files:**
+- Create: `packages/cooklang-import/src/browser/image-encoder.ts`
+- Modify: `packages/cooklang-import/src/browser/import-widget.tsx`
+
+- [ ] **Step 1: Create `src/browser/image-encoder.ts`**
+
+DOM/canvas-dependent — no unit test; verified manually.
+
+```ts
+export const MAX_IMPORT_IMAGES = 5;
+const MAX_EDGE_PX = 2048;
+const JPEG_QUALITY = 0.7;
+
+/**
+ * Downscales (longest edge <= 2048px) and re-encodes an image file as a
+ * base64 JPEG string (no data-URL prefix), matching the payload the
+ * cookify images endpoint expects.
+ */
+export namespace ImageEncoder {
+
+    export async function toBase64Jpeg(file: File): Promise<string> {
+        const bitmap = await createImageBitmap(file);
+        try {
+            const scale = Math.min(1, MAX_EDGE_PX / Math.max(bitmap.width, bitmap.height));
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.round(bitmap.width * scale);
+            canvas.height = Math.round(bitmap.height * scale);
+            const context = canvas.getContext('2d');
+            if (!context) {
+                throw new Error('Canvas 2D context unavailable');
+            }
+            context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+            const dataUrl = canvas.toDataURL('image/jpeg', JPEG_QUALITY);
+            return dataUrl.substring(dataUrl.indexOf(',') + 1);
+        } finally {
+            bitmap.close();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Implement the images tab in `ImportWidget`**
+
+Add state:
+
+```ts
+protected images: Array<{ file: File; previewUrl: string }> = [];
+protected dropActive = false;
+```
+
+Replace `renderImagesTab` and add handlers:
+
+```tsx
+protected renderImagesTab(): React.ReactNode {
+    if (!this.signedIn) {
+        return (
+            <div className='cooklang-import-signin-gate'>
+                <i className='codicon codicon-account' />
+                <span>{nls.localize('theia/cooklang-import/imagesSignIn', 'Sign in to CookCloud to use image clipping.')}</span>
+                <button className='theia-button main' onClick={this.signIn}>
+                    {nls.localize('theia/cooklang-import/signIn', 'Sign in')}
+                </button>
+            </div>
+        );
+    }
+    return (
+        <div className='cooklang-import-form'>
+            <div className={'cooklang-import-dropzone' + (this.dropActive ? ' cooklang-import-dropzone-active' : '')}
+                onDragOver={this.onDragOver} onDragLeave={this.onDragLeave} onDrop={this.onDrop}>
+                {nls.localize('theia/cooklang-import/dropImages', 'Drop up to {0} recipe photos here, or', MAX_IMPORT_IMAGES)}
+                <input type='file' accept='image/*' multiple onChange={this.onFilesPicked} disabled={this.busy} />
+            </div>
+            {this.images.length > 0 &&
+                <div className='cooklang-import-thumbs'>
+                    {this.images.map(image => <img key={image.previewUrl} src={image.previewUrl} />)}
+                </div>}
+            <button className='theia-button main' onClick={this.importFromImages}
+                disabled={this.busy || this.images.length === 0}>
+                {nls.localize('theia/cooklang-import/importButton', 'Import')}
+            </button>
+        </div>
+    );
+}
+
+protected onDragOver = (event: React.DragEvent): void => {
+    event.preventDefault();
+    this.dropActive = true;
+    this.update();
+};
+
+protected onDragLeave = (): void => {
+    this.dropActive = false;
+    this.update();
+};
+
+protected onDrop = (event: React.DragEvent): void => {
+    event.preventDefault();
+    this.dropActive = false;
+    this.addImageFiles(Array.from(event.dataTransfer.files));
+};
+
+protected onFilesPicked = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    this.addImageFiles(Array.from(event.target.files ?? []));
+    event.target.value = '';
+};
+
+protected addImageFiles(files: File[]): void {
+    const imageFiles = files.filter(file => file.type.startsWith('image/'));
+    for (const file of imageFiles) {
+        if (this.images.length >= MAX_IMPORT_IMAGES) {
+            break;
+        }
+        this.images.push({ file, previewUrl: URL.createObjectURL(file) });
+    }
+    this.update();
+}
+
+protected clearImages(): void {
+    this.images.forEach(image => URL.revokeObjectURL(image.previewUrl));
+    this.images = [];
+}
+
+protected importFromImages = (): void => {
+    const files = this.images.map(image => image.file);
+    this.runImport(async () => {
+        const encoded = await Promise.all(files.map(file => ImageEncoder.toBase64Jpeg(file)));
+        return this.importService.convertImages(encoded);
+    }).then(() => {
+        if (this.successMessage) {
+            this.clearImages();
+            this.update();
+        }
+    }, (err: unknown) => console.error('Image import failed:', err));
+};
+```
+
+Add imports at the top: `import { ImageEncoder, MAX_IMPORT_IMAGES } from './image-encoder';`
+
+Also revoke preview URLs on widget disposal — in `init()`:
+
+```ts
+this.toDispose.push({ dispose: () => this.clearImages() });
+```
+
+- [ ] **Step 3: Compile, lint, smoke-test**
+
+Signed out: images tab shows the sign-in gate (no picker). Signed in: drop 1–2 photos of a cookbook page → Import → draft created and opened. Also verify the 5-image cap (drop 6, only 5 thumbnails).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-import/src/browser
+git commit -m "feat(import): auth-gated image import with drag-and-drop"
+```
+
+---
+
+### Task 10: Clipping browser tab + `webviewTag` enablement
+
+**Files:**
+- Modify: `packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts`
+- Modify: `packages/cooklang-import/src/browser/import-widget.tsx`
+
+- [ ] **Step 1: Enable the webview tag in the branding electron-main**
+
+In `CooklangElectronMainApplication.getDefaultOptions()` (line 23), merge `webPreferences` **after** the config spread so it cannot be overridden off:
+
+```ts
+protected override getDefaultOptions(): TheiaBrowserWindowOptions {
+    const options = super.getDefaultOptions();
+    const resolved = {
+        ...options,
+        ...this.resolveWindowOptions(this.config.electron?.windowOptions || {}),
+    };
+    return {
+        ...resolved,
+        webPreferences: {
+            ...resolved.webPreferences,
+            // Required by the recipe-import clipping browser (<webview> tag).
+            webviewTag: true,
+        },
+    };
+}
+```
+
+- [ ] **Step 2: Implement the browser tab in `ImportWidget`**
+
+The `<webview>` element has no React/TS typings in browser code; declare the minimal surface locally. Security per spec: isolated `partition`, no node integration (webview default when not explicitly enabled — do NOT set `nodeintegration`).
+
+Add to `import-widget.tsx`:
+
+```tsx
+import { RecipePayload } from './recipe-payload';
+
+interface WebviewElement extends HTMLElement {
+    src: string;
+    canGoBack(): boolean;
+    canGoForward(): boolean;
+    goBack(): void;
+    goForward(): void;
+    reload(): void;
+    getURL(): string;
+    executeJavaScript(code: string): Promise<unknown>;
+}
+
+const CLIP_SCRIPT = `(() => ({
+    jsonLdBlocks: Array.from(document.querySelectorAll('script[type="application/ld+json"]')).map(s => s.textContent || ''),
+    pageText: document.body ? document.body.innerText : ''
+}))()`;
+```
+
+State + handlers on `ImportWidget`:
+
+```ts
+protected webview: WebviewElement | undefined;
+protected browserAddress = '';
+protected browserUrl = '';           // committed URL loaded in the webview
+protected pageLoaded = false;
+protected pageLoadFailed = false;
+```
+
+```tsx
+protected renderBrowserTab(): React.ReactNode {
+    return (
+        <div className='cooklang-import-browser'>
+            <div className='cooklang-import-browser-toolbar'>
+                <button className='theia-button secondary' onClick={this.browserBack} disabled={!this.canGoBack()}>
+                    <i className='codicon codicon-arrow-left' />
+                </button>
+                <button className='theia-button secondary' onClick={this.browserForward} disabled={!this.canGoForward()}>
+                    <i className='codicon codicon-arrow-right' />
+                </button>
+                <button className='theia-button secondary' onClick={this.browserReload} disabled={!this.browserUrl}>
+                    <i className='codicon codicon-refresh' />
+                </button>
+                <input className='theia-input' type='text' value={this.browserAddress}
+                    placeholder={nls.localize('theia/cooklang-import/browserPlaceholder', 'Enter a URL and press Enter')}
+                    onChange={this.onAddressChanged} onKeyDown={this.onAddressKeyDown} />
+                <button className='theia-button main' onClick={this.clipPage}
+                    disabled={this.busy || !this.pageLoaded}>
+                    {nls.localize('theia/cooklang-import/clipButton', 'Clip Recipe')}
+                </button>
+            </div>
+            {this.pageLoadFailed &&
+                <div className='cooklang-import-status cooklang-import-error'>
+                    {nls.localize('theia/cooklang-import/pageLoadFailed', 'The page failed to load.')}
+                </div>}
+            {this.browserUrl
+                ? React.createElement('webview', {
+                    ref: this.setWebview,
+                    src: this.browserUrl,
+                    partition: 'import-browser',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any)
+                : <div className='cooklang-import-dropzone'>
+                    {nls.localize('theia/cooklang-import/browserHint', 'Browse to a recipe page, then press Clip Recipe.')}
+                </div>}
+        </div>
+    );
+}
+
+protected setWebview = (element: HTMLElement | null): void => {
+    if (this.webview === element) {
+        return;
+    }
+    this.webview = (element ?? undefined) as WebviewElement | undefined;
+    if (this.webview) {
+        this.webview.addEventListener('did-finish-load', this.onPageLoaded);
+        this.webview.addEventListener('did-fail-load', this.onPageFailed);
+        this.webview.addEventListener('did-navigate', this.onPageNavigated);
+        this.webview.addEventListener('did-navigate-in-page', this.onPageNavigated);
+    }
+};
+
+protected onAddressChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    this.browserAddress = event.target.value;
+    this.update();
+};
+
+protected onAddressKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key !== 'Enter' || this.browserAddress.trim().length === 0) {
+        return;
+    }
+    let address = this.browserAddress.trim();
+    if (!/^https?:\/\//i.test(address)) {
+        address = `https://${address}`;
+    }
+    this.pageLoaded = false;
+    this.pageLoadFailed = false;
+    if (this.browserUrl === address && this.webview) {
+        this.webview.reload();
+    } else if (this.browserUrl && this.webview) {
+        // Reuse the existing webview; setting src navigates it.
+        this.webview.src = address;
+        this.browserUrl = address;
+    } else {
+        this.browserUrl = address;
+    }
+    this.browserAddress = address;
+    this.update();
+};
+
+protected onPageLoaded = (): void => {
+    this.pageLoaded = true;
+    this.pageLoadFailed = false;
+    this.update();
+};
+
+protected onPageFailed = (): void => {
+    this.pageLoaded = false;
+    this.pageLoadFailed = true;
+    this.update();
+};
+
+protected onPageNavigated = (): void => {
+    if (this.webview) {
+        this.browserAddress = this.webview.getURL();
+    }
+    this.update();
+};
+
+// Electron throws if webview methods are called before the webview's
+// dom-ready; only query navigation state once a page has loaded.
+protected canGoBack(): boolean {
+    return this.pageLoaded && !!this.webview?.canGoBack();
+}
+
+protected canGoForward(): boolean {
+    return this.pageLoaded && !!this.webview?.canGoForward();
+}
+
+protected browserBack = (): void => {
+    if (this.pageLoaded) {
+        this.webview?.goBack();
+    }
+};
+
+protected browserForward = (): void => {
+    if (this.pageLoaded) {
+        this.webview?.goForward();
+    }
+};
+protected browserReload = (): void => {
+    this.pageLoaded = false;
+    this.pageLoadFailed = false;
+    this.webview?.reload();
+    this.update();
+};
+
+protected clipPage = (): void => {
+    const webview = this.webview;
+    if (!webview) {
+        return;
+    }
+    this.runImport(async () => {
+        const data = await webview.executeJavaScript(CLIP_SCRIPT) as { jsonLdBlocks: string[]; pageText: string };
+        const payload = RecipePayload.extract(data.jsonLdBlocks ?? [], data.pageText ?? '');
+        return this.importService.convertText(payload);
+    });
+};
+```
+
+Note: `renderActiveTab` must keep the webview mounted only while the browser tab is active — the current switch already does that; leaving the tab drops navigation state, which is acceptable for v1.
+
+- [ ] **Step 3: Rebuild and smoke-test**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-branding
+npx lerna run compile --scope @theia/cooklang-import
+cd app && npm run bundle && npm run start:electron
+```
+
+In the Browser tab: navigate to a recipe site with JSON-LD (most major recipe sites), press Clip Recipe → draft created from the structured recipe. Then try a plain blog page without JSON-LD → clip falls back to page text. Verify back/forward/reload work and Clip is disabled before the first page finishes loading.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts packages/cooklang-import/src/browser/import-widget.tsx
+git commit -m "feat(import): internal clipping browser with JSON-LD extraction"
+```
+
+---
+
+### Task 11: Final verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Full package checks**
+
+```bash
+npx lerna run compile --scope @theia/cooklang-import --scope @theia/cooklang-branding
+npx lerna run lint --scope @theia/cooklang-import --scope @theia/cooklang-branding
+npx lerna run test --scope @theia/cooklang-import
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Manual E2E checklist** (`cd app && npm run bundle && npm run start:electron`, open a workspace folder)
+
+- URL import (signed out): success → `Drafts/<Title>.cook` opened; banner visible.
+- Text import (signed out): success.
+- Images tab signed out: sign-in gate, no picker.
+- Sign in (`Cook.md: Login`), images tab: drag-and-drop 2 photos → import succeeds; banner gone.
+- Browser tab: clip a JSON-LD recipe site; clip a non-recipe text page (fallback path).
+- Duplicate name: import the same URL twice → second file is `<Title>-2.cook`.
+- No workspace open: command reports "Open a folder before importing recipes."
+- Rate limit (if reachable): repeated anonymous imports → 429 message with Sign in button.
+
+- [ ] **Step 3: Use the superpowers:verification-before-completion skill, then the superpowers:finishing-a-development-branch skill** (merge/PR decision belongs to the user).

--- a/docs/superpowers/specs/2026-07-24-recipe-import-design.md
+++ b/docs/superpowers/specs/2026-07-24-recipe-import-design.md
@@ -70,8 +70,8 @@ New package **`packages/cooklang-import` (`@theia/cooklang-import`)**, registere
 1. **URL** — input field + Import button → `convertUrl`.
 2. **Text** — textarea + Import button → `convertText`.
 3. **Images** — drag-and-drop zone + file picker. Up to **5** images (iOS parity).
-   Client-side resize + JPEG compression (canvas, quality 0.7) → base64 →
-   `convertImages`. When signed out, the tab content is replaced by
+   Client-side JPEG compression (canvas, quality 0.7; downscale so the longest edge
+   is ≤ 2048 px) → base64 → `convertImages`. When signed out, the tab content is replaced by
    "Sign in to CookCloud to use image clipping" + a Sign in button that runs the
    existing `cooked.login` command.
 4. **Web Browser** — Electron `<webview>` with URL bar, back/forward/reload, and a
@@ -80,8 +80,12 @@ New package **`packages/cooklang-import` (`@theia/cooklang-import`)**, registere
      schema.org `Recipe` object (including `@graph` nesting); if found, sends the
      serialized Recipe JSON as text;
    - otherwise falls back to the page's rendered `document.body.innerText`;
-   - either way the payload goes to `convertText`.
+   - either way the payload goes to `convertText`. No client-side truncation;
+     oversized payloads are the server's concern (it returns 422).
    Clip is disabled until a page has finished loading.
+   The `<webview>` runs with node integration disabled and an isolated session
+   partition (`partition="import-browser"`) — it must have no access to the app's
+   context.
 
 Cross-tab UI:
 
@@ -104,6 +108,8 @@ Browser-side service that, given a `ConvertResult`:
    `WorkspaceService`), dedupes collisions with a counter (`Name-2.cook`).
 4. Writes the file and opens it in the editor.
 
+There is deliberately **no preview/confirm step**: a successful conversion is saved
+to `Drafts/` immediately and opened in the editor, which serves as the preview.
 Nothing is written to disk unless conversion succeeds.
 
 ### `src/browser/import-contribution.ts`

--- a/docs/superpowers/specs/2026-07-24-recipe-import-design.md
+++ b/docs/superpowers/specs/2026-07-24-recipe-import-design.md
@@ -1,0 +1,157 @@
+# Recipe Import — Design
+
+**Date:** 2026-07-24
+**Status:** Approved by user (brainstorming session)
+
+## Goal
+
+Let users import recipes into Cooklang format from four sources — a URL, pasted text,
+dragged-and-dropped recipe images, and an internal clipping browser (Paprika-style) —
+and save the result into a `Drafts/` folder in the workspace.
+
+Image import is available only to signed-in users. Anonymous users can use the other
+three methods but get low server-side API limits and are prompted to sign in to
+increase them.
+
+## Background
+
+- The iOS app (`../mobile-app-ios`) already ships this feature against the cook.md
+  REST API. This design replicates its backend contract:
+  - `POST https://cook.md/api/cookify/url` — body `{"url": "..."}` → `200 {"cooklang": "...", "name": "..."}` (`name` optional). Bearer token optional.
+  - `POST https://cook.md/api/cookify/text` — body `{"text": "..."}` → `200 {"cooklang": "..."}`. Bearer token optional.
+  - `POST https://cook.md/api/cookify/images` — body `{"images": ["<base64 JPEG>", ...]}` → `200 {"cooklang": "..."}`. Bearer token **required**.
+  - Errors for all three: `401` unauthorized, `422` conversion failed, `429` rate limited.
+  - Headers: `Content-Type: application/json`, `Accept: application/json`,
+    `X-Client-Version: editor/<app version>`.
+  - The base URL respects the `WEB_BASE_URL` env override (default `https://cook.md`),
+    consistent with `@theia/cooklang-account`.
+- The editor already has cook.md auth in `@theia/cooklang-account`
+  (`AuthService.getToken()`, `cooked.login` command, JWT persisted in
+  `~/.theia/cookbot-auth.json`).
+- `@theia/cooklang-ai` has gRPC-based URL/text conversion reachable only through the
+  AI chat agent. **Decision:** the import feature uses the REST cookify API instead
+  (images + anonymous rate limiting already exist server-side; no backend changes
+  needed). The gRPC tools remain untouched.
+- No drafts-folder convention exists yet; CookCloud sync treats the workspace root as
+  the recipe library, so a `Drafts/` subfolder syncs automatically. The iOS app uses
+  the same `Drafts` folder name.
+- No embedded browser exists; the Electron window must enable `webviewTag` for the
+  clipping browser.
+
+## Architecture
+
+New package **`packages/cooklang-import` (`@theia/cooklang-import`)**, registered in
+`app/package.json` and `app/tsconfig.json` like the other custom packages.
+
+### `src/common/recipe-import-protocol.ts`
+
+- `RecipeImportService` symbol + interface, RPC path `/services/cooklang-import`
+  (remote service ⇒ interface + symbol, per coding guidelines).
+- Methods:
+  - `convertUrl(url: string): Promise<ConvertResult>`
+  - `convertText(text: string): Promise<ConvertResult>`
+  - `convertImages(imagesBase64: string[]): Promise<ConvertResult>`
+- `ConvertResult = { cooklang: string; name?: string }`
+- Errors carry a typed code: `'unauthorized' | 'rate-limited' | 'conversion-failed' | 'network'`.
+
+### `src/node/cookify-api-client.ts` + backend module
+
+- REST client implementing the contract above.
+- Injects `AuthService` (from `@theia/cooklang-account`); attaches
+  `Authorization: Bearer <token>` when a token exists. For `convertImages`, rejects
+  locally with `unauthorized` when no token is present (mirrors iOS).
+- Maps HTTP 401/422/429 and network failures to the typed error codes.
+- Bound as the `RecipeImportService` backend with a `ConnectionHandler`.
+
+### `src/browser/import-widget.tsx`
+
+`ReactWidget` opened as a main-area tab ("Import Recipe") with four internal tabs:
+
+1. **URL** — input field + Import button → `convertUrl`.
+2. **Text** — textarea + Import button → `convertText`.
+3. **Images** — drag-and-drop zone + file picker. Up to **5** images (iOS parity).
+   Client-side resize + JPEG compression (canvas, quality 0.7) → base64 →
+   `convertImages`. When signed out, the tab content is replaced by
+   "Sign in to CookCloud to use image clipping" + a Sign in button that runs the
+   existing `cooked.login` command.
+4. **Web Browser** — Electron `<webview>` with URL bar, back/forward/reload, and a
+   **"Clip Recipe"** button. Clip executes a script in the page that:
+   - collects `<script type="application/ld+json">` blocks and looks for a
+     schema.org `Recipe` object (including `@graph` nesting); if found, sends the
+     serialized Recipe JSON as text;
+   - otherwise falls back to the page's rendered `document.body.innerText`;
+   - either way the payload goes to `convertText`.
+   Clip is disabled until a page has finished loading.
+
+Cross-tab UI:
+
+- **Signed-out banner** on URL/Text/Browser tabs: "Sign in for higher import limits"
+  with a Sign in link.
+- Busy/progress state during conversion; success state after save.
+
+Auth state comes from the injected `AuthService` proxy (same pattern as
+`AccountWidget`); refreshed on widget activation and after the sign-in flow.
+
+### `src/browser/draft-saver.ts`
+
+Browser-side service that, given a `ConvertResult`:
+
+1. Resolves the title: API `name` → `title:` in the returned Cooklang frontmatter →
+   localized "Imported Recipe" fallback. Injects `---\ntitle: ...\n---` frontmatter
+   when missing (iOS parity).
+2. Sanitizes the title into a filename.
+3. Ensures `Drafts/` exists at the workspace root (via `FileService` +
+   `WorkspaceService`), dedupes collisions with a counter (`Name-2.cook`).
+4. Writes the file and opens it in the editor.
+
+Nothing is written to disk unless conversion succeeds.
+
+### `src/browser/import-contribution.ts`
+
+- Command `cooklang.import.open` ("Import Recipe…"), File menu entry, view
+  contribution opening the widget in the main area.
+
+### Change outside the package
+
+- `packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts`:
+  set `webPreferences.webviewTag: true` in the window options so the Browser tab's
+  `<webview>` works.
+
+## Data flow
+
+User input (URL / text / images / clipped page content) → `ImportWidget` → RPC →
+`CookifyApiClient` (node) → cook.md → `{ cooklang, name? }` → `DraftSaver` writes
+`Drafts/<Title>.cook` and opens it in the editor. `Drafts/` syncs to CookCloud like
+any workspace folder.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| 422 conversion failed | "Couldn't extract a recipe from this URL/text/image. Try another source." |
+| 429 rate limited, signed out | "Import limit reached — sign in to increase your limits" + Sign in button |
+| 429 rate limited, signed in | "Import limit reached. Please try again later." |
+| 401 unauthorized | Prompt to sign in (token missing/expired) |
+| Network failure | Generic retryable error message |
+| No workspace open | Import command shows a message asking to open a folder first |
+| Webview load failure | Error state in the browser tab; Clip disabled until a page loads |
+
+All user-facing strings localized via `nls.localize`.
+
+## Testing
+
+- Unit specs (`*.spec.ts`):
+  - `CookifyApiClient` against mocked fetch: status→error mapping, optional vs
+    required auth header, images-without-token rejection.
+  - Title resolution + frontmatter injection.
+  - Filename sanitization and dedup logic.
+  - JSON-LD Recipe extraction (pure function) against sample page HTML, including
+    `@graph` and missing-Recipe fallback.
+- Manual verification of widget/webview flows (Electron-only surface).
+
+## Out of scope
+
+- Backend/server changes (all endpoints already exist).
+- Changes to the gRPC cookbot conversion tools in `@theia/cooklang-ai`.
+- Client-side quota counters (limits are enforced server-side).
+- OCR on-device; image extraction is server-side.

--- a/docs/superpowers/specs/2026-07-24-recipe-import-design.md
+++ b/docs/superpowers/specs/2026-07-24-recipe-import-design.md
@@ -80,8 +80,9 @@ New package **`packages/cooklang-import` (`@theia/cooklang-import`)**, registere
      schema.org `Recipe` object (including `@graph` nesting); if found, sends the
      serialized Recipe JSON as text;
    - otherwise falls back to the page's rendered `document.body.innerText`;
-   - either way the payload goes to `convertText`. No client-side truncation;
-     oversized payloads are the server's concern (it returns 422).
+   - either way the payload goes to `convertText`. Clip payloads are clamped
+     client-side (200 000 chars per JSON-LD block and for page text) as an
+     untrusted-input defense; the server may still 422 oversized content.
    Clip is disabled until a page has finished loading.
    The `<webview>` runs with node integration disabled and an isolated session
    partition (`partition="import-browser"`) — it must have no access to the app's

--- a/docs/superpowers/specs/2026-07-24-recipe-import-design.md
+++ b/docs/superpowers/specs/2026-07-24-recipe-import-design.md
@@ -161,3 +161,14 @@ All user-facing strings localized via `nls.localize`.
 - Changes to the gRPC cookbot conversion tools in `@theia/cooklang-ai`.
 - Client-side quota counters (limits are enforced server-side).
 - OCR on-device; image extraction is server-side.
+
+## Phase 2 (planned follow-up, separate spec)
+
+Local conversion via the `cooklang-import` Rust crate (the same library that powers
+the hosted cookify service), wrapped in `packages/cooklang-native` (NAPI-RS) and
+plugged in behind the same `RecipeImportService` protocol: the backend routes to the
+local engine when the user has configured an AI provider (own API key or Ollama),
+falling back to the cook.md REST API otherwise. Local URL/text conversion needs an
+LLM provider key; local image import additionally needs `GOOGLE_API_KEY` for OCR —
+hence the server path (with its anonymous rate limits and sign-in gating) remains
+the default for users without keys. Decided 2026-07-24.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "app": {
       "name": "@cook-md/editor-app",
-      "version": "0.1.0-alpha.24",
+      "version": "0.1.0-alpha.34",
       "license": "(EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/ai-chat": "1.70.0",
@@ -80,6 +80,7 @@
         "@theia/cooklang-account": "1.70.0",
         "@theia/cooklang-ai": "1.70.0",
         "@theia/cooklang-branding": "1.70.0",
+        "@theia/cooklang-import": "1.70.0",
         "@theia/core": "1.70.0",
         "@theia/editor": "1.70.0",
         "@theia/editor-preview": "1.70.0",
@@ -6033,6 +6034,10 @@
     },
     "node_modules/@theia/cooklang-branding": {
       "resolved": "packages/cooklang-branding",
+      "link": true
+    },
+    "node_modules/@theia/cooklang-import": {
+      "resolved": "packages/cooklang-import",
       "link": true
     },
     "node_modules/@theia/cooklang-native": {
@@ -29170,6 +29175,21 @@
         "@theia/cooklang-account": "1.70.0",
         "@theia/core": "1.70.0",
         "@theia/monaco": "1.70.0",
+        "tslib": "^2.6.2"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.70.0"
+      }
+    },
+    "packages/cooklang-import": {
+      "name": "@theia/cooklang-import",
+      "version": "1.70.0",
+      "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
+      "dependencies": {
+        "@theia/cooklang-account": "1.70.0",
+        "@theia/core": "1.70.0",
+        "@theia/filesystem": "1.70.0",
+        "@theia/workspace": "1.70.0",
         "tslib": "^2.6.2"
       },
       "devDependencies": {

--- a/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
@@ -22,9 +22,18 @@ export class CooklangElectronMainApplication extends ElectronMainApplication {
 
     protected override getDefaultOptions(): TheiaBrowserWindowOptions {
         const options = super.getDefaultOptions();
-        return {
+        const resolved = {
             ...options,
             ...this.resolveWindowOptions(this.config.electron?.windowOptions || {}),
+        };
+        return {
+            ...resolved,
+            webPreferences: {
+                ...resolved.webPreferences,
+                // Required by the recipe-import clipping browser (<webview> tag). Placed after the
+                // config-derived spread so it cannot be disabled via windowOptions.
+                webviewTag: true,
+            },
         };
     }
 

--- a/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
@@ -55,6 +55,27 @@ export class CooklangElectronMainApplication extends ElectronMainApplication {
      * (plain web browsing only) and keep core's hardening for everything else.
      */
     protected override onWebContentsCreated(event: ElectronEvent, webContents: WebContents): void {
+        // Verify webview options before creation, per the Electron security checklist
+        // (https://www.electronjs.org/docs/latest/tutorial/security#12-verify-webview-options-before-creation).
+        // Registered on every webContents — including the clipping guest itself, so a
+        // clipped page cannot attach a nested <webview> either: strip preload scripts
+        // and node capabilities, validate the initial src (its load bypasses the
+        // will-navigate guard below), and reject any <webview> that is not the
+        // recipe-import clipping browser.
+        webContents.on('will-attach-webview', (evt, webPreferences, params) => {
+            delete webPreferences.preload;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            delete (webPreferences as any).preloadURL;
+            webPreferences.nodeIntegration = false;
+            webPreferences.contextIsolation = true;
+            webPreferences.webviewTag = false;
+            if (params.partition !== IMPORT_BROWSER_PARTITION) {
+                evt.preventDefault();
+            }
+            if (params.src && !/^(https?:|about:blank)/i.test(params.src)) {
+                evt.preventDefault();
+            }
+        });
         if (this.isImportBrowserWebview(webContents)) {
             // (a) Allow ordinary http/https browsing inside the clipping webview, nothing else
             // (no file:, no custom schemes that could reach into the app or the OS).
@@ -75,20 +96,6 @@ export class CooklangElectronMainApplication extends ElectronMainApplication {
             return;
         }
         super.onWebContentsCreated(event, webContents);
-        // Verify webview options before creation, per the Electron security checklist
-        // (https://www.electronjs.org/docs/latest/tutorial/security#12-verify-webview-options-before-creation):
-        // strip preload scripts and node capabilities, and reject any <webview> that
-        // is not the recipe-import clipping browser.
-        webContents.on('will-attach-webview', (evt, webPreferences, params) => {
-            delete webPreferences.preload;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            delete (webPreferences as any).preloadURL;
-            webPreferences.nodeIntegration = false;
-            webPreferences.contextIsolation = true;
-            if (params.partition !== IMPORT_BROWSER_PARTITION) {
-                evt.preventDefault();
-            }
-        });
     }
 
     protected isImportBrowserWebview(webContents: WebContents): boolean {

--- a/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
+++ b/packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts
@@ -12,10 +12,21 @@
 // *****************************************************************************
 
 import { injectable } from '@theia/core/shared/inversify';
-import { app, BrowserWindowConstructorOptions } from '@theia/core/electron-shared/electron';
+import { app, BrowserWindowConstructorOptions, Event as ElectronEvent, session, WebContents } from '@theia/core/electron-shared/electron';
 import { ElectronMainApplication } from '@theia/core/lib/electron-main/electron-main-application';
 import { TheiaBrowserWindowOptions } from '@theia/core/lib/electron-main/theia-electron-window';
 import * as path from 'path';
+
+/**
+ * Session partition of the recipe-import clipping browser `<webview>`.
+ * Must match the `partition` attribute in
+ * `packages/cooklang-import/src/browser/import-browser-tab.tsx`.
+ *
+ * The name carries no `persist:` prefix, so the session is in-memory:
+ * site logins made inside the clipping browser do not survive an app
+ * restart. This is a deliberate privacy default.
+ */
+const IMPORT_BROWSER_PARTITION = 'import-browser';
 
 @injectable()
 export class CooklangElectronMainApplication extends ElectronMainApplication {
@@ -35,6 +46,58 @@ export class CooklangElectronMainApplication extends ElectronMainApplication {
                 webviewTag: true,
             },
         };
+    }
+
+    /**
+     * Core's handler preventDefaults every `will-navigate` for all web contents,
+     * which would also freeze the clipping browser `<webview>`: no link inside a
+     * clipped page could be followed. Give that webview its own navigation policy
+     * (plain web browsing only) and keep core's hardening for everything else.
+     */
+    protected override onWebContentsCreated(event: ElectronEvent, webContents: WebContents): void {
+        if (this.isImportBrowserWebview(webContents)) {
+            // (a) Allow ordinary http/https browsing inside the clipping webview, nothing else
+            // (no file:, no custom schemes that could reach into the app or the OS).
+            webContents.on('will-navigate', evt => {
+                if (!this.isWebUrl(evt.url)) {
+                    evt.preventDefault();
+                }
+            });
+            // (b) Never let clipped pages spawn windows or reach the OS handler:
+            // open http/https popups/new-tab links in the webview itself, drop the rest.
+            webContents.setWindowOpenHandler(details => {
+                if (this.isWebUrl(details.url)) {
+                    webContents.loadURL(details.url)
+                        .catch(error => console.warn('Import browser failed to open popup URL in place:', error));
+                }
+                return { action: 'deny' };
+            });
+            return;
+        }
+        super.onWebContentsCreated(event, webContents);
+        // Verify webview options before creation, per the Electron security checklist
+        // (https://www.electronjs.org/docs/latest/tutorial/security#12-verify-webview-options-before-creation):
+        // strip preload scripts and node capabilities, and reject any <webview> that
+        // is not the recipe-import clipping browser.
+        webContents.on('will-attach-webview', (evt, webPreferences, params) => {
+            delete webPreferences.preload;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            delete (webPreferences as any).preloadURL;
+            webPreferences.nodeIntegration = false;
+            webPreferences.contextIsolation = true;
+            if (params.partition !== IMPORT_BROWSER_PARTITION) {
+                evt.preventDefault();
+            }
+        });
+    }
+
+    protected isImportBrowserWebview(webContents: WebContents): boolean {
+        return webContents.getType() === 'webview'
+            && webContents.session === session.fromPartition(IMPORT_BROWSER_PARTITION);
+    }
+
+    protected isWebUrl(url: string): boolean {
+        return /^https?:/i.test(url);
     }
 
     protected resolveWindowOptions(windowOptions: BrowserWindowConstructorOptions): BrowserWindowConstructorOptions {

--- a/packages/cooklang-import/.eslintrc.js
+++ b/packages/cooklang-import/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/cooklang-import/package.json
+++ b/packages/cooklang-import/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@theia/core": "1.70.0",
     "@theia/filesystem": "1.70.0",
+    "@theia/navigator": "1.70.0",
     "@theia/workspace": "1.70.0",
     "@theia/cooklang-account": "1.70.0",
     "tslib": "^2.6.2"

--- a/packages/cooklang-import/package.json
+++ b/packages/cooklang-import/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@theia/cooklang-import",
+  "version": "1.70.0",
+  "description": "Theia - Cooklang Recipe Import (URL, text, images, clipping browser)",
+  "dependencies": {
+    "@theia/core": "1.70.0",
+    "@theia/filesystem": "1.70.0",
+    "@theia/workspace": "1.70.0",
+    "@theia/cooklang-account": "1.70.0",
+    "tslib": "^2.6.2"
+  },
+  "main": "lib/common",
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/cooklang-import-frontend-module",
+      "backend": "lib/node/cooklang-import-backend-module"
+    }
+  ],
+  "keywords": ["theia-extension"],
+  "license": "AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
+  "files": ["lib", "src"],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.70.0"
+  }
+}

--- a/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
+++ b/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
@@ -12,6 +12,8 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { DraftSaver } from './draft-saver';
 
 export default new ContainerModule(bind => {
+    bind(DraftSaver).toSelf().inSingletonScope();
 });

--- a/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
+++ b/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
@@ -16,6 +16,7 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { bindViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { RecipeImportService, RecipeImportServicePath } from '../common/recipe-import-protocol';
 import { DraftSaver } from './draft-saver';
 import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
@@ -38,4 +39,5 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bindViewContribution(bind, ImportContribution);
+    bind(TabBarToolbarContribution).toService(ImportContribution);
 });

--- a/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
+++ b/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
@@ -18,11 +18,14 @@ import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
 import { bindViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { RecipeImportService, RecipeImportServicePath } from '../common/recipe-import-protocol';
+import { bindCooklangImportPreferences } from './import-preferences';
 import { DraftSaver } from './draft-saver';
 import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
 import { ImportContribution } from './import-contribution';
 
 export default new ContainerModule(bind => {
+    bindCooklangImportPreferences(bind);
+
     bind(RecipeImportService).toDynamicValue(ctx =>
         ServiceConnectionProvider.createProxy<RecipeImportService>(ctx.container, RecipeImportServicePath)
     ).inSingletonScope();

--- a/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
+++ b/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
@@ -11,9 +11,28 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+import '../../src/browser/style/index.css';
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
+import { WidgetFactory } from '@theia/core/lib/browser/widget-manager';
+import { bindViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { RecipeImportService, RecipeImportServicePath } from '../common/recipe-import-protocol';
 import { DraftSaver } from './draft-saver';
+import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
+import { ImportContribution } from './import-contribution';
 
 export default new ContainerModule(bind => {
+    bind(RecipeImportService).toDynamicValue(ctx =>
+        ServiceConnectionProvider.createProxy<RecipeImportService>(ctx.container, RecipeImportServicePath)
+    ).inSingletonScope();
+
     bind(DraftSaver).toSelf().inSingletonScope();
+
+    bind(ImportWidget).toSelf().inSingletonScope();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: IMPORT_WIDGET_ID,
+        createWidget: () => ctx.container.get(ImportWidget),
+    })).inSingletonScope();
+
+    bindViewContribution(bind, ImportContribution);
 });

--- a/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
+++ b/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+
+export default new ContainerModule(bind => {
+});

--- a/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
+++ b/packages/cooklang-import/src/browser/cooklang-import-frontend-module.ts
@@ -28,7 +28,10 @@ export default new ContainerModule(bind => {
 
     bind(DraftSaver).toSelf().inSingletonScope();
 
-    bind(ImportWidget).toSelf().inSingletonScope();
+    // Deliberately NOT inSingletonScope: the widget is closable and gets disposed on
+    // close. WidgetManager caches live instances itself; a singleton binding would
+    // hand back the same disposed instance on reopen, which never renders again.
+    bind(ImportWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({
         id: IMPORT_WIDGET_ID,
         createWidget: () => ctx.container.get(ImportWidget),

--- a/packages/cooklang-import/src/browser/draft-name.spec.ts
+++ b/packages/cooklang-import/src/browser/draft-name.spec.ts
@@ -27,6 +27,18 @@ describe('DraftName', () => {
             expect(DraftName.resolveTitle('Mix @eggs{2}.', undefined)).to.equal(undefined);
             expect(DraftName.resolveTitle('---\nservings: 4\n---\nMix.', undefined)).to.equal(undefined);
         });
+        it('reads the frontmatter title from CRLF content', () => {
+            expect(DraftName.resolveTitle('---\r\ntitle: Pancakes\r\n---\r\nMix @eggs{2}.', undefined)).to.equal('Pancakes');
+        });
+        it('collapses newlines in the API-provided name', () => {
+            expect(DraftName.resolveTitle('Mix.', 'Pan\ncakes')).to.equal('Pan cakes');
+        });
+        it('unquotes a double-quoted frontmatter title', () => {
+            expect(DraftName.resolveTitle('---\ntitle: "Mom\'s Pancakes"\n---\nMix.', undefined)).to.equal("Mom's Pancakes");
+        });
+        it('unquotes a single-quoted frontmatter title', () => {
+            expect(DraftName.resolveTitle("---\ntitle: 'Pancakes'\n---\nMix.", undefined)).to.equal('Pancakes');
+        });
     });
 
     describe('ensureTitleFrontmatter', () => {
@@ -42,6 +54,18 @@ describe('DraftName', () => {
             expect(DraftName.ensureTitleFrontmatter('Mix @eggs{2}.', 'Pancakes'))
                 .to.equal('---\ntitle: Pancakes\n---\n\nMix @eggs{2}.');
         });
+        it('inserts title into a CRLF frontmatter and normalizes it to LF', () => {
+            expect(DraftName.ensureTitleFrontmatter('---\r\nservings: 4\r\n---\r\nMix.', 'Pancakes'))
+                .to.equal('---\ntitle: Pancakes\nservings: 4\n---\nMix.');
+        });
+        it('leaves CRLF content with a titled frontmatter unchanged', () => {
+            const src = '---\r\ntitle: Pancakes\r\n---\r\nMix @eggs{2}.';
+            expect(DraftName.ensureTitleFrontmatter(src, 'Pancakes')).to.equal(src);
+        });
+        it('collapses newlines in the title to prevent frontmatter injection', () => {
+            expect(DraftName.ensureTitleFrontmatter('Mix.', 'Pancakes\nservings: 99'))
+                .to.equal('---\ntitle: Pancakes servings: 99\n---\n\nMix.');
+        });
     });
 
     describe('sanitizeFilename', () => {
@@ -54,6 +78,17 @@ describe('DraftName', () => {
         it('falls back for names that sanitize to nothing', () => {
             expect(DraftName.sanitizeFilename('::""//')).to.equal('Imported Recipe');
         });
+        it('appends Recipe to Windows reserved device names', () => {
+            expect(DraftName.sanitizeFilename('Nul')).to.equal('Nul Recipe');
+            expect(DraftName.sanitizeFilename('COM1')).to.equal('COM1 Recipe');
+        });
+        it('truncates overly long names to 120 characters', () => {
+            expect(DraftName.sanitizeFilename('A'.repeat(200))).to.equal('A'.repeat(120));
+        });
+        it('re-trims trailing dots and spaces after truncation', () => {
+            const name = DraftName.sanitizeFilename(`${'A'.repeat(119)} B`);
+            expect(name).to.equal('A'.repeat(119));
+        });
     });
 
     describe('uniqueBaseName', () => {
@@ -65,6 +100,11 @@ describe('DraftName', () => {
             const taken = new Set(['Pancakes', 'Pancakes-2']);
             const name = await DraftName.uniqueBaseName('Pancakes', async candidate => taken.has(candidate));
             expect(name).to.equal('Pancakes-3');
+        });
+        it('falls back to a timestamp suffix when every counter is taken', async () => {
+            const name = await DraftName.uniqueBaseName('Pancakes', async () => true);
+            expect(name.startsWith('Pancakes-')).to.equal(true);
+            expect(name).to.not.equal('Pancakes-1000');
         });
     });
 });

--- a/packages/cooklang-import/src/browser/draft-name.spec.ts
+++ b/packages/cooklang-import/src/browser/draft-name.spec.ts
@@ -1,0 +1,70 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { DraftName } from './draft-name';
+
+describe('DraftName', () => {
+
+    describe('resolveTitle', () => {
+        it('prefers the API-provided name', () => {
+            expect(DraftName.resolveTitle('---\ntitle: Other\n---\n', 'Pancakes')).to.equal('Pancakes');
+        });
+        it('ignores a blank API name and reads the frontmatter title', () => {
+            expect(DraftName.resolveTitle('---\ntitle: Pancakes\n---\nMix @eggs{2}.', '  ')).to.equal('Pancakes');
+        });
+        it('returns undefined when neither source has a title', () => {
+            expect(DraftName.resolveTitle('Mix @eggs{2}.', undefined)).to.equal(undefined);
+            expect(DraftName.resolveTitle('---\nservings: 4\n---\nMix.', undefined)).to.equal(undefined);
+        });
+    });
+
+    describe('ensureTitleFrontmatter', () => {
+        it('leaves content with a titled frontmatter unchanged', () => {
+            const src = '---\ntitle: Pancakes\n---\nMix @eggs{2}.';
+            expect(DraftName.ensureTitleFrontmatter(src, 'Pancakes')).to.equal(src);
+        });
+        it('inserts title into an existing frontmatter without one', () => {
+            expect(DraftName.ensureTitleFrontmatter('---\nservings: 4\n---\nMix.', 'Pancakes'))
+                .to.equal('---\ntitle: Pancakes\nservings: 4\n---\nMix.');
+        });
+        it('prepends frontmatter when there is none', () => {
+            expect(DraftName.ensureTitleFrontmatter('Mix @eggs{2}.', 'Pancakes'))
+                .to.equal('---\ntitle: Pancakes\n---\n\nMix @eggs{2}.');
+        });
+    });
+
+    describe('sanitizeFilename', () => {
+        it('strips characters that are unsafe in filenames', () => {
+            expect(DraftName.sanitizeFilename('Mom’s "Best" Soup: a/b\\c?')).to.equal('Mom’s Best Soup abc');
+        });
+        it('collapses whitespace and trims leading/trailing dots and spaces', () => {
+            expect(DraftName.sanitizeFilename('  .Fancy   Bread.  ')).to.equal('Fancy Bread');
+        });
+        it('falls back for names that sanitize to nothing', () => {
+            expect(DraftName.sanitizeFilename('::""//')).to.equal('Imported Recipe');
+        });
+    });
+
+    describe('uniqueBaseName', () => {
+        it('returns the base name when it is free', async () => {
+            const name = await DraftName.uniqueBaseName('Pancakes', async () => false);
+            expect(name).to.equal('Pancakes');
+        });
+        it('appends an incrementing counter until the name is free', async () => {
+            const taken = new Set(['Pancakes', 'Pancakes-2']);
+            const name = await DraftName.uniqueBaseName('Pancakes', async candidate => taken.has(candidate));
+            expect(name).to.equal('Pancakes-3');
+        });
+    });
+});

--- a/packages/cooklang-import/src/browser/draft-name.ts
+++ b/packages/cooklang-import/src/browser/draft-name.ts
@@ -1,0 +1,75 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * Naming helpers for imported drafts: title resolution, frontmatter
+ * injection (parity with the iOS app's clipping flow), and safe,
+ * collision-free file names.
+ */
+export namespace DraftName {
+
+    export function resolveTitle(cooklang: string, apiName: string | undefined): string | undefined {
+        if (apiName && apiName.trim().length > 0) {
+            return apiName.trim();
+        }
+        return frontmatterTitle(cooklang);
+    }
+
+    export function ensureTitleFrontmatter(cooklang: string, title: string): string {
+        const lines = cooklang.split('\n');
+        if (lines[0]?.trim() === '---') {
+            if (frontmatterTitle(cooklang) !== undefined) {
+                return cooklang;
+            }
+            return [lines[0], `title: ${title}`, ...lines.slice(1)].join('\n');
+        }
+        return `---\ntitle: ${title}\n---\n\n${cooklang}`;
+    }
+
+    export function sanitizeFilename(title: string): string {
+        const cleaned = title
+            .replace(/[/\\:*?"<>|]/g, '')
+            .replace(/\s+/g, ' ')
+            .replace(/^[. ]+|[. ]+$/g, '');
+        return cleaned.length > 0 ? cleaned : 'Imported Recipe';
+    }
+
+    export async function uniqueBaseName(base: string, exists: (candidate: string) => Promise<boolean>): Promise<string> {
+        if (!await exists(base)) {
+            return base;
+        }
+        for (let i = 2; ; i++) {
+            const candidate = `${base}-${i}`;
+            if (!await exists(candidate)) {
+                return candidate;
+            }
+        }
+    }
+
+    function frontmatterTitle(cooklang: string): string | undefined {
+        const lines = cooklang.split('\n');
+        if (lines[0]?.trim() !== '---') {
+            return undefined;
+        }
+        for (let i = 1; i < lines.length; i++) {
+            if (lines[i].trim() === '---') {
+                return undefined;
+            }
+            const match = lines[i].match(/^title:\s*(.+)$/);
+            if (match) {
+                return match[1].trim();
+            }
+        }
+        return undefined;
+    }
+}

--- a/packages/cooklang-import/src/browser/draft-name.ts
+++ b/packages/cooklang-import/src/browser/draft-name.ts
@@ -18,46 +18,69 @@
  */
 export namespace DraftName {
 
+    const MAX_FILENAME_LENGTH = 120;
+    const MAX_UNIQUE_NAME_ATTEMPTS = 1000;
+    const WINDOWS_RESERVED_NAMES = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
     export function resolveTitle(cooklang: string, apiName: string | undefined): string | undefined {
         if (apiName && apiName.trim().length > 0) {
-            return apiName.trim();
+            return sanitizeTitleValue(apiName);
         }
         return frontmatterTitle(cooklang);
     }
 
     export function ensureTitleFrontmatter(cooklang: string, title: string): string {
-        const lines = cooklang.split('\n');
+        const safeTitle = sanitizeTitleValue(title);
+        const lines = cooklang.split(/\r?\n/);
         if (lines[0]?.trim() === '---') {
             if (frontmatterTitle(cooklang) !== undefined) {
                 return cooklang;
             }
-            return [lines[0], `title: ${title}`, ...lines.slice(1)].join('\n');
+            return [lines[0], `title: ${safeTitle}`, ...lines.slice(1)].join('\n');
         }
-        return `---\ntitle: ${title}\n---\n\n${cooklang}`;
+        return `---\ntitle: ${safeTitle}\n---\n\n${cooklang}`;
     }
 
     export function sanitizeFilename(title: string): string {
-        const cleaned = title
+        let cleaned = title
             .replace(/[/\\:*?"<>|]/g, '')
             .replace(/\s+/g, ' ')
             .replace(/^[. ]+|[. ]+$/g, '');
-        return cleaned.length > 0 ? cleaned : 'Imported Recipe';
+        if (cleaned.length > MAX_FILENAME_LENGTH) {
+            cleaned = cleaned.substring(0, MAX_FILENAME_LENGTH).replace(/[. ]+$/g, '');
+        }
+        if (cleaned.length === 0) {
+            return 'Imported Recipe';
+        }
+        if (WINDOWS_RESERVED_NAMES.test(cleaned)) {
+            return `${cleaned} Recipe`;
+        }
+        return cleaned;
     }
 
     export async function uniqueBaseName(base: string, exists: (candidate: string) => Promise<boolean>): Promise<string> {
         if (!await exists(base)) {
             return base;
         }
-        for (let i = 2; ; i++) {
+        for (let i = 2; i <= MAX_UNIQUE_NAME_ATTEMPTS; i++) {
             const candidate = `${base}-${i}`;
             if (!await exists(candidate)) {
                 return candidate;
             }
         }
+        return `${base}-${Date.now()}`;
+    }
+
+    /**
+     * Collapses all whitespace — including newlines, which would otherwise
+     * inject arbitrary frontmatter lines — into single spaces and trims.
+     */
+    function sanitizeTitleValue(title: string): string {
+        return title.replace(/\s+/g, ' ').trim();
     }
 
     function frontmatterTitle(cooklang: string): string | undefined {
-        const lines = cooklang.split('\n');
+        const lines = cooklang.split(/\r?\n/);
         if (lines[0]?.trim() !== '---') {
             return undefined;
         }
@@ -67,9 +90,18 @@ export namespace DraftName {
             }
             const match = lines[i].match(/^title:\s*(.+)$/);
             if (match) {
-                return match[1].trim();
+                return unquote(match[1].trim());
             }
         }
         return undefined;
+    }
+
+    /**
+     * Strips one pair of matching surrounding YAML quotes, if present.
+     */
+    function unquote(value: string): string {
+        return value
+            .replace(/^"(.*)"$/, '$1')
+            .replace(/^'(.*)'$/, '$1');
     }
 }

--- a/packages/cooklang-import/src/browser/draft-saver.ts
+++ b/packages/cooklang-import/src/browser/draft-saver.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import URI from '@theia/core/lib/common/uri';
+import { nls } from '@theia/core/lib/common/nls';
+import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { ConvertSuccess } from '../common/recipe-import-protocol';
+import { DraftName } from './draft-name';
+
+export const DRAFTS_FOLDER_NAME = 'Drafts';
+
+/**
+ * Writes a converted recipe into `<workspace root>/Drafts/<Title>.cook`
+ * (creating the folder and de-duplicating the name) and opens it in the editor.
+ */
+@injectable()
+export class DraftSaver {
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(OpenerService)
+    protected readonly openerService: OpenerService;
+
+    async save(result: ConvertSuccess): Promise<URI> {
+        const roots = await this.workspaceService.roots;
+        if (roots.length === 0) {
+            throw new Error(nls.localize('theia/cooklang-import/noWorkspace', 'Open a folder before importing recipes.'));
+        }
+        const draftsDir = roots[0].resource.resolve(DRAFTS_FOLDER_NAME);
+        if (!await this.fileService.exists(draftsDir)) {
+            await this.fileService.createFolder(draftsDir);
+        }
+        const title = DraftName.resolveTitle(result.cooklang, result.name)
+            ?? nls.localize('theia/cooklang-import/importedRecipe', 'Imported Recipe');
+        const content = DraftName.ensureTitleFrontmatter(result.cooklang, title);
+        const base = await DraftName.uniqueBaseName(
+            DraftName.sanitizeFilename(title),
+            candidate => this.fileService.exists(draftsDir.resolve(`${candidate}.cook`))
+        );
+        const uri = draftsDir.resolve(`${base}.cook`);
+        await this.fileService.create(uri, content);
+        await open(this.openerService, uri);
+        return uri;
+    }
+}

--- a/packages/cooklang-import/src/browser/image-encoder.ts
+++ b/packages/cooklang-import/src/browser/image-encoder.ts
@@ -11,7 +11,6 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
-export const MAX_IMPORT_IMAGES = 5;
 const MAX_EDGE_PX = 2048;
 const JPEG_QUALITY = 0.7;
 

--- a/packages/cooklang-import/src/browser/image-encoder.ts
+++ b/packages/cooklang-import/src/browser/image-encoder.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+export const MAX_IMPORT_IMAGES = 5;
+const MAX_EDGE_PX = 2048;
+const JPEG_QUALITY = 0.7;
+
+/**
+ * Downscales (longest edge <= 2048px) and re-encodes an image file as a
+ * base64 JPEG string (no data-URL prefix), matching the payload the
+ * cookify images endpoint expects.
+ */
+export namespace ImageEncoder {
+
+    export async function toBase64Jpeg(file: File): Promise<string> {
+        const bitmap = await createImageBitmap(file);
+        try {
+            const scale = Math.min(1, MAX_EDGE_PX / Math.max(bitmap.width, bitmap.height));
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.round(bitmap.width * scale);
+            canvas.height = Math.round(bitmap.height * scale);
+            const context = canvas.getContext('2d');
+            if (!context) {
+                throw new Error('Canvas 2D context unavailable');
+            }
+            context.drawImage(bitmap, 0, 0, canvas.width, canvas.height);
+            const dataUrl = canvas.toDataURL('image/jpeg', JPEG_QUALITY);
+            return dataUrl.substring(dataUrl.indexOf(',') + 1);
+        } finally {
+            bitmap.close();
+        }
+    }
+}

--- a/packages/cooklang-import/src/browser/import-browser-tab.tsx
+++ b/packages/cooklang-import/src/browser/import-browser-tab.tsx
@@ -1,0 +1,250 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { nls } from '@theia/core/lib/common/nls';
+import * as React from '@theia/core/shared/react';
+import { RecipePayload } from './recipe-payload';
+
+/**
+ * Minimal typing for the Electron `<webview>` element. We deliberately avoid
+ * pulling in Electron renderer typings here since this is plain browser code.
+ */
+interface WebviewElement extends HTMLElement {
+    src: string;
+    canGoBack(): boolean;
+    canGoForward(): boolean;
+    goBack(): void;
+    goForward(): void;
+    reload(): void;
+    getURL(): string;
+    executeJavaScript(code: string): Promise<unknown>;
+}
+
+interface DidFailLoadEvent extends Event {
+    isMainFrame: boolean;
+}
+
+/**
+ * Collects the raw data used to build a clip payload. Runs inside the clipped
+ * page; extraction logic (choosing JSON-LD vs. page text) lives in {@link RecipePayload}.
+ */
+const CLIP_SCRIPT = `(() => ({
+    jsonLdBlocks: Array.from(document.querySelectorAll('script[type="application/ld+json"]')).map(s => s.textContent || ''),
+    pageText: document.body ? document.body.innerText : ''
+}))()`;
+
+interface ClipScriptResult {
+    jsonLdBlocks: string[];
+    pageText: string;
+}
+
+export interface ImportBrowserTabProps {
+    busy: boolean;
+    onClip: (payload: string) => void;
+}
+
+interface ImportBrowserTabState {
+    address: string;
+    committedUrl: string;
+    pageLoaded: boolean;
+    pageLoadFailed: boolean;
+    clipError: string | undefined;
+}
+
+/**
+ * Internal clipping browser: an embedded, isolated `<webview>` the user
+ * navigates to a recipe page, then clips via JSON-LD/page-text extraction.
+ *
+ * Navigation state (address, loaded page) is owned by this component's React
+ * state rather than the parent widget. It is deliberately not persisted across
+ * tab switches for v1: the browser tab unmounts when another tab is selected,
+ * so surfing history is lost. Revisit if users want the browser to stay warm.
+ */
+export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, ImportBrowserTabState> {
+
+    protected webview: WebviewElement | undefined;
+
+    protected readonly handleDidFinishLoad = (): void => {
+        this.setState({ pageLoaded: true, pageLoadFailed: false });
+    };
+
+    protected readonly handleDidFailLoad = (event: Event): void => {
+        if ((event as DidFailLoadEvent).isMainFrame === false) {
+            return;
+        }
+        this.setState({ pageLoaded: false, pageLoadFailed: true });
+    };
+
+    protected readonly handleDidNavigate = (): void => {
+        if (this.webview) {
+            this.setState({ address: this.webview.getURL() });
+        }
+    };
+
+    constructor(props: ImportBrowserTabProps) {
+        super(props);
+        this.state = {
+            address: '',
+            committedUrl: '',
+            pageLoaded: false,
+            pageLoadFailed: false,
+            clipError: undefined
+        };
+    }
+
+    override render(): React.ReactNode {
+        return (
+            <div className='cooklang-import-browser'>
+                <div className='cooklang-import-browser-toolbar'>
+                    <button className='theia-button secondary' onClick={this.goBack} disabled={!this.canGoBack()}
+                        title={nls.localizeByDefault('Back')}>
+                        <i className='codicon codicon-arrow-left' />
+                    </button>
+                    <button className='theia-button secondary' onClick={this.goForward} disabled={!this.canGoForward()}
+                        title={nls.localizeByDefault('Forward')}>
+                        <i className='codicon codicon-arrow-right' />
+                    </button>
+                    <button className='theia-button secondary' onClick={this.reload} disabled={!this.state.pageLoaded}
+                        title={nls.localizeByDefault('Reload')}>
+                        <i className='codicon codicon-refresh' />
+                    </button>
+                    <input className='theia-input' type='text' value={this.state.address}
+                        placeholder='https://example.com/best-pancakes'
+                        onChange={this.onAddressChanged} onKeyDown={this.onAddressKeyDown} />
+                    <button className='theia-button main' onClick={this.clip}
+                        disabled={this.props.busy || !this.state.pageLoaded}>
+                        {nls.localize('theia/cooklang-import/clipRecipe', 'Clip Recipe')}
+                    </button>
+                </div>
+                {this.state.pageLoadFailed &&
+                    <div className='cooklang-import-status cooklang-import-error'>
+                        {nls.localize('theia/cooklang-import/pageLoadFailed', 'Couldn’t load this page.')}
+                    </div>}
+                {this.renderBrowserArea()}
+                {this.state.clipError &&
+                    <div className='cooklang-import-status cooklang-import-error'>{this.state.clipError}</div>}
+            </div>
+        );
+    }
+
+    protected renderBrowserArea(): React.ReactNode {
+        if (!this.state.committedUrl) {
+            return (
+                <div className='cooklang-import-signin-gate'>
+                    <span>{nls.localize('theia/cooklang-import/browserHint', 'Browse to a recipe page, then press Clip Recipe.')}</span>
+                </div>
+            );
+        }
+        // React has no intrinsic 'webview' type; createElement with a raw props object is required.
+        return React.createElement('webview', {
+            ref: this.setWebview,
+            src: this.state.committedUrl,
+            partition: 'import-browser'
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+    }
+
+    protected setWebview = (element: WebviewElement | null): void => {
+        if (this.webview) {
+            this.webview.removeEventListener('did-finish-load', this.handleDidFinishLoad);
+            this.webview.removeEventListener('did-fail-load', this.handleDidFailLoad);
+            this.webview.removeEventListener('did-navigate', this.handleDidNavigate);
+            this.webview.removeEventListener('did-navigate-in-page', this.handleDidNavigate);
+        }
+        this.webview = element ?? undefined;
+        if (this.webview) {
+            this.webview.addEventListener('did-finish-load', this.handleDidFinishLoad);
+            this.webview.addEventListener('did-fail-load', this.handleDidFailLoad);
+            this.webview.addEventListener('did-navigate', this.handleDidNavigate);
+            this.webview.addEventListener('did-navigate-in-page', this.handleDidNavigate);
+        }
+    };
+
+    protected canGoBack(): boolean {
+        return this.state.pageLoaded && !!this.webview?.canGoBack();
+    }
+
+    protected canGoForward(): boolean {
+        return this.state.pageLoaded && !!this.webview?.canGoForward();
+    }
+
+    protected goBack = (): void => {
+        if (this.canGoBack()) {
+            this.webview?.goBack();
+        }
+    };
+
+    protected goForward = (): void => {
+        if (this.canGoForward()) {
+            this.webview?.goForward();
+        }
+    };
+
+    protected reload = (): void => {
+        if (this.state.pageLoaded) {
+            this.webview?.reload();
+        }
+    };
+
+    protected onAddressChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        this.setState({ address: event.target.value });
+    };
+
+    protected onAddressKeyDown = (event: React.KeyboardEvent): void => {
+        if (event.key === 'Enter') {
+            this.navigate();
+        }
+    };
+
+    protected navigate(): void {
+        const raw = this.state.address.trim();
+        if (!raw) {
+            return;
+        }
+        const url = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+        try {
+            new URL(url);
+        } catch {
+            this.setState({ pageLoaded: false, pageLoadFailed: true });
+            return;
+        }
+        if (url === this.state.committedUrl) {
+            this.setState({ pageLoaded: false, pageLoadFailed: false });
+            this.webview?.reload();
+            return;
+        }
+        this.setState({ address: url, committedUrl: url, pageLoaded: false, pageLoadFailed: false, clipError: undefined });
+        if (this.webview) {
+            this.webview.src = url;
+        }
+    }
+
+    protected clip = (): void => {
+        if (!this.webview || !this.state.pageLoaded) {
+            return;
+        }
+        this.setState({ clipError: undefined });
+        this.webview.executeJavaScript(CLIP_SCRIPT).then(result => {
+            const data = result as ClipScriptResult;
+            const payload = RecipePayload.extract(data.jsonLdBlocks ?? [], data.pageText ?? '');
+            if (!payload.trim()) {
+                this.setState({ clipError: nls.localize('theia/cooklang-import/nothingToClip', 'Nothing to clip on this page.') });
+                return;
+            }
+            this.props.onClip(payload);
+        }).catch(err => {
+            console.error('Failed to clip page:', err);
+            this.setState({ clipError: nls.localize('theia/cooklang-import/clipFailed', 'Couldn’t read this page. Try reloading it.') });
+        });
+    };
+}

--- a/packages/cooklang-import/src/browser/import-browser-tab.tsx
+++ b/packages/cooklang-import/src/browser/import-browser-tab.tsx
@@ -71,6 +71,10 @@ interface ClipScriptResult {
 export interface ImportBrowserTabProps {
     busy: boolean;
     onClip: (payload: string) => void;
+    /** Page loaded when the tab opens (user preference; must be http/https to be honored). */
+    startPage?: string;
+    /** Widget-level import status (error/success) rendered in the browser's status row. */
+    statusNode?: React.ReactNode;
 }
 
 interface ImportBrowserTabState {
@@ -123,9 +127,10 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
 
     constructor(props: ImportBrowserTabProps) {
         super(props);
+        const startPage = props.startPage && /^https?:\/\//i.test(props.startPage) ? props.startPage : '';
         this.state = {
-            address: '',
-            committedUrl: '',
+            address: startPage,
+            committedUrl: startPage,
             domReady: false,
             pageLoaded: false,
             pageLoadFailed: false,
@@ -154,16 +159,31 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
                         onChange={this.onAddressChanged} onKeyDown={this.onAddressKeyDown} />
                     <button className='theia-button main' onClick={this.clip}
                         disabled={this.props.busy || !this.state.pageLoaded}>
-                        {nls.localize('theia/cooklang-import/clipRecipe', 'Clip Recipe')}
+                        {this.props.busy
+                            ? <React.Fragment>
+                                <i className='codicon codicon-loading codicon-modifier-spin' />
+                                {nls.localize('theia/cooklang-import/importing', 'Importing…')}
+                            </React.Fragment>
+                            : nls.localize('theia/cooklang-import/clipRecipe', 'Clip Recipe')}
                     </button>
                 </div>
-                {this.state.pageLoadFailed &&
-                    <div className='cooklang-import-status cooklang-import-error'>
-                        {nls.localize('theia/cooklang-import/pageLoadFailed', 'Couldn’t load this page.')}
-                    </div>}
+                {this.renderStatusRow()}
                 {this.renderBrowserArea()}
+            </div>
+        );
+    }
+
+    /** Fixed-height status row between toolbar and page, so messages never shift the layout. */
+    protected renderStatusRow(): React.ReactNode {
+        return (
+            <div className='cooklang-import-browser-status'>
+                {this.state.pageLoadFailed &&
+                    <span className='cooklang-import-error'>
+                        {nls.localize('theia/cooklang-import/pageLoadFailed', 'Couldn’t load this page.')}
+                    </span>}
                 {this.state.clipError &&
-                    <div className='cooklang-import-status cooklang-import-error'>{this.state.clipError}</div>}
+                    <span className='cooklang-import-error'>{this.state.clipError}</span>}
+                {this.props.statusNode}
             </div>
         );
     }

--- a/packages/cooklang-import/src/browser/import-browser-tab.tsx
+++ b/packages/cooklang-import/src/browser/import-browser-tab.tsx
@@ -32,7 +32,27 @@ interface WebviewElement extends HTMLElement {
 
 interface DidFailLoadEvent extends Event {
     isMainFrame: boolean;
+    errorCode: number;
 }
+
+interface DidNavigateEvent extends Event {
+    url?: string;
+}
+
+/** Chromium's ERR_ABORTED, reported when a load is superseded by a newer one — not a real failure. */
+const ERR_ABORTED = -3;
+
+/** Upper bound applied to each JSON-LD block and to the page text before extraction. */
+const MAX_CLIP_TEXT_LENGTH = 200000;
+
+/**
+ * Session partition of the clipping `<webview>`. The name has no `persist:`
+ * prefix, so the session is in-memory: site logins made inside the clipping
+ * browser do not survive an app restart — a deliberate privacy default.
+ * Must match `IMPORT_BROWSER_PARTITION` in
+ * `packages/cooklang-branding/src/electron-main/cooklang-electron-main-application.ts`.
+ */
+const IMPORT_BROWSER_PARTITION = 'import-browser';
 
 /**
  * Collects the raw data used to build a clip payload. Runs inside the clipped
@@ -44,8 +64,8 @@ const CLIP_SCRIPT = `(() => ({
 }))()`;
 
 interface ClipScriptResult {
-    jsonLdBlocks: string[];
-    pageText: string;
+    jsonLdBlocks: unknown;
+    pageText: unknown;
 }
 
 export interface ImportBrowserTabProps {
@@ -56,6 +76,8 @@ export interface ImportBrowserTabProps {
 interface ImportBrowserTabState {
     address: string;
     committedUrl: string;
+    /** True once 'dom-ready' fired: webview methods (reload, canGoBack, …) throw before that. */
+    domReady: boolean;
     pageLoaded: boolean;
     pageLoadFailed: boolean;
     clipError: string | undefined;
@@ -74,20 +96,28 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
 
     protected webview: WebviewElement | undefined;
 
+    protected readonly handleDomReady = (): void => {
+        this.setState({ domReady: true });
+    };
+
     protected readonly handleDidFinishLoad = (): void => {
         this.setState({ pageLoaded: true, pageLoadFailed: false });
     };
 
     protected readonly handleDidFailLoad = (event: Event): void => {
-        if ((event as DidFailLoadEvent).isMainFrame === false) {
+        const failure = event as DidFailLoadEvent;
+        if (failure.isMainFrame === false || failure.errorCode === ERR_ABORTED) {
             return;
         }
         this.setState({ pageLoaded: false, pageLoadFailed: true });
     };
 
-    protected readonly handleDidNavigate = (): void => {
-        if (this.webview) {
-            this.setState({ address: this.webview.getURL() });
+    // 'did-navigate' fires at commit time, before 'dom-ready', when getURL() would
+    // still throw — so read the URL off the event instead of asking the webview.
+    protected readonly handleDidNavigate = (event: Event): void => {
+        const url = (event as DidNavigateEvent).url;
+        if (url) {
+            this.setState({ address: url });
         }
     };
 
@@ -96,6 +126,7 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
         this.state = {
             address: '',
             committedUrl: '',
+            domReady: false,
             pageLoaded: false,
             pageLoadFailed: false,
             clipError: undefined
@@ -114,12 +145,12 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
                         title={nls.localizeByDefault('Forward')}>
                         <i className='codicon codicon-arrow-right' />
                     </button>
-                    <button className='theia-button secondary' onClick={this.reload} disabled={!this.state.pageLoaded}
+                    <button className='theia-button secondary' onClick={this.reload} disabled={!this.state.committedUrl}
                         title={nls.localizeByDefault('Reload')}>
                         <i className='codicon codicon-refresh' />
                     </button>
                     <input className='theia-input' type='text' value={this.state.address}
-                        placeholder='https://example.com/best-pancakes'
+                        placeholder={nls.localize('theia/cooklang-import/browserPlaceholder', 'Enter a URL and press Enter')}
                         onChange={this.onAddressChanged} onKeyDown={this.onAddressKeyDown} />
                     <button className='theia-button main' onClick={this.clip}
                         disabled={this.props.busy || !this.state.pageLoaded}>
@@ -140,7 +171,7 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
     protected renderBrowserArea(): React.ReactNode {
         if (!this.state.committedUrl) {
             return (
-                <div className='cooklang-import-signin-gate'>
+                <div className='cooklang-import-browser-hint'>
                     <span>{nls.localize('theia/cooklang-import/browserHint', 'Browse to a recipe page, then press Clip Recipe.')}</span>
                 </div>
             );
@@ -149,13 +180,14 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
         return React.createElement('webview', {
             ref: this.setWebview,
             src: this.state.committedUrl,
-            partition: 'import-browser'
+            partition: IMPORT_BROWSER_PARTITION
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any);
     }
 
     protected setWebview = (element: WebviewElement | null): void => {
         if (this.webview) {
+            this.webview.removeEventListener('dom-ready', this.handleDomReady);
             this.webview.removeEventListener('did-finish-load', this.handleDidFinishLoad);
             this.webview.removeEventListener('did-fail-load', this.handleDidFailLoad);
             this.webview.removeEventListener('did-navigate', this.handleDidNavigate);
@@ -163,6 +195,7 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
         }
         this.webview = element ?? undefined;
         if (this.webview) {
+            this.webview.addEventListener('dom-ready', this.handleDomReady);
             this.webview.addEventListener('did-finish-load', this.handleDidFinishLoad);
             this.webview.addEventListener('did-fail-load', this.handleDidFailLoad);
             this.webview.addEventListener('did-navigate', this.handleDidNavigate);
@@ -171,11 +204,11 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
     };
 
     protected canGoBack(): boolean {
-        return this.state.pageLoaded && !!this.webview?.canGoBack();
+        return this.state.domReady && !!this.webview?.canGoBack();
     }
 
     protected canGoForward(): boolean {
-        return this.state.pageLoaded && !!this.webview?.canGoForward();
+        return this.state.domReady && !!this.webview?.canGoForward();
     }
 
     protected goBack = (): void => {
@@ -191,10 +224,25 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
     };
 
     protected reload = (): void => {
-        if (this.state.pageLoaded) {
-            this.webview?.reload();
-        }
+        this.reloadCommittedUrl();
     };
+
+    /**
+     * Reloads the committed page. Before the first 'dom-ready' (e.g. after a failed
+     * initial load) `reload()` throws, so retry by re-assigning `src` instead —
+     * assigning `src` its own value reloads the page.
+     */
+    protected reloadCommittedUrl(): void {
+        if (!this.webview || !this.state.committedUrl) {
+            return;
+        }
+        this.setState({ pageLoaded: false, pageLoadFailed: false });
+        if (this.state.domReady) {
+            this.webview.reload();
+        } else {
+            this.webview.src = this.state.committedUrl;
+        }
+    }
 
     protected onAddressChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
         this.setState({ address: event.target.value });
@@ -219,14 +267,12 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
             return;
         }
         if (url === this.state.committedUrl) {
-            this.setState({ pageLoaded: false, pageLoadFailed: false });
-            this.webview?.reload();
+            this.reloadCommittedUrl();
             return;
         }
+        // The controlled `src` prop of the webview element performs the navigation;
+        // no imperative load is needed here.
         this.setState({ address: url, committedUrl: url, pageLoaded: false, pageLoadFailed: false, clipError: undefined });
-        if (this.webview) {
-            this.webview.src = url;
-        }
     }
 
     protected clip = (): void => {
@@ -236,7 +282,14 @@ export class ImportBrowserTab extends React.Component<ImportBrowserTabProps, Imp
         this.setState({ clipError: undefined });
         this.webview.executeJavaScript(CLIP_SCRIPT).then(result => {
             const data = result as ClipScriptResult;
-            const payload = RecipePayload.extract(data.jsonLdBlocks ?? [], data.pageText ?? '');
+            // Defensive clamping: the data comes from an untrusted page, so keep only
+            // strings and cap their size before handing them to the extractor.
+            const jsonLdBlocks = Array.isArray(data.jsonLdBlocks)
+                ? data.jsonLdBlocks.filter((block): block is string => typeof block === 'string')
+                    .map(block => block.slice(0, MAX_CLIP_TEXT_LENGTH))
+                : [];
+            const pageText = typeof data.pageText === 'string' ? data.pageText.slice(0, MAX_CLIP_TEXT_LENGTH) : '';
+            const payload = RecipePayload.extract(jsonLdBlocks, pageText);
             if (!payload.trim()) {
                 this.setState({ clipError: nls.localize('theia/cooklang-import/nothingToClip', 'Nothing to clip on this page.') });
                 return;

--- a/packages/cooklang-import/src/browser/import-contribution.ts
+++ b/packages/cooklang-import/src/browser/import-contribution.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
+import { Command, CommandRegistry } from '@theia/core/lib/common/command';
+import { MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
+
+export namespace ImportCommands {
+    export const OPEN: Command = Command.toLocalizedCommand({
+        id: 'cooklang.import.open',
+        label: 'Import Recipe…',
+    }, 'theia/cooklang-import/openCommand');
+}
+
+@injectable()
+export class ImportContribution extends AbstractViewContribution<ImportWidget> {
+
+    constructor() {
+        super({
+            widgetId: IMPORT_WIDGET_ID,
+            widgetName: ImportWidget.LABEL,
+            defaultWidgetOptions: { area: 'main' },
+        });
+    }
+
+    override registerCommands(registry: CommandRegistry): void {
+        super.registerCommands(registry);
+        registry.registerCommand(ImportCommands.OPEN, {
+            execute: () => this.openView({ activate: true, reveal: true }),
+        });
+    }
+
+    override registerMenus(menus: MenuModelRegistry): void {
+        super.registerMenus(menus);
+        menus.registerMenuAction(CommonMenus.FILE, {
+            commandId: ImportCommands.OPEN.id,
+            order: 'z10',
+        });
+    }
+}

--- a/packages/cooklang-import/src/browser/import-contribution.ts
+++ b/packages/cooklang-import/src/browser/import-contribution.ts
@@ -17,6 +17,7 @@ import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-con
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
+import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
 import { MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { FILE_NAVIGATOR_ID } from '@theia/navigator/lib/browser/navigator-widget';
 import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
@@ -61,6 +62,15 @@ export class ImportContribution extends AbstractViewContribution<ImportWidget> i
         menus.registerMenuAction(CommonMenus.FILE, {
             commandId: ImportCommands.OPEN.id,
             order: 'z10',
+        });
+    }
+
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
+        super.registerKeybindings(keybindings);
+        // ctrlcmd+alt+i: ctrlcmd+shift+i is taken by devtools in Electron builds.
+        keybindings.registerKeybinding({
+            command: ImportCommands.OPEN.id,
+            keybinding: 'ctrlcmd+alt+i',
         });
     }
 

--- a/packages/cooklang-import/src/browser/import-contribution.ts
+++ b/packages/cooklang-import/src/browser/import-contribution.ts
@@ -12,10 +12,13 @@
 // *****************************************************************************
 
 import { injectable } from '@theia/core/shared/inversify';
+import { Widget } from '@theia/core/lib/browser/widgets/widget';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { FILE_NAVIGATOR_ID } from '@theia/navigator/lib/browser/navigator-widget';
 import { ImportWidget, IMPORT_WIDGET_ID } from './import-widget';
 
 export namespace ImportCommands {
@@ -23,10 +26,15 @@ export namespace ImportCommands {
         id: 'cooklang.import.open',
         label: 'Import Recipe…',
     }, 'theia/cooklang-import/openCommand');
+    /** Toolbar variant shown on the Explorer's tab bar (visibility scoped to the navigator widget). */
+    export const OPEN_FROM_NAVIGATOR: Command = {
+        id: 'cooklang.import.openFromNavigator',
+        iconClass: 'codicon codicon-cloud-download',
+    };
 }
 
 @injectable()
-export class ImportContribution extends AbstractViewContribution<ImportWidget> {
+export class ImportContribution extends AbstractViewContribution<ImportWidget> implements TabBarToolbarContribution {
 
     constructor() {
         super({
@@ -41,6 +49,11 @@ export class ImportContribution extends AbstractViewContribution<ImportWidget> {
         registry.registerCommand(ImportCommands.OPEN, {
             execute: () => this.openView({ activate: true, reveal: true }),
         });
+        registry.registerCommand(ImportCommands.OPEN_FROM_NAVIGATOR, {
+            execute: () => this.openView({ activate: true, reveal: true }),
+            isEnabled: widget => this.isNavigator(widget),
+            isVisible: widget => this.isNavigator(widget),
+        });
     }
 
     override registerMenus(menus: MenuModelRegistry): void {
@@ -49,5 +62,18 @@ export class ImportContribution extends AbstractViewContribution<ImportWidget> {
             commandId: ImportCommands.OPEN.id,
             order: 'z10',
         });
+    }
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: ImportCommands.OPEN_FROM_NAVIGATOR.id,
+            command: ImportCommands.OPEN_FROM_NAVIGATOR.id,
+            tooltip: ImportCommands.OPEN.label,
+            priority: 0,
+        });
+    }
+
+    protected isNavigator(widget: Widget | undefined): boolean {
+        return widget instanceof Widget && widget.id === FILE_NAVIGATOR_ID;
     }
 }

--- a/packages/cooklang-import/src/browser/import-contribution.ts
+++ b/packages/cooklang-import/src/browser/import-contribution.ts
@@ -59,9 +59,10 @@ export class ImportContribution extends AbstractViewContribution<ImportWidget> i
 
     override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
-        menus.registerMenuAction(CommonMenus.FILE, {
+        // Group id sorts after the '1_new'/'1_new_text' groups and before '2_open',
+        // placing Import Recipe directly under the New-file entries.
+        menus.registerMenuAction([...CommonMenus.FILE, '1z_import'], {
             commandId: ImportCommands.OPEN.id,
-            order: 'z10',
         });
     }
 

--- a/packages/cooklang-import/src/browser/import-preferences.ts
+++ b/packages/cooklang-import/src/browser/import-preferences.ts
@@ -1,0 +1,32 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { interfaces } from '@theia/core/shared/inversify';
+import { PreferenceContribution, PreferenceSchema } from '@theia/core/lib/common/preferences';
+
+export const IMPORT_BROWSER_START_PAGE_PREF = 'cooklang.import.browserStartPage';
+export const IMPORT_BROWSER_START_PAGE_DEFAULT = 'https://duckduckgo.com';
+
+export const cooklangImportPreferencesSchema: PreferenceSchema = {
+    'properties': {
+        [IMPORT_BROWSER_START_PAGE_PREF]: {
+            'type': 'string',
+            'description': 'Web page opened by default in the recipe import browser tab.',
+            'default': IMPORT_BROWSER_START_PAGE_DEFAULT
+        }
+    }
+};
+
+export function bindCooklangImportPreferences(bind: interfaces.Bind): void {
+    bind(PreferenceContribution).toConstantValue({ schema: cooklangImportPreferencesSchema });
+}

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -25,6 +25,9 @@ export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
 
 export type ImportTab = 'url' | 'text' | 'images' | 'browser';
 
+const TAB_ORDER: ImportTab[] = ['url', 'text', 'images', 'browser'];
+const TAB_PANEL_ID = 'cooklang-import-tabpanel';
+
 @injectable()
 export class ImportWidget extends ReactWidget {
 
@@ -54,6 +57,8 @@ export class ImportWidget extends ReactWidget {
     protected errorMessage: string | undefined;
     protected errorShowsSignIn = false;
     protected successMessage: string | undefined;
+    protected urlValue = '';
+    protected textValue = '';
 
     @postConstruct()
     protected init(): void {
@@ -154,7 +159,7 @@ export class ImportWidget extends ReactWidget {
                 {this.renderTabBar()}
                 {!this.signedIn && this.activeTab !== 'images' && this.renderLimitsBanner()}
                 {this.renderStatus()}
-                <div className='cooklang-import-tab-body' role='tabpanel'>
+                <div className='cooklang-import-tab-body' role='tabpanel' id={TAB_PANEL_ID} aria-labelledby={this.tabElementId(this.activeTab)}>
                     {this.renderActiveTab()}
                 </div>
             </div>
@@ -162,26 +167,74 @@ export class ImportWidget extends ReactWidget {
     }
 
     protected renderTabBar(): React.ReactNode {
-        const tabs: Array<{ id: ImportTab; label: string }> = [
-            { id: 'url', label: nls.localizeByDefault('URL') },
-            { id: 'text', label: nls.localizeByDefault('Text') },
-            { id: 'images', label: nls.localize('theia/cooklang-import/tabImages', 'Images') },
-            { id: 'browser', label: nls.localize('theia/cooklang-import/tabBrowser', 'Web Browser') },
-        ];
         return (
             <div className='cooklang-import-tabbar' role='tablist'>
-                {tabs.map(tab => (
-                    <TabButton key={tab.id} tab={tab.id} label={tab.label}
-                        active={this.activeTab === tab.id}
-                        onSelect={this.onTabSelected} />
+                {TAB_ORDER.map(tab => (
+                    <TabButton key={tab} tab={tab} label={this.tabLabel(tab)}
+                        active={this.activeTab === tab}
+                        id={this.tabElementId(tab)}
+                        ariaControls={TAB_PANEL_ID}
+                        onSelect={this.onTabSelected}
+                        onKeyDown={this.onTabKeyDown} />
                 ))}
             </div>
         );
     }
 
+    protected tabLabel(tab: ImportTab): string {
+        switch (tab) {
+            case 'url': return nls.localizeByDefault('URL');
+            case 'text': return nls.localizeByDefault('Text');
+            case 'images': return nls.localize('theia/cooklang-import/tabImages', 'Images');
+            case 'browser': return nls.localize('theia/cooklang-import/tabBrowser', 'Web Browser');
+        }
+    }
+
+    protected tabElementId(tab: ImportTab): string {
+        return `cooklang-import-tab-${tab}`;
+    }
+
     protected onTabSelected = (tab: ImportTab): void => {
         this.selectTab(tab);
     };
+
+    protected onTabKeyDown = (tab: ImportTab, event: React.KeyboardEvent): void => {
+        switch (event.key) {
+            case 'Enter':
+            case ' ':
+                event.preventDefault();
+                this.selectTab(tab);
+                break;
+            case 'ArrowRight':
+                event.preventDefault();
+                this.focusTab(this.adjacentTab(tab, 1));
+                break;
+            case 'ArrowLeft':
+                event.preventDefault();
+                this.focusTab(this.adjacentTab(tab, -1));
+                break;
+            case 'Home':
+                event.preventDefault();
+                this.focusTab(TAB_ORDER[0]);
+                break;
+            case 'End':
+                event.preventDefault();
+                this.focusTab(TAB_ORDER[TAB_ORDER.length - 1]);
+                break;
+        }
+    };
+
+    protected adjacentTab(tab: ImportTab, delta: number): ImportTab {
+        const index = TAB_ORDER.indexOf(tab);
+        const nextIndex = (index + delta + TAB_ORDER.length) % TAB_ORDER.length;
+        return TAB_ORDER[nextIndex];
+    }
+
+    protected focusTab(tab: ImportTab): void {
+        this.selectTab(tab);
+        const element = this.node.querySelector<HTMLElement>(`#${this.tabElementId(tab)}`);
+        element?.focus();
+    }
 
     protected renderLimitsBanner(): React.ReactNode {
         return (
@@ -215,7 +268,7 @@ export class ImportWidget extends ReactWidget {
     }
 
     protected renderActiveTab(): React.ReactNode {
-        // Tabs are implemented in Tasks 8-10; placeholders until then.
+        // Images and browser tabs are implemented in Tasks 9-10; placeholders until then.
         switch (this.activeTab) {
             case 'url': return this.renderUrlTab();
             case 'text': return this.renderTextTab();
@@ -225,12 +278,59 @@ export class ImportWidget extends ReactWidget {
     }
 
     protected renderUrlTab(): React.ReactNode {
-        return <div />;
+        return (
+            <div className='cooklang-import-form'>
+                <label>{nls.localize('theia/cooklang-import/urlLabel', 'Recipe page URL')}</label>
+                <input className='theia-input' type='text' value={this.urlValue}
+                    placeholder='https://example.com/best-pancakes'
+                    onChange={this.onUrlChanged} onKeyDown={this.onUrlKeyDown} disabled={this.busy} />
+                <button className='theia-button main' onClick={this.importFromUrl}
+                    disabled={this.busy || this.urlValue.trim().length === 0}>
+                    {nls.localize('theia/cooklang-import/importButton', 'Import')}
+                </button>
+            </div>
+        );
     }
 
+    protected onUrlChanged = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        this.urlValue = event.target.value;
+        this.update();
+    };
+
+    protected onUrlKeyDown = (event: React.KeyboardEvent): void => {
+        if (event.key === 'Enter' && this.urlValue.trim().length > 0 && !this.busy) {
+            this.importFromUrl();
+        }
+    };
+
+    protected importFromUrl = (): void => {
+        const url = this.urlValue.trim();
+        this.runImport(() => this.importService.convertUrl(url)).catch(err => console.error('Failed to import from URL:', err));
+    };
+
     protected renderTextTab(): React.ReactNode {
-        return <div />;
+        return (
+            <div className='cooklang-import-form'>
+                <label>{nls.localize('theia/cooklang-import/textLabel', 'Paste the recipe text')}</label>
+                <textarea className='theia-input' value={this.textValue}
+                    onChange={this.onTextChanged} disabled={this.busy} />
+                <button className='theia-button main' onClick={this.importFromText}
+                    disabled={this.busy || this.textValue.trim().length === 0}>
+                    {nls.localize('theia/cooklang-import/importButton', 'Import')}
+                </button>
+            </div>
+        );
     }
+
+    protected onTextChanged = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+        this.textValue = event.target.value;
+        this.update();
+    };
+
+    protected importFromText = (): void => {
+        const text = this.textValue.trim();
+        this.runImport(() => this.importService.convertText(text)).catch(err => console.error('Failed to import from text:', err));
+    };
 
     protected renderImagesTab(): React.ReactNode {
         return <div />;
@@ -245,13 +345,16 @@ interface TabButtonProps {
     tab: ImportTab;
     label: string;
     active: boolean;
+    id: string;
+    ariaControls: string;
     onSelect: (tab: ImportTab) => void;
+    onKeyDown: (tab: ImportTab, event: React.KeyboardEvent) => void;
 }
 
 class TabButton extends React.Component<TabButtonProps> {
     override render(): React.ReactNode {
-        const { label, active } = this.props;
-        return <div role='tab' aria-selected={active} tabIndex={active ? 0 : -1}
+        const { label, active, id, ariaControls } = this.props;
+        return <div role='tab' id={id} aria-selected={active} aria-controls={ariaControls} tabIndex={active ? 0 : -1}
             className={'cooklang-import-tab' + (active ? ' cooklang-import-tab-active' : '')}
             onClick={this.handleClick} onKeyDown={this.handleKeyDown}>{label}</div>;
     }
@@ -259,9 +362,6 @@ class TabButton extends React.Component<TabButtonProps> {
         this.props.onSelect(this.props.tab);
     };
     protected handleKeyDown = (event: React.KeyboardEvent): void => {
-        if (event.key === 'Enter' || event.key === ' ') {
-            event.preventDefault();
-            this.props.onSelect(this.props.tab);
-        }
+        this.props.onKeyDown(this.props.tab, event);
     };
 }

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -20,6 +20,7 @@ import { AuthService, AuthState } from '@theia/cooklang-account/lib/common/auth-
 import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
 import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
 import { DraftSaver, DRAFTS_FOLDER_NAME } from './draft-saver';
+import { ImageEncoder, MAX_IMPORT_IMAGES } from './image-encoder';
 
 export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
 
@@ -59,6 +60,8 @@ export class ImportWidget extends ReactWidget {
     protected successMessage: string | undefined;
     protected urlValue = '';
     protected textValue = '';
+    protected images: Array<{ file: File; previewUrl: string }> = [];
+    protected dropActive = false;
 
     @postConstruct()
     protected init(): void {
@@ -70,6 +73,7 @@ export class ImportWidget extends ReactWidget {
         this.addClass('cooklang-import-widget');
         this.refreshAuthState();
         this.toDispose.push(this.authContribution.onDidChangeAuth(() => this.refreshAuthState()));
+        this.toDispose.push({ dispose: () => this.clearImages() });
     }
 
     protected refreshAuthState(): void {
@@ -304,7 +308,17 @@ export class ImportWidget extends ReactWidget {
     };
 
     protected importFromUrl = (): void => {
-        const url = this.urlValue.trim();
+        const raw = this.urlValue.trim();
+        const url = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(raw) ? raw : `https://${raw}`;
+        try {
+            new URL(url);
+        } catch {
+            this.errorMessage = nls.localize('theia/cooklang-import/invalidUrl', 'Enter a valid web address.');
+            this.errorShowsSignIn = false;
+            this.successMessage = undefined;
+            this.update();
+            return;
+        }
         this.runImport(() => this.importService.convertUrl(url)).catch(err => console.error('Failed to import from URL:', err));
     };
 
@@ -333,8 +347,95 @@ export class ImportWidget extends ReactWidget {
     };
 
     protected renderImagesTab(): React.ReactNode {
-        return <div />;
+        if (!this.signedIn) {
+            return (
+                <div className='cooklang-import-signin-gate'>
+                    <i className='codicon codicon-account' />
+                    <span>{nls.localize('theia/cooklang-import/imagesSignIn', 'Sign in to CookCloud to use image clipping.')}</span>
+                    <button className='theia-button main' onClick={this.signIn}>
+                        {nls.localizeByDefault('Sign in')}
+                    </button>
+                </div>
+            );
+        }
+        return (
+            <div className='cooklang-import-form'>
+                <div className={'cooklang-import-dropzone' + (this.dropActive ? ' cooklang-import-dropzone-active' : '')}
+                    onDragOver={this.onDragOver} onDragLeave={this.onDragLeave} onDrop={this.onDrop}>
+                    {nls.localize('theia/cooklang-import/dropImages', 'Drop up to {0} recipe photos here, or', MAX_IMPORT_IMAGES)}
+                    <input type='file' accept='image/*' multiple onChange={this.onFilesPicked} disabled={this.busy} />
+                </div>
+                {this.images.length > 0 &&
+                    <div className='cooklang-import-thumbs'>
+                        {this.images.map((image, index) => <ImageThumb key={image.previewUrl} index={index}
+                            previewUrl={image.previewUrl} onRemove={this.onRemoveImage} />)}
+                    </div>}
+                <button className='theia-button main' onClick={this.importFromImages}
+                    disabled={this.busy || this.images.length === 0}>
+                    {nls.localize('theia/cooklang-import/importButton', 'Import')}
+                </button>
+            </div>
+        );
     }
+
+    protected onDragOver = (event: React.DragEvent): void => {
+        event.preventDefault();
+        this.dropActive = true;
+        this.update();
+    };
+
+    protected onDragLeave = (): void => {
+        this.dropActive = false;
+        this.update();
+    };
+
+    protected onDrop = (event: React.DragEvent): void => {
+        event.preventDefault();
+        this.dropActive = false;
+        this.addImageFiles(Array.from(event.dataTransfer.files));
+    };
+
+    protected onFilesPicked = (event: React.ChangeEvent<HTMLInputElement>): void => {
+        this.addImageFiles(Array.from(event.target.files ?? []));
+        event.target.value = '';
+    };
+
+    protected addImageFiles(files: File[]): void {
+        const imageFiles = files.filter(file => file.type.startsWith('image/'));
+        for (const file of imageFiles) {
+            if (this.images.length >= MAX_IMPORT_IMAGES) {
+                break;
+            }
+            this.images.push({ file, previewUrl: URL.createObjectURL(file) });
+        }
+        this.update();
+    }
+
+    protected onRemoveImage = (index: number): void => {
+        const [removed] = this.images.splice(index, 1);
+        if (removed) {
+            URL.revokeObjectURL(removed.previewUrl);
+        }
+        this.update();
+    };
+
+    protected clearImages(): void {
+        this.images.forEach(image => URL.revokeObjectURL(image.previewUrl));
+        this.images = [];
+    }
+
+    protected importFromImages = (): void => {
+        const files = this.images.map(image => image.file);
+        this.runImport(async () => {
+            const encoded = await Promise.all(files.map(file => ImageEncoder.toBase64Jpeg(file)));
+            return this.importService.convertImages(encoded);
+        }).then(() => {
+            if (this.successMessage) {
+                this.clearImages();
+                this.update();
+            }
+        }, (err: unknown) => console.error('Image import failed:', err));
+    };
 
     protected renderBrowserTab(): React.ReactNode {
         return <div />;
@@ -363,5 +464,28 @@ class TabButton extends React.Component<TabButtonProps> {
     };
     protected handleKeyDown = (event: React.KeyboardEvent): void => {
         this.props.onKeyDown(this.props.tab, event);
+    };
+}
+
+interface ImageThumbProps {
+    index: number;
+    previewUrl: string;
+    onRemove: (index: number) => void;
+}
+
+class ImageThumb extends React.Component<ImageThumbProps> {
+    override render(): React.ReactNode {
+        return (
+            <div className='cooklang-import-thumb'>
+                <img src={this.props.previewUrl} />
+                <button className='cooklang-import-thumb-remove' onClick={this.handleRemove}
+                    title={nls.localizeByDefault('Remove')}>
+                    <i className='codicon codicon-close' />
+                </button>
+            </div>
+        );
+    }
+    protected handleRemove = (): void => {
+        this.props.onRemove(this.props.index);
     };
 }

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -309,7 +309,7 @@ export class ImportWidget extends ReactWidget {
 
     protected importFromUrl = (): void => {
         const raw = this.urlValue.trim();
-        const url = /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(raw) ? raw : `https://${raw}`;
+        const url = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
         try {
             new URL(url);
         } catch {
@@ -368,7 +368,7 @@ export class ImportWidget extends ReactWidget {
                 {this.images.length > 0 &&
                     <div className='cooklang-import-thumbs'>
                         {this.images.map((image, index) => <ImageThumb key={image.previewUrl} index={index}
-                            previewUrl={image.previewUrl} onRemove={this.onRemoveImage} />)}
+                            previewUrl={image.previewUrl} fileName={image.file.name} onRemove={this.onRemoveImage} />)}
                     </div>}
                 <button className='theia-button main' onClick={this.importFromImages}
                     disabled={this.busy || this.images.length === 0}>
@@ -384,7 +384,10 @@ export class ImportWidget extends ReactWidget {
         this.update();
     };
 
-    protected onDragLeave = (): void => {
+    protected onDragLeave = (event: React.DragEvent): void => {
+        if (event.currentTarget.contains(event.relatedTarget as Node)) {
+            return;
+        }
         this.dropActive = false;
         this.update();
     };
@@ -392,6 +395,10 @@ export class ImportWidget extends ReactWidget {
     protected onDrop = (event: React.DragEvent): void => {
         event.preventDefault();
         this.dropActive = false;
+        if (this.busy) {
+            this.update();
+            return;
+        }
         this.addImageFiles(Array.from(event.dataTransfer.files));
     };
 
@@ -427,7 +434,17 @@ export class ImportWidget extends ReactWidget {
     protected importFromImages = (): void => {
         const files = this.images.map(image => image.file);
         this.runImport(async () => {
-            const encoded = await Promise.all(files.map(file => ImageEncoder.toBase64Jpeg(file)));
+            // Encode sequentially so at most one full-resolution bitmap is held in memory at a time.
+            const encoded: string[] = [];
+            for (const file of files) {
+                try {
+                    encoded.push(await ImageEncoder.toBase64Jpeg(file));
+                } catch {
+                    // E.g. HEIC photos: Chromium cannot decode them, so createImageBitmap rejects.
+                    throw new Error(nls.localize('theia/cooklang-import/imageDecodeFailed',
+                        'Couldn’t read {0}. Convert it to JPEG or PNG and try again.', file.name));
+                }
+            }
             return this.importService.convertImages(encoded);
         }).then(() => {
             if (this.successMessage) {
@@ -470,6 +487,7 @@ class TabButton extends React.Component<TabButtonProps> {
 interface ImageThumbProps {
     index: number;
     previewUrl: string;
+    fileName: string;
     onRemove: (index: number) => void;
 }
 
@@ -477,7 +495,7 @@ class ImageThumb extends React.Component<ImageThumbProps> {
     override render(): React.ReactNode {
         return (
             <div className='cooklang-import-thumb'>
-                <img src={this.props.previewUrl} />
+                <img src={this.props.previewUrl} alt={this.props.fileName} />
                 <button className='cooklang-import-thumb-remove' onClick={this.handleRemove}
                     title={nls.localizeByDefault('Remove')}>
                     <i className='codicon codicon-close' />

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -15,6 +15,7 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { CommandService } from '@theia/core/lib/common/command';
 import { nls } from '@theia/core/lib/common/nls';
+import { PreferenceService } from '@theia/core/lib/common/preferences';
 import * as React from '@theia/core/shared/react';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { AuthService, AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
@@ -23,6 +24,7 @@ import { ConvertResult, ImportErrorCode, MAX_IMPORT_IMAGES, RecipeImportService 
 import { DraftSaver, DRAFTS_FOLDER_NAME } from './draft-saver';
 import { ImageEncoder } from './image-encoder';
 import { ImportBrowserTab } from './import-browser-tab';
+import { IMPORT_BROWSER_START_PAGE_DEFAULT, IMPORT_BROWSER_START_PAGE_PREF } from './import-preferences';
 
 export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
 
@@ -54,6 +56,9 @@ export class ImportWidget extends ReactWidget {
 
     @inject(CommandService)
     protected readonly commandService: CommandService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
 
     protected activeTab: ImportTab = 'url';
     protected authState: AuthState = { status: 'logged-out' };
@@ -174,7 +179,6 @@ export class ImportWidget extends ReactWidget {
             <div className='cooklang-import-content'>
                 {this.renderTabBar()}
                 {!this.signedIn && this.activeTab !== 'images' && this.renderLimitsBanner()}
-                {this.renderStatus()}
                 <div className='cooklang-import-tab-body' role='tabpanel' id={TAB_PANEL_ID} aria-labelledby={this.tabElementId(this.activeTab)}>
                     {this.renderActiveTab()}
                 </div>
@@ -261,12 +265,13 @@ export class ImportWidget extends ReactWidget {
         );
     }
 
-    protected renderStatus(): React.ReactNode {
+    /**
+     * Error/success message rendered next to the action button (the busy state
+     * lives inside the button itself), so appearing status never shifts the form.
+     */
+    protected renderInlineStatus(): React.ReactNode {
         if (this.busy) {
-            return <div className='cooklang-import-status'>
-                <i className='codicon codicon-loading codicon-modifier-spin' />
-                {nls.localize('theia/cooklang-import/importing', 'Importing…')}
-            </div>;
+            return undefined;
         }
         if (this.errorMessage) {
             return <div className='cooklang-import-status cooklang-import-error'>
@@ -281,6 +286,23 @@ export class ImportWidget extends ReactWidget {
             return <div className='cooklang-import-status cooklang-import-success'>{this.successMessage}</div>;
         }
         return undefined;
+    }
+
+    /** Import button (spinner + 'Importing…' while busy) with the inline status beside it. */
+    protected renderActionRow(onClick: () => void, disabled: boolean): React.ReactNode {
+        return (
+            <div className='cooklang-import-action-row'>
+                <button className='theia-button main' onClick={onClick} disabled={this.busy || disabled}>
+                    {this.busy
+                        ? <React.Fragment>
+                            <i className='codicon codicon-loading codicon-modifier-spin' />
+                            {nls.localize('theia/cooklang-import/importing', 'Importing…')}
+                        </React.Fragment>
+                        : nls.localize('theia/cooklang-import/importButton', 'Import')}
+                </button>
+                {this.renderInlineStatus()}
+            </div>
+        );
     }
 
     protected renderActiveTab(): React.ReactNode {
@@ -299,10 +321,7 @@ export class ImportWidget extends ReactWidget {
                 <input className='theia-input' type='text' value={this.urlValue}
                     placeholder='https://example.com/best-pancakes'
                     onChange={this.onUrlChanged} onKeyDown={this.onUrlKeyDown} disabled={this.busy} />
-                <button className='theia-button main' onClick={this.importFromUrl}
-                    disabled={this.busy || this.urlValue.trim().length === 0}>
-                    {nls.localize('theia/cooklang-import/importButton', 'Import')}
-                </button>
+                {this.renderActionRow(this.importFromUrl, this.urlValue.trim().length === 0)}
             </div>
         );
     }
@@ -339,10 +358,7 @@ export class ImportWidget extends ReactWidget {
                 <label>{nls.localize('theia/cooklang-import/textLabel', 'Paste the recipe text')}</label>
                 <textarea className='theia-input' value={this.textValue}
                     onChange={this.onTextChanged} disabled={this.busy} />
-                <button className='theia-button main' onClick={this.importFromText}
-                    disabled={this.busy || this.textValue.trim().length === 0}>
-                    {nls.localize('theia/cooklang-import/importButton', 'Import')}
-                </button>
+                {this.renderActionRow(this.importFromText, this.textValue.trim().length === 0)}
             </div>
         );
     }
@@ -381,10 +397,7 @@ export class ImportWidget extends ReactWidget {
                         {this.images.map((image, index) => <ImageThumb key={image.previewUrl} index={index}
                             previewUrl={image.previewUrl} fileName={image.file.name} onRemove={this.onRemoveImage} />)}
                     </div>}
-                <button className='theia-button main' onClick={this.importFromImages}
-                    disabled={this.busy || this.images.length === 0}>
-                    {nls.localize('theia/cooklang-import/importButton', 'Import')}
-                </button>
+                {this.renderActionRow(this.importFromImages, this.images.length === 0)}
             </div>
         );
     }
@@ -468,7 +481,9 @@ export class ImportWidget extends ReactWidget {
     protected renderBrowserTab(): React.ReactNode {
         // Navigation state (address bar, loaded page) lives inside ImportBrowserTab's own
         // React state; it is intentionally lost when the user switches away from this tab.
-        return <ImportBrowserTab busy={this.busy} onClip={this.onClipPayload} />;
+        const startPage = this.preferenceService.get<string>(IMPORT_BROWSER_START_PAGE_PREF, IMPORT_BROWSER_START_PAGE_DEFAULT);
+        return <ImportBrowserTab busy={this.busy} onClip={this.onClipPayload}
+            startPage={startPage} statusNode={this.renderInlineStatus()} />;
     }
 
     protected onClipPayload = (payload: string): void => {

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -21,6 +21,7 @@ import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/li
 import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
 import { DraftSaver, DRAFTS_FOLDER_NAME } from './draft-saver';
 import { ImageEncoder, MAX_IMPORT_IMAGES } from './image-encoder';
+import { ImportBrowserTab } from './import-browser-tab';
 
 export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
 
@@ -272,7 +273,6 @@ export class ImportWidget extends ReactWidget {
     }
 
     protected renderActiveTab(): React.ReactNode {
-        // Images and browser tabs are implemented in Tasks 9-10; placeholders until then.
         switch (this.activeTab) {
             case 'url': return this.renderUrlTab();
             case 'text': return this.renderTextTab();
@@ -455,8 +455,14 @@ export class ImportWidget extends ReactWidget {
     };
 
     protected renderBrowserTab(): React.ReactNode {
-        return <div />;
+        // Navigation state (address bar, loaded page) lives inside ImportBrowserTab's own
+        // React state; it is intentionally lost when the user switches away from this tab.
+        return <ImportBrowserTab busy={this.busy} onClip={this.onClipPayload} />;
     }
+
+    protected onClipPayload = (payload: string): void => {
+        this.runImport(() => this.importService.convertText(payload)).catch(err => console.error('Clip import failed:', err));
+    };
 }
 
 interface TabButtonProps {

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -1,0 +1,246 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { CommandService } from '@theia/core/lib/common/command';
+import { nls } from '@theia/core/lib/common/nls';
+import * as React from '@theia/core/shared/react';
+import { AuthService, AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
+import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
+import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
+import { DraftSaver } from './draft-saver';
+
+export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
+
+export type ImportTab = 'url' | 'text' | 'images' | 'browser';
+
+@injectable()
+export class ImportWidget extends ReactWidget {
+
+    static readonly ID = IMPORT_WIDGET_ID;
+    static readonly LABEL = nls.localize('theia/cooklang-import/widgetLabel', 'Import Recipe');
+
+    @inject(RecipeImportService)
+    protected readonly importService: RecipeImportService;
+
+    @inject(DraftSaver)
+    protected readonly draftSaver: DraftSaver;
+
+    @inject(AuthService)
+    protected readonly authService: AuthService;
+
+    @inject(AuthContribution)
+    protected readonly authContribution: AuthContribution;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    protected activeTab: ImportTab = 'url';
+    protected authState: AuthState = { status: 'logged-out' };
+    protected busy = false;
+    protected errorMessage: string | undefined;
+    protected errorShowsSignIn = false;
+    protected successMessage: string | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = ImportWidget.ID;
+        this.title.label = ImportWidget.LABEL;
+        this.title.caption = ImportWidget.LABEL;
+        this.title.iconClass = 'codicon codicon-cloud-download';
+        this.title.closable = true;
+        this.addClass('cooklang-import-widget');
+        this.refreshAuthState();
+        this.toDispose.push(this.authContribution.onDidChangeAuth(() => this.refreshAuthState()));
+    }
+
+    protected refreshAuthState(): void {
+        this.authService.getAuthState().then(state => {
+            this.authState = state;
+            this.update();
+        });
+    }
+
+    protected get signedIn(): boolean {
+        return this.authState.status === 'logged-in';
+    }
+
+    protected signIn = (): void => {
+        this.commandService.executeCommand(CookmdLoginCommand.id);
+    };
+
+    protected selectTab(tab: ImportTab): void {
+        this.activeTab = tab;
+        this.errorMessage = undefined;
+        this.successMessage = undefined;
+        this.update();
+    }
+
+    // Shared conversion pipeline used by all tabs (Tasks 8-10 call this).
+    protected async runImport(convert: () => Promise<ConvertResult>): Promise<void> {
+        this.busy = true;
+        this.errorMessage = undefined;
+        this.successMessage = undefined;
+        this.update();
+        try {
+            const result = await convert();
+            if (result.error !== undefined) {
+                this.showError(result.error);
+                return;
+            }
+            const uri = await this.draftSaver.save(result);
+            this.successMessage = nls.localize('theia/cooklang-import/savedTo', 'Saved to {0}', `Drafts/${uri.path.base}`);
+        } catch (err) {
+            this.errorMessage = err instanceof Error ? err.message : String(err);
+            this.errorShowsSignIn = false;
+        } finally {
+            this.busy = false;
+            this.update();
+        }
+    }
+
+    protected showError(code: ImportErrorCode): void {
+        this.errorShowsSignIn = false;
+        switch (code) {
+            case 'rate-limited':
+                if (this.signedIn) {
+                    this.errorMessage = nls.localize('theia/cooklang-import/rateLimited', 'Import limit reached. Please try again later.');
+                } else {
+                    this.errorMessage = nls.localize('theia/cooklang-import/rateLimitedAnon', 'Import limit reached — sign in to increase your limits.');
+                    this.errorShowsSignIn = true;
+                }
+                break;
+            case 'unauthorized':
+                this.errorMessage = nls.localize('theia/cooklang-import/unauthorized', 'Please sign in to continue.');
+                this.errorShowsSignIn = true;
+                break;
+            case 'conversion-failed':
+                this.errorMessage = nls.localize('theia/cooklang-import/conversionFailed', 'Couldn’t extract a recipe from this source. Try another one.');
+                break;
+            default:
+                this.errorMessage = nls.localize('theia/cooklang-import/networkError', 'Connection problem. Please try again.');
+        }
+    }
+
+    protected render(): React.ReactNode {
+        return (
+            <div className='cooklang-import-content'>
+                {this.renderTabBar()}
+                {!this.signedIn && this.activeTab !== 'images' && this.renderLimitsBanner()}
+                {this.renderStatus()}
+                <div className='cooklang-import-tab-body'>
+                    {this.renderActiveTab()}
+                </div>
+            </div>
+        );
+    }
+
+    protected renderTabBar(): React.ReactNode {
+        const tabs: Array<{ id: ImportTab; label: string }> = [
+            { id: 'url', label: nls.localizeByDefault('URL') },
+            { id: 'text', label: nls.localizeByDefault('Text') },
+            { id: 'images', label: nls.localize('theia/cooklang-import/tabImages', 'Images') },
+            { id: 'browser', label: nls.localize('theia/cooklang-import/tabBrowser', 'Web Browser') },
+        ];
+        return (
+            <div className='cooklang-import-tabbar' role='tablist'>
+                {tabs.map(tab => (
+                    <TabButton key={tab.id} tab={tab.id} label={tab.label}
+                        active={this.activeTab === tab.id}
+                        onSelect={this.onTabSelected} />
+                ))}
+            </div>
+        );
+    }
+
+    protected onTabSelected = (tab: ImportTab): void => {
+        this.selectTab(tab);
+    };
+
+    protected renderLimitsBanner(): React.ReactNode {
+        return (
+            <div className='cooklang-import-banner'>
+                <span>{nls.localize('theia/cooklang-import/limitsBanner', 'Sign in for higher import limits.')}</span>
+                <a onClick={this.signIn}>{nls.localizeByDefault('Sign in')}</a>
+            </div>
+        );
+    }
+
+    protected renderStatus(): React.ReactNode {
+        if (this.busy) {
+            return <div className='cooklang-import-status'>
+                <i className='codicon codicon-loading codicon-modifier-spin' />
+                {nls.localize('theia/cooklang-import/importing', 'Importing…')}
+            </div>;
+        }
+        if (this.errorMessage) {
+            return <div className='cooklang-import-status cooklang-import-error'>
+                <span>{this.errorMessage}</span>
+                {this.errorShowsSignIn && !this.signedIn &&
+                    <button className='theia-button' onClick={this.signIn}>
+                        {nls.localizeByDefault('Sign in')}
+                    </button>}
+            </div>;
+        }
+        if (this.successMessage) {
+            return <div className='cooklang-import-status cooklang-import-success'>{this.successMessage}</div>;
+        }
+        return undefined;
+    }
+
+    protected renderActiveTab(): React.ReactNode {
+        // Tabs are implemented in Tasks 8-10; placeholders until then.
+        switch (this.activeTab) {
+            case 'url': return this.renderUrlTab();
+            case 'text': return this.renderTextTab();
+            case 'images': return this.renderImagesTab();
+            case 'browser': return this.renderBrowserTab();
+        }
+    }
+
+    protected renderUrlTab(): React.ReactNode {
+        return <div />;
+    }
+
+    protected renderTextTab(): React.ReactNode {
+        return <div />;
+    }
+
+    protected renderImagesTab(): React.ReactNode {
+        return <div />;
+    }
+
+    protected renderBrowserTab(): React.ReactNode {
+        return <div />;
+    }
+}
+
+interface TabButtonProps {
+    tab: ImportTab;
+    label: string;
+    active: boolean;
+    onSelect: (tab: ImportTab) => void;
+}
+
+class TabButton extends React.Component<TabButtonProps> {
+    override render(): React.ReactNode {
+        const { label, active } = this.props;
+        return <div role='tab' aria-selected={active}
+            className={'cooklang-import-tab' + (active ? ' cooklang-import-tab-active' : '')}
+            onClick={this.handleClick}>{label}</div>;
+    }
+    protected handleClick = (): void => {
+        this.props.onSelect(this.props.tab);
+    };
+}

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -16,11 +16,12 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { CommandService } from '@theia/core/lib/common/command';
 import { nls } from '@theia/core/lib/common/nls';
 import * as React from '@theia/core/shared/react';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { AuthService, AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
-import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
+import { ConvertResult, ImportErrorCode, MAX_IMPORT_IMAGES, RecipeImportService } from '../common/recipe-import-protocol';
 import { DraftSaver, DRAFTS_FOLDER_NAME } from './draft-saver';
-import { ImageEncoder, MAX_IMPORT_IMAGES } from './image-encoder';
+import { ImageEncoder } from './image-encoder';
 import { ImportBrowserTab } from './import-browser-tab';
 
 export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
@@ -41,6 +42,9 @@ export class ImportWidget extends ReactWidget {
 
     @inject(DraftSaver)
     protected readonly draftSaver: DraftSaver;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     @inject(AuthService)
     protected readonly authService: AuthService;
@@ -107,7 +111,7 @@ export class ImportWidget extends ReactWidget {
         this.update();
     }
 
-    // Shared conversion pipeline used by all tabs (Tasks 8-10 call this).
+    // Shared conversion pipeline used by all tabs.
     protected async runImport(convert: () => Promise<ConvertResult>): Promise<void> {
         if (this.busy) {
             return;
@@ -118,6 +122,13 @@ export class ImportWidget extends ReactWidget {
         this.successMessage = undefined;
         this.update();
         try {
+            // Checked here (before the rate-limited conversion API call) as well as in
+            // DraftSaver.save (backstop): failing fast avoids wasting a rate-limited request.
+            const roots = await this.workspaceService.roots;
+            if (roots.length === 0) {
+                this.errorMessage = nls.localize('theia/cooklang-import/noWorkspace', 'Open a folder before importing recipes.');
+                return;
+            }
             const result = await convert();
             if (result.error !== undefined) {
                 this.showError(result.error);

--- a/packages/cooklang-import/src/browser/import-widget.tsx
+++ b/packages/cooklang-import/src/browser/import-widget.tsx
@@ -19,7 +19,7 @@ import * as React from '@theia/core/shared/react';
 import { AuthService, AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
 import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
-import { DraftSaver } from './draft-saver';
+import { DraftSaver, DRAFTS_FOLDER_NAME } from './draft-saver';
 
 export const IMPORT_WIDGET_ID = 'cooklang-import-widget';
 
@@ -48,6 +48,8 @@ export class ImportWidget extends ReactWidget {
 
     protected activeTab: ImportTab = 'url';
     protected authState: AuthState = { status: 'logged-out' };
+    // Import status is deliberately widget-global (not per-tab) for v1:
+    // only one import runs at a time and switching tabs clears it.
     protected busy = false;
     protected errorMessage: string | undefined;
     protected errorShowsSignIn = false;
@@ -69,7 +71,7 @@ export class ImportWidget extends ReactWidget {
         this.authService.getAuthState().then(state => {
             this.authState = state;
             this.update();
-        });
+        }).catch(err => console.warn('Failed to refresh auth state:', err));
     }
 
     protected get signedIn(): boolean {
@@ -80,17 +82,29 @@ export class ImportWidget extends ReactWidget {
         this.commandService.executeCommand(CookmdLoginCommand.id);
     };
 
+    protected onSignInKeyDown = (event: React.KeyboardEvent): void => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.signIn();
+        }
+    };
+
     protected selectTab(tab: ImportTab): void {
         this.activeTab = tab;
         this.errorMessage = undefined;
+        this.errorShowsSignIn = false;
         this.successMessage = undefined;
         this.update();
     }
 
     // Shared conversion pipeline used by all tabs (Tasks 8-10 call this).
     protected async runImport(convert: () => Promise<ConvertResult>): Promise<void> {
+        if (this.busy) {
+            return;
+        }
         this.busy = true;
         this.errorMessage = undefined;
+        this.errorShowsSignIn = false;
         this.successMessage = undefined;
         this.update();
         try {
@@ -100,7 +114,7 @@ export class ImportWidget extends ReactWidget {
                 return;
             }
             const uri = await this.draftSaver.save(result);
-            this.successMessage = nls.localize('theia/cooklang-import/savedTo', 'Saved to {0}', `Drafts/${uri.path.base}`);
+            this.successMessage = nls.localize('theia/cooklang-import/savedTo', 'Saved to {0}', `${DRAFTS_FOLDER_NAME}/${uri.path.base}`);
         } catch (err) {
             this.errorMessage = err instanceof Error ? err.message : String(err);
             this.errorShowsSignIn = false;
@@ -128,6 +142,7 @@ export class ImportWidget extends ReactWidget {
             case 'conversion-failed':
                 this.errorMessage = nls.localize('theia/cooklang-import/conversionFailed', 'Couldn’t extract a recipe from this source. Try another one.');
                 break;
+            case 'network':
             default:
                 this.errorMessage = nls.localize('theia/cooklang-import/networkError', 'Connection problem. Please try again.');
         }
@@ -139,7 +154,7 @@ export class ImportWidget extends ReactWidget {
                 {this.renderTabBar()}
                 {!this.signedIn && this.activeTab !== 'images' && this.renderLimitsBanner()}
                 {this.renderStatus()}
-                <div className='cooklang-import-tab-body'>
+                <div className='cooklang-import-tab-body' role='tabpanel'>
                     {this.renderActiveTab()}
                 </div>
             </div>
@@ -172,7 +187,7 @@ export class ImportWidget extends ReactWidget {
         return (
             <div className='cooklang-import-banner'>
                 <span>{nls.localize('theia/cooklang-import/limitsBanner', 'Sign in for higher import limits.')}</span>
-                <a onClick={this.signIn}>{nls.localizeByDefault('Sign in')}</a>
+                <a role='button' tabIndex={0} onClick={this.signIn} onKeyDown={this.onSignInKeyDown}>{nls.localizeByDefault('Sign in')}</a>
             </div>
         );
     }
@@ -236,11 +251,17 @@ interface TabButtonProps {
 class TabButton extends React.Component<TabButtonProps> {
     override render(): React.ReactNode {
         const { label, active } = this.props;
-        return <div role='tab' aria-selected={active}
+        return <div role='tab' aria-selected={active} tabIndex={active ? 0 : -1}
             className={'cooklang-import-tab' + (active ? ' cooklang-import-tab-active' : '')}
-            onClick={this.handleClick}>{label}</div>;
+            onClick={this.handleClick} onKeyDown={this.handleKeyDown}>{label}</div>;
     }
     protected handleClick = (): void => {
         this.props.onSelect(this.props.tab);
+    };
+    protected handleKeyDown = (event: React.KeyboardEvent): void => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            this.props.onSelect(this.props.tab);
+        }
     };
 }

--- a/packages/cooklang-import/src/browser/recipe-payload.spec.ts
+++ b/packages/cooklang-import/src/browser/recipe-payload.spec.ts
@@ -1,0 +1,54 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { RecipePayload } from './recipe-payload';
+
+const RECIPE = { '@type': 'Recipe', name: 'Pancakes', recipeIngredient: ['2 eggs'] };
+
+describe('RecipePayload.extract', () => {
+
+    it('returns the serialized Recipe from a plain JSON-LD block', () => {
+        const result = RecipePayload.extract([JSON.stringify(RECIPE)], 'page text');
+        expect(JSON.parse(result)).to.deep.equal(RECIPE);
+    });
+
+    it('finds a Recipe inside a top-level array', () => {
+        const block = JSON.stringify([{ '@type': 'WebSite' }, RECIPE]);
+        expect(JSON.parse(RecipePayload.extract([block], ''))).to.deep.equal(RECIPE);
+    });
+
+    it('finds a Recipe inside an @graph', () => {
+        const block = JSON.stringify({ '@context': 'https://schema.org', '@graph': [{ '@type': 'WebPage' }, RECIPE] });
+        expect(JSON.parse(RecipePayload.extract([block], ''))).to.deep.equal(RECIPE);
+    });
+
+    it('matches @type arrays containing Recipe', () => {
+        const recipe = { '@type': ['Thing', 'Recipe'], name: 'Soup' };
+        expect(JSON.parse(RecipePayload.extract([JSON.stringify(recipe)], ''))).to.deep.equal(recipe);
+    });
+
+    it('skips malformed blocks and still finds a Recipe in a later block', () => {
+        const result = RecipePayload.extract(['{not json', JSON.stringify(RECIPE)], '');
+        expect(JSON.parse(result)).to.deep.equal(RECIPE);
+    });
+
+    it('falls back to trimmed page text when no Recipe is present', () => {
+        const block = JSON.stringify({ '@type': 'NewsArticle' });
+        expect(RecipePayload.extract([block], '  Grandma’s stew: brown the beef…  ')).to.equal('Grandma’s stew: brown the beef…');
+    });
+
+    it('falls back to page text when there are no blocks at all', () => {
+        expect(RecipePayload.extract([], 'just text')).to.equal('just text');
+    });
+});

--- a/packages/cooklang-import/src/browser/recipe-payload.ts
+++ b/packages/cooklang-import/src/browser/recipe-payload.ts
@@ -1,0 +1,58 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * Chooses the payload sent to /api/cookify/text when clipping a page:
+ * the schema.org Recipe from JSON-LD when present, otherwise the page text.
+ */
+export namespace RecipePayload {
+
+    export function extract(jsonLdBlocks: string[], pageText: string): string {
+        for (const block of jsonLdBlocks) {
+            let parsed: unknown;
+            try {
+                parsed = JSON.parse(block);
+            } catch {
+                continue;
+            }
+            const recipe = findRecipe(parsed);
+            if (recipe) {
+                return JSON.stringify(recipe);
+            }
+        }
+        return pageText.trim();
+    }
+
+    function findRecipe(node: unknown): object | undefined {
+        if (Array.isArray(node)) {
+            for (const item of node) {
+                const found = findRecipe(item);
+                if (found) {
+                    return found;
+                }
+            }
+            return undefined;
+        }
+        if (node && typeof node === 'object') {
+            const type = (node as { '@type'?: unknown })['@type'];
+            if (type === 'Recipe' || (Array.isArray(type) && type.includes('Recipe'))) {
+                return node;
+            }
+            const graph = (node as { '@graph'?: unknown })['@graph'];
+            if (Array.isArray(graph)) {
+                return findRecipe(graph);
+            }
+        }
+        return undefined;
+    }
+}

--- a/packages/cooklang-import/src/browser/style/index.css
+++ b/packages/cooklang-import/src/browser/style/index.css
@@ -1,0 +1,136 @@
+.cooklang-import-widget {
+    display: flex;
+    flex-direction: column;
+}
+
+.cooklang-import-content {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: var(--theia-ui-padding);
+}
+
+.cooklang-import-tabbar {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--theia-panel-border);
+    margin-bottom: var(--theia-ui-padding);
+}
+
+.cooklang-import-tab {
+    padding: 4px 12px;
+    cursor: pointer;
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-tab-active {
+    color: var(--theia-foreground);
+    border-bottom: 2px solid var(--theia-focusBorder);
+}
+
+.cooklang-import-banner {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 8px;
+    margin-bottom: var(--theia-ui-padding);
+    background-color: var(--theia-editorWidget-background);
+    border: 1px solid var(--theia-panel-border);
+    border-radius: 3px;
+}
+
+.cooklang-import-banner a {
+    cursor: pointer;
+    color: var(--theia-textLink-foreground);
+}
+
+.cooklang-import-status {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 0;
+}
+
+.cooklang-import-error {
+    color: var(--theia-errorForeground);
+}
+
+.cooklang-import-success {
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-tab-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.cooklang-import-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--theia-ui-padding);
+    max-width: 640px;
+}
+
+.cooklang-import-form textarea {
+    min-height: 200px;
+    resize: vertical;
+}
+
+.cooklang-import-dropzone {
+    border: 2px dashed var(--theia-panel-border);
+    border-radius: 4px;
+    padding: 32px;
+    text-align: center;
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-dropzone.cooklang-import-dropzone-active {
+    border-color: var(--theia-focusBorder);
+}
+
+.cooklang-import-thumbs {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.cooklang-import-thumbs img {
+    max-width: 96px;
+    max-height: 96px;
+    object-fit: cover;
+    border-radius: 3px;
+}
+
+.cooklang-import-signin-gate {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--theia-ui-padding);
+    padding: 48px 16px;
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-browser {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: 4px;
+}
+
+.cooklang-import-browser-toolbar {
+    display: flex;
+    gap: 4px;
+    align-items: center;
+}
+
+.cooklang-import-browser-toolbar input {
+    flex: 1;
+}
+
+.cooklang-import-browser webview {
+    flex: 1;
+    border: 1px solid var(--theia-panel-border);
+}

--- a/packages/cooklang-import/src/browser/style/index.css
+++ b/packages/cooklang-import/src/browser/style/index.css
@@ -103,6 +103,28 @@
     border-radius: 3px;
 }
 
+.cooklang-import-thumb {
+    position: relative;
+    display: inline-flex;
+}
+
+.cooklang-import-thumb-remove {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 18px;
+    height: 18px;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid var(--theia-panel-border);
+    background-color: var(--theia-editorWidget-background);
+    color: var(--theia-foreground);
+    cursor: pointer;
+}
+
 .cooklang-import-signin-gate {
     display: flex;
     flex-direction: column;

--- a/packages/cooklang-import/src/browser/style/index.css
+++ b/packages/cooklang-import/src/browser/style/index.css
@@ -95,6 +95,25 @@
     resize: vertical;
 }
 
+.cooklang-import-action-row {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    align-self: stretch;
+    min-height: 26px;
+}
+
+.cooklang-import-action-row .codicon-loading {
+    margin-right: 4px;
+}
+
+.cooklang-import-browser-status {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-height: 22px;
+}
+
 .cooklang-import-dropzone {
     border: 2px dashed var(--theia-panel-border);
     border-radius: 4px;

--- a/packages/cooklang-import/src/browser/style/index.css
+++ b/packages/cooklang-import/src/browser/style/index.css
@@ -126,6 +126,10 @@
     border-color: var(--theia-focusBorder);
 }
 
+.cooklang-import-dropzone input[type='file'] {
+    margin-left: 8px;
+}
+
 .cooklang-import-thumbs {
     display: flex;
     gap: 8px;

--- a/packages/cooklang-import/src/browser/style/index.css
+++ b/packages/cooklang-import/src/browser/style/index.css
@@ -7,14 +7,14 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    padding: var(--theia-ui-padding);
+    padding: calc(var(--theia-ui-padding) * 3);
 }
 
 .cooklang-import-tabbar {
     display: flex;
-    gap: 4px;
+    gap: 8px;
     border-bottom: 1px solid var(--theia-panel-border);
-    margin-bottom: var(--theia-ui-padding);
+    margin-bottom: calc(var(--theia-ui-padding) * 3);
 }
 
 .cooklang-import-tab {
@@ -69,8 +69,25 @@
 .cooklang-import-form {
     display: flex;
     flex-direction: column;
-    gap: var(--theia-ui-padding);
+    align-items: flex-start;
+    gap: calc(var(--theia-ui-padding) * 2);
     max-width: 640px;
+}
+
+.cooklang-import-form label {
+    color: var(--theia-descriptionForeground);
+}
+
+.cooklang-import-form input,
+.cooklang-import-form textarea,
+.cooklang-import-form .cooklang-import-dropzone,
+.cooklang-import-form .cooklang-import-thumbs {
+    align-self: stretch;
+}
+
+.cooklang-import-form button.theia-button {
+    min-width: 100px;
+    margin-left: 0;
 }
 
 .cooklang-import-form textarea {

--- a/packages/cooklang-import/src/browser/style/index.css
+++ b/packages/cooklang-import/src/browser/style/index.css
@@ -156,3 +156,12 @@
     flex: 1;
     border: 1px solid var(--theia-panel-border);
 }
+
+.cooklang-import-browser-hint {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 16px;
+    color: var(--theia-descriptionForeground);
+}

--- a/packages/cooklang-import/src/common/recipe-import-protocol.ts
+++ b/packages/cooklang-import/src/common/recipe-import-protocol.ts
@@ -34,6 +34,9 @@ export interface ConvertFailure {
 
 export type ConvertResult = ConvertSuccess | ConvertFailure;
 
+/** Maximum number of images accepted by a single `convertImages` call. */
+export const MAX_IMPORT_IMAGES = 5;
+
 /**
  * Converts recipes to Cooklang via the cook.md cookify REST API.
  * Remote service: interface + symbol (used from both frontend and backend).
@@ -41,6 +44,6 @@ export type ConvertResult = ConvertSuccess | ConvertFailure;
 export interface RecipeImportService {
     convertUrl(url: string): Promise<ConvertResult>;
     convertText(text: string): Promise<ConvertResult>;
-    /** Base64-encoded JPEGs, max 5. Requires a signed-in user. */
+    /** Base64-encoded JPEGs, max {@link MAX_IMPORT_IMAGES}. Requires a signed-in user. */
     convertImages(imagesBase64: string[]): Promise<ConvertResult>;
 }

--- a/packages/cooklang-import/src/common/recipe-import-protocol.ts
+++ b/packages/cooklang-import/src/common/recipe-import-protocol.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+export const RecipeImportServicePath = '/services/cooklang-import';
+export const RecipeImportService = Symbol('RecipeImportService');
+
+export type ImportErrorCode = 'unauthorized' | 'rate-limited' | 'conversion-failed' | 'network';
+
+// Conversion failures are returned as a result union rather than thrown: Theia's RPC proxy
+// does not preserve custom fields on thrown Errors, so a typed `error` code in the return
+// value is the reliable way to get the failure kind across the wire.
+
+export interface ConvertSuccess {
+    cooklang: string;
+    name?: string;
+    error?: undefined;
+}
+
+export interface ConvertFailure {
+    error: ImportErrorCode;
+    cooklang?: undefined;
+    name?: undefined;
+}
+
+export type ConvertResult = ConvertSuccess | ConvertFailure;
+
+/**
+ * Converts recipes to Cooklang via the cook.md cookify REST API.
+ * Remote service: interface + symbol (used from both frontend and backend).
+ */
+export interface RecipeImportService {
+    convertUrl(url: string): Promise<ConvertResult>;
+    convertText(text: string): Promise<ConvertResult>;
+    /** Base64-encoded JPEGs, max 5. Requires a signed-in user. */
+    convertImages(imagesBase64: string[]): Promise<ConvertResult>;
+}

--- a/packages/cooklang-import/src/node/cookify-api-client.spec.ts
+++ b/packages/cooklang-import/src/node/cookify-api-client.spec.ts
@@ -82,6 +82,20 @@ describe('CookifyApiClient', () => {
         expect(JSON.parse(client.requests[0].body)).to.deep.equal({ images: ['aaa', 'bbb'] });
     });
 
+    it('rejects convertImages locally when more than 5 images are given', async () => {
+        const client = createClient('jwt-token');
+        const result = await client.convertImages(['1', '2', '3', '4', '5', '6']);
+        expect(result.error).to.equal('conversion-failed');
+        expect(client.requests).to.have.length(0);
+    });
+
+    it('rejects convertImages locally when the image list is empty', async () => {
+        const client = createClient('jwt-token');
+        const result = await client.convertImages([]);
+        expect(result.error).to.equal('conversion-failed');
+        expect(client.requests).to.have.length(0);
+    });
+
     const statusCases: Array<[number, string]> = [
         [401, 'unauthorized'],
         [422, 'conversion-failed'],

--- a/packages/cooklang-import/src/node/cookify-api-client.spec.ts
+++ b/packages/cooklang-import/src/node/cookify-api-client.spec.ts
@@ -1,0 +1,113 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { CookifyApiClient, HttpResponse } from './cookify-api-client';
+import { ConvertResult } from '../common/recipe-import-protocol';
+
+class TestClient extends CookifyApiClient {
+    requests: Array<{ url: string; body: string; headers: Record<string, string> }> = [];
+    nextResponse: HttpResponse = { status: 200, body: '{"cooklang": "recipe"}' };
+    failWith: Error | undefined;
+
+    protected override httpPost(url: URL, body: string, headers: Record<string, string>): Promise<HttpResponse> {
+        this.requests.push({ url: url.toString(), body, headers });
+        return this.failWith ? Promise.reject(this.failWith) : Promise.resolve(this.nextResponse);
+    }
+}
+
+function createClient(token: string | undefined): TestClient {
+    const client = new TestClient();
+    // Property injection: assign the injected services directly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (client as any).authService = { getToken: () => Promise.resolve(token) };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (client as any).applicationServer = { getApplicationInfo: () => Promise.resolve({ name: 'cook-editor', version: '0.1.0' }) };
+    return client;
+}
+
+describe('CookifyApiClient', () => {
+
+    it('POSTs the url and returns cooklang + name on 200', async () => {
+        const client = createClient(undefined);
+        client.nextResponse = { status: 200, body: '{"cooklang": "---\\ntitle: Pancakes\\n---\\n", "name": "Pancakes"}' };
+        const result = await client.convertUrl('https://example.com/pancakes');
+        expect(result.cooklang).to.contain('Pancakes');
+        expect(result.name).to.equal('Pancakes');
+        expect(client.requests[0].url).to.equal('https://cook.md/api/cookify/url');
+        expect(JSON.parse(client.requests[0].body)).to.deep.equal({ url: 'https://example.com/pancakes' });
+    });
+
+    it('omits the Authorization header when logged out and adds it when a token exists', async () => {
+        const anonymous = createClient(undefined);
+        await anonymous.convertText('some recipe text');
+        expect(anonymous.requests[0].headers).to.not.have.property('Authorization');
+
+        const signedIn = createClient('jwt-token');
+        await signedIn.convertText('some recipe text');
+        expect(signedIn.requests[0].headers.Authorization).to.equal('Bearer jwt-token');
+    });
+
+    it('sends JSON and client-version headers', async () => {
+        const client = createClient(undefined);
+        await client.convertText('text');
+        const headers = client.requests[0].headers;
+        expect(headers['Content-Type']).to.equal('application/json');
+        expect(headers.Accept).to.equal('application/json');
+        expect(headers['X-Client-Version']).to.equal('editor/0.1.0');
+    });
+
+    it('rejects convertImages locally when no token is present', async () => {
+        const client = createClient(undefined);
+        const result = await client.convertImages(['base64data']);
+        expect(result.error).to.equal('unauthorized');
+        expect(client.requests).to.have.length(0);
+    });
+
+    it('sends images with the bearer token when signed in', async () => {
+        const client = createClient('jwt-token');
+        const result = await client.convertImages(['aaa', 'bbb']);
+        expect(result.error).to.equal(undefined);
+        expect(client.requests[0].url).to.equal('https://cook.md/api/cookify/images');
+        expect(JSON.parse(client.requests[0].body)).to.deep.equal({ images: ['aaa', 'bbb'] });
+    });
+
+    const statusCases: Array<[number, string]> = [
+        [401, 'unauthorized'],
+        [422, 'conversion-failed'],
+        [429, 'rate-limited'],
+        [500, 'network'],
+    ];
+    for (const [status, code] of statusCases) {
+        it(`maps HTTP ${status} to '${code}'`, async () => {
+            const client = createClient(undefined);
+            client.nextResponse = { status, body: '' };
+            const result: ConvertResult = await client.convertUrl('https://example.com');
+            expect(result.error).to.equal(code);
+        });
+    }
+
+    it('maps transport failures to network error', async () => {
+        const client = createClient(undefined);
+        client.failWith = new Error('ECONNREFUSED');
+        const result = await client.convertUrl('https://example.com');
+        expect(result.error).to.equal('network');
+    });
+
+    it('maps a 200 with unparseable body to conversion-failed', async () => {
+        const client = createClient(undefined);
+        client.nextResponse = { status: 200, body: 'not json' };
+        const result = await client.convertUrl('https://example.com');
+        expect(result.error).to.equal('conversion-failed');
+    });
+});

--- a/packages/cooklang-import/src/node/cookify-api-client.ts
+++ b/packages/cooklang-import/src/node/cookify-api-client.ts
@@ -1,0 +1,120 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import * as http from 'http';
+import * as https from 'https';
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
+import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
+import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
+
+export interface HttpResponse {
+    status: number;
+    body: string;
+}
+
+/**
+ * REST client for the cook.md cookify API. Mirrors the contract used by the
+ * iOS app: POST /api/cookify/{url,text,images}; Bearer token optional for
+ * url/text, required for images; 401/422/429 map to typed error codes.
+ */
+@injectable()
+export class CookifyApiClient implements RecipeImportService {
+
+    @inject(AuthService)
+    protected readonly authService: AuthService;
+
+    @inject(ApplicationServer)
+    protected readonly applicationServer: ApplicationServer;
+
+    protected get baseUrl(): string {
+        return process.env.WEB_BASE_URL || 'https://cook.md';
+    }
+
+    convertUrl(url: string): Promise<ConvertResult> {
+        return this.post('/api/cookify/url', { url }, false);
+    }
+
+    convertText(text: string): Promise<ConvertResult> {
+        return this.post('/api/cookify/text', { text }, false);
+    }
+
+    convertImages(imagesBase64: string[]): Promise<ConvertResult> {
+        return this.post('/api/cookify/images', { images: imagesBase64 }, true);
+    }
+
+    protected async post(path: string, payload: object, requireAuth: boolean): Promise<ConvertResult> {
+        const token = await this.authService.getToken();
+        if (requireAuth && !token) {
+            return { error: 'unauthorized' };
+        }
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'X-Client-Version': `editor/${await this.clientVersion()}`,
+        };
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+        let response: HttpResponse;
+        try {
+            response = await this.httpPost(new URL(path, this.baseUrl), JSON.stringify(payload), headers);
+        } catch (err) {
+            console.warn('cookify request failed:', err instanceof Error ? err.message : String(err));
+            return { error: 'network' };
+        }
+        if (response.status >= 200 && response.status < 300) {
+            try {
+                const data = JSON.parse(response.body);
+                if (typeof data.cooklang !== 'string') {
+                    return { error: 'conversion-failed' };
+                }
+                return { cooklang: data.cooklang, name: typeof data.name === 'string' ? data.name : undefined };
+            } catch {
+                return { error: 'conversion-failed' };
+            }
+        }
+        return { error: this.errorForStatus(response.status) };
+    }
+
+    protected errorForStatus(status: number): ImportErrorCode {
+        switch (status) {
+            case 401: return 'unauthorized';
+            case 422: return 'conversion-failed';
+            case 429: return 'rate-limited';
+            default: return 'network';
+        }
+    }
+
+    protected async clientVersion(): Promise<string> {
+        try {
+            const info = await this.applicationServer.getApplicationInfo();
+            return info?.version ?? 'dev';
+        } catch {
+            return 'dev';
+        }
+    }
+
+    protected httpPost(url: URL, body: string, headers: Record<string, string>): Promise<HttpResponse> {
+        const lib = url.protocol === 'https:' ? https : http;
+        return new Promise((resolve, reject) => {
+            const req = lib.request(url, { method: 'POST', headers }, (res: http.IncomingMessage) => {
+                let data = '';
+                res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+                res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+            });
+            req.on('error', reject);
+            req.end(body);
+        });
+    }
+}

--- a/packages/cooklang-import/src/node/cookify-api-client.ts
+++ b/packages/cooklang-import/src/node/cookify-api-client.ts
@@ -16,7 +16,7 @@ import * as https from 'https';
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
-import { ConvertResult, ImportErrorCode, RecipeImportService } from '../common/recipe-import-protocol';
+import { ConvertResult, ImportErrorCode, MAX_IMPORT_IMAGES, RecipeImportService } from '../common/recipe-import-protocol';
 
 export interface HttpResponse {
     status: number;
@@ -24,7 +24,6 @@ export interface HttpResponse {
 }
 
 const REQUEST_TIMEOUT_MS = 60_000;
-const MAX_IMAGES = 5;
 
 /**
  * REST client for the cook.md cookify API. Mirrors the contract used by the
@@ -53,7 +52,7 @@ export class CookifyApiClient implements RecipeImportService {
     }
 
     convertImages(imagesBase64: string[]): Promise<ConvertResult> {
-        if (imagesBase64.length === 0 || imagesBase64.length > MAX_IMAGES) {
+        if (imagesBase64.length === 0 || imagesBase64.length > MAX_IMPORT_IMAGES) {
             return Promise.resolve({ error: 'conversion-failed' });
         }
         return this.post('/api/cookify/images', { images: imagesBase64 }, true);

--- a/packages/cooklang-import/src/node/cookify-api-client.ts
+++ b/packages/cooklang-import/src/node/cookify-api-client.ts
@@ -23,6 +23,9 @@ export interface HttpResponse {
     body: string;
 }
 
+const REQUEST_TIMEOUT_MS = 60_000;
+const MAX_IMAGES = 5;
+
 /**
  * REST client for the cook.md cookify API. Mirrors the contract used by the
  * iOS app: POST /api/cookify/{url,text,images}; Bearer token optional for
@@ -50,6 +53,9 @@ export class CookifyApiClient implements RecipeImportService {
     }
 
     convertImages(imagesBase64: string[]): Promise<ConvertResult> {
+        if (imagesBase64.length === 0 || imagesBase64.length > MAX_IMAGES) {
+            return Promise.resolve({ error: 'conversion-failed' });
+        }
         return this.post('/api/cookify/images', { images: imagesBase64 }, true);
     }
 
@@ -110,9 +116,11 @@ export class CookifyApiClient implements RecipeImportService {
         return new Promise((resolve, reject) => {
             const req = lib.request(url, { method: 'POST', headers }, (res: http.IncomingMessage) => {
                 let data = '';
-                res.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+                res.setEncoding('utf8');
+                res.on('data', (chunk: string) => { data += chunk; });
                 res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
             });
+            req.setTimeout(REQUEST_TIMEOUT_MS, () => req.destroy(new Error('cookify request timed out')));
             req.on('error', reject);
             req.end(body);
         });

--- a/packages/cooklang-import/src/node/cooklang-import-backend-module.ts
+++ b/packages/cooklang-import/src/node/cooklang-import-backend-module.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+
+export default new ContainerModule(bind => {
+});

--- a/packages/cooklang-import/src/node/cooklang-import-backend-module.ts
+++ b/packages/cooklang-import/src/node/cooklang-import-backend-module.ts
@@ -12,6 +12,16 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common/messaging';
+import { RecipeImportService, RecipeImportServicePath } from '../common/recipe-import-protocol';
+import { CookifyApiClient } from './cookify-api-client';
 
 export default new ContainerModule(bind => {
+    bind(CookifyApiClient).toSelf().inSingletonScope();
+    bind(RecipeImportService).toService(CookifyApiClient);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(RecipeImportServicePath, () =>
+            ctx.container.get(RecipeImportService)
+        )
+    ).inSingletonScope();
 });

--- a/packages/cooklang-import/tsconfig.json
+++ b/packages/cooklang-import/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../cooklang-account"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../filesystem"
+    },
+    {
+      "path": "../workspace"
+    }
+  ]
+}

--- a/packages/cooklang-import/tsconfig.json
+++ b/packages/cooklang-import/tsconfig.json
@@ -19,6 +19,9 @@
       "path": "../filesystem"
     },
     {
+      "path": "../navigator"
+    },
+    {
       "path": "../workspace"
     }
   ]

--- a/packages/cooklang/tsconfig.json
+++ b/packages/cooklang/tsconfig.json
@@ -13,6 +13,9 @@
       "path": "../ai-core"
     },
     {
+      "path": "../cooklang-account"
+    },
+    {
       "path": "../core"
     },
     {


### PR DESCRIPTION
## Summary

Adds a recipe import feature: a main-area **Import Recipe** widget (File menu / command palette) that converts recipes to Cooklang via the cook.md cookify REST API and saves them to `Drafts/` in the workspace, opened in the editor. Spec: `docs/superpowers/specs/2026-07-24-recipe-import-design.md`, plan: `docs/superpowers/plans/2026-07-24-recipe-import.md`.

- **New package `@theia/cooklang-import`**: shared RPC protocol with a typed error union; node-side REST client (`POST /api/cookify/{url,text,images}`, Bearer token from `@theia/cooklang-account`, 401/422/429 → typed errors, UTF-8-safe body handling, 60s timeout); JSON-LD schema.org Recipe extraction; draft naming helpers (frontmatter title resolution/injection, CRLF handling, filename sanitization incl. Windows reserved names, collision dedup) — all unit-tested (42 specs).
- **Four import methods**: URL field (with client-side URL validation), pasted text, drag-and-drop images (≤5, canvas-downscaled to ≤2048px JPEG, sequential encoding, HEIC-friendly errors; sign-in required), and a Paprika-style **clipping browser** (`<webview>` in an isolated in-memory partition) that extracts JSON-LD or falls back to page text.
- **Auth/limits UX** (iOS-app parity): images tab shows a sign-in gate when logged out; anonymous users see a "Sign in for higher import limits" banner and a sign-in CTA on 429s.
- **Electron main hardening in `@theia/cooklang-branding`**: `webviewTag` enabled with a `will-attach-webview` guard (partition allowlist, preload stripping, no node integration, no nested webviews, initial-src validation) and a dedicated navigation/popup policy for the import webview (http/https only, popups load in place, no dialogs/openExternal).

**Phase 2** (recorded in the spec): local conversion via the `cooklang-import` Rust crate behind the same protocol for BYO-key/Ollama users.

## Test plan

- [x] `npx lerna run compile/lint --scope @theia/cooklang-import --scope @theia/cooklang-branding` clean
- [x] `npx lerna run test --scope @theia/cooklang-import` — 42 passing
- [x] `cd app && npm run bundle` succeeds (needs `NODE_OPTIONS=--max-old-space-size=8192`; default heap OOMs on this monorepo's webpack build — pre-existing)
- [ ] Manual E2E: URL/text import signed-out (draft created + opened, banner shown); images gate → sign in → drag-drop import; browser tab: type URL, **click links on the page** (exercises the will-navigate override), `target=_blank` stays in-webview, clip a JSON-LD site and a plain-text page; duplicate import → `-2.cook`; no-workspace message; 429 sign-in CTA if reachable