### PR TITLE
fix: re-initialize and retry Cookbot request on expired session

### DIFF
--- a/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
@@ -1,0 +1,164 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelStreamResponse, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core/lib/common';
+import { CookbotChatChunk, CookbotInitResult } from '../common/cookbot-protocol';
+import { CookbotLanguageModel } from './cookbot-language-model';
+
+// ── Test fakes ──────────────────────────────────────────────────────────
+
+/** gRPC UNAUTHENTICATED error as @grpc/grpc-js surfaces it on the stream. */
+function sessionExpiredError(): Error {
+    return Object.assign(
+        new Error('16 UNAUTHENTICATED: Invalid or expired session. Please call Initialize to start a new session.'),
+        { code: 16 }
+    );
+}
+
+async function* failingStream(error: Error, ...before: CookbotChatChunk[]): AsyncIterable<CookbotChatChunk> {
+    for (const chunk of before) {
+        yield chunk;
+    }
+    throw error;
+}
+
+async function* textStream(text: string): AsyncIterable<CookbotChatChunk> {
+    yield { type: 'content_block_start', index: 0, blockType: 'text', text };
+    yield { type: 'content_block_stop', index: 0 };
+    yield { type: 'message_stop' };
+}
+
+class FakeGrpcClient {
+    initializeCalls = 0;
+    sendMessageCalls = 0;
+    streams: Array<() => AsyncIterable<CookbotChatChunk>> = [];
+
+    async initialize(): Promise<CookbotInitResult> {
+        this.initializeCalls++;
+        return { success: true, sessionId: `session-${this.initializeCalls}`, serverVersion: 'test' };
+    }
+
+    sendMessage(): { stream: AsyncIterable<CookbotChatChunk> } {
+        const factory = this.streams[this.sendMessageCalls++];
+        if (!factory) {
+            throw new Error('Unexpected sendMessage call');
+        }
+        return { stream: factory() };
+    }
+}
+
+function createModel(grpcClient: FakeGrpcClient): CookbotLanguageModel {
+    const model = new CookbotLanguageModel();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (model as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (model as any).workspaceServer = { getMostRecentlyUsedWorkspace: async () => undefined };
+    return model;
+}
+
+function userRequest(): UserRequest {
+    return {
+        messages: [{ actor: 'user', type: 'text', text: 'hi' }],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+}
+
+async function collect(model: CookbotLanguageModel): Promise<LanguageModelStreamResponsePart[]> {
+    const response = await model.request(userRequest()) as LanguageModelStreamResponse;
+    const parts: LanguageModelStreamResponsePart[] = [];
+    for await (const part of response.stream) {
+        parts.push(part);
+    }
+    return parts;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('CookbotLanguageModel session expiry', () => {
+
+    it('re-initializes and retries once when the session has expired', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(sessionExpiredError()),
+            () => textStream('Hello'),
+        ];
+        const model = createModel(grpcClient);
+
+        const parts = await collect(model);
+
+        const texts = parts.filter(p => 'content' in p).map(p => (p as { content: string }).content);
+        expect(texts).to.deep.equal(['Hello']);
+        expect(grpcClient.sendMessageCalls).to.equal(2);
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+
+    it('surfaces the error when the retry also fails with an expired session', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(sessionExpiredError()),
+            () => failingStream(sessionExpiredError()),
+        ];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.contain('UNAUTHENTICATED');
+        expect(grpcClient.sendMessageCalls).to.equal(2);
+    });
+
+    it('does not retry when content was already streamed', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(
+                sessionExpiredError(),
+                { type: 'content_block_start', index: 0, blockType: 'text', text: 'partial' }
+            ),
+        ];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.contain('UNAUTHENTICATED');
+        expect(grpcClient.sendMessageCalls).to.equal(1);
+    });
+
+    it('surfaces non-session errors without retrying', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(Object.assign(new Error('14 UNAVAILABLE: connection refused'), { code: 14 })),
+        ];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.contain('UNAVAILABLE');
+        expect(grpcClient.sendMessageCalls).to.equal(1);
+        expect(grpcClient.initializeCalls).to.equal(1);
+    });
+});

--- a/packages/cooklang-ai/src/node/cookbot-language-model.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.ts
@@ -115,36 +115,56 @@ export class CookbotLanguageModel implements LanguageModel {
         }
         const token = cancellationToken ?? request.cancellationToken;
 
-        const { stream: grpcStream } = this.grpcClient.sendMessage(allMessages, tools, token);
-
         const that = this;
         const asyncIterator = {
             async *[Symbol.asyncIterator](): AsyncIterableIterator<LanguageModelStreamResponsePart> {
-                const toolCalls: ToolCallback[] = [];
-                let toolCall: ToolCallback | undefined;
-                const currentMessages: CookbotMessageParam[] = [];
+                let sessionRetryDone = false;
+                let toolCalls: ToolCallback[];
+                let currentMessages: CookbotMessageParam[];
                 let currentInputTokens = 0;
                 let currentOutputTokens = 0;
 
-                try {
-                    for await (const chunk of grpcStream) {
-                        const parts = that.processChunk(chunk, toolCalls, toolCall, currentMessages);
-                        for (const part of parts.yields) {
-                            yield part;
+                // The server invalidates idle sessions; the first request after a
+                // long idle then fails with UNAUTHENTICATED (code 16). Re-initialize
+                // and retry once, but only while nothing was streamed to the UI yet.
+                attempt: while (true) {
+                    toolCalls = [];
+                    let toolCall: ToolCallback | undefined;
+                    currentMessages = [];
+                    currentInputTokens = 0;
+                    currentOutputTokens = 0;
+                    let partsYielded = false;
+
+                    const { stream: grpcStream } = that.grpcClient.sendMessage(allMessages, tools, token);
+
+                    try {
+                        for await (const chunk of grpcStream) {
+                            const parts = that.processChunk(chunk, toolCalls, toolCall, currentMessages);
+                            for (const part of parts.yields) {
+                                partsYielded = true;
+                                yield part;
+                            }
+                            toolCall = parts.toolCall;
+                            if (parts.inputTokens !== undefined) {
+                                currentInputTokens = parts.inputTokens;
+                            }
+                            if (parts.outputTokens !== undefined) {
+                                currentOutputTokens = parts.outputTokens;
+                            }
                         }
-                        toolCall = parts.toolCall;
-                        if (parts.inputTokens !== undefined) {
-                            currentInputTokens = parts.inputTokens;
+                        break;
+                    } catch (error: unknown) {
+                        if (error instanceof Error && 'code' in error && (error as { code?: number }).code === 16) {
+                            that.initPromise = undefined;
+                            if (!sessionRetryDone && !partsYielded) {
+                                sessionRetryDone = true;
+                                console.info('[CookbotLM] Session expired, re-initializing and retrying');
+                                await that.ensureInitialized();
+                                continue attempt;
+                            }
                         }
-                        if (parts.outputTokens !== undefined) {
-                            currentOutputTokens = parts.outputTokens;
-                        }
+                        throw error;
                     }
-                } catch (error: unknown) {
-                    if (error instanceof Error && 'code' in error && (error as { code?: number }).code === 16) {
-                        that.initPromise = undefined;
-                    }
-                    throw error;
                 }
 
                 // Yield usage info


### PR DESCRIPTION
## Summary
- First Cookbot chat message after a long idle failed visibly with `16 UNAUTHENTICATED: Invalid or expired session. Please call Initialize to start a new session.` — only a manual "try again" recovered, because the error handler merely cleared the cached `initPromise` and rethrew.
- `CookbotLanguageModel.handleStreamingRequest` now runs the gRPC stream in a retry loop: on code 16 it clears the cached session, re-runs `Initialize`, and resends the same request transparently.
- The retry happens at most once and only if nothing was streamed to the UI yet, so mid-response failures still surface instead of silently duplicating output. Non-session errors (e.g. `14 UNAVAILABLE`) are never retried.

## Test Plan
- [x] New `cookbot-language-model.spec.ts` covers: successful retry after expiry, double-expiry surfacing the error, no retry after partial content, no retry for non-session error codes
- [x] `npx lerna run test --scope @theia/cooklang-ai` — 14 passing
- [x] `npx lerna run lint --scope @theia/cooklang-ai` — clean
- [ ] Manual: idle the packaged app past session TTL, send a chat message, confirm it succeeds without the UNAUTHENTICATED error