### PR TITLE
fix: surface Cookbot chat errors and auto-retry dropped connections

### DIFF
--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -48,6 +48,7 @@ import {
     ToolCallResult,
     ToolInvocationContext
 } from '../common';
+import { LanguageModelStreamState } from './language-model-stream-state';
 
 @injectable()
 export class LanguageModelDelegateClientImpl
@@ -80,13 +81,6 @@ export class LanguageModelDelegateClientImpl
     languageModelRemoved(id: string): void {
         this.receiver.languageModelRemoved(id);
     }
-}
-
-interface StreamState {
-    id: string;
-    tokens: (LanguageModelStreamResponsePart | undefined)[];
-    resolve?: (_: unknown) => void;
-    reject?: (_: unknown) => void;
 }
 
 @injectable()
@@ -245,16 +239,8 @@ export class FrontendLanguageModelRegistryImpl
                     return response;
                 }
                 if (isLanguageModelStreamResponseDelegate(response)) {
-                    if (!this.streams.has(response.streamId)) {
-                        const newStreamState = {
-                            id: response.streamId,
-                            tokens: [],
-                        };
-                        this.streams.set(response.streamId, newStreamState);
-                    }
-                    const streamState = this.streams.get(response.streamId)!;
                     return {
-                        stream: this.getIterable(streamState),
+                        stream: this.getIterable(this.getOrCreateStreamState(response.streamId)),
                     };
                 }
                 this.logger.error(
@@ -266,48 +252,31 @@ export class FrontendLanguageModelRegistryImpl
         };
     }
 
-    protected streams = new Map<string, StreamState>();
+    protected streams = new Map<string, LanguageModelStreamState>();
     protected requests = new Map<string, LanguageModelRequest>();
 
-    async *getIterable(
-        state: StreamState
-    ): AsyncIterable<LanguageModelStreamResponsePart> {
-        let current = -1;
-        while (true) {
-            if (current < state.tokens.length - 1) {
-                current++;
-                const token = state.tokens[current];
-                if (token === undefined) {
-                    // message is finished
-                    break;
-                }
-                if (token !== undefined) {
-                    yield token;
-                }
-            } else {
-                await new Promise((resolve, reject) => {
-                    state.resolve = resolve;
-                    state.reject = reject;
-                });
-            }
+    protected getOrCreateStreamState(id: string): LanguageModelStreamState {
+        let state = this.streams.get(id);
+        if (!state) {
+            state = new LanguageModelStreamState(id);
+            this.streams.set(id, state);
         }
-        this.streams.delete(state.id);
+        return state;
+    }
+
+    async *getIterable(
+        state: LanguageModelStreamState
+    ): AsyncIterable<LanguageModelStreamResponsePart> {
+        try {
+            yield* state.getIterable();
+        } finally {
+            this.streams.delete(state.id);
+        }
     }
 
     // called by backend via the "delegate client" with new tokens
     send(id: string, token: LanguageModelStreamResponsePart | undefined): void {
-        if (!this.streams.has(id)) {
-            const newStreamState = {
-                id,
-                tokens: [],
-            };
-            this.streams.set(id, newStreamState);
-        }
-        const streamState = this.streams.get(id)!;
-        streamState.tokens.push(token);
-        if (streamState.resolve) {
-            streamState.resolve(token);
-        }
+        this.getOrCreateStreamState(id).push(token);
     }
 
     // called by backend once tool is invoked
@@ -330,15 +299,7 @@ export class FrontendLanguageModelRegistryImpl
 
     // called by backend via the "delegate client" with the error to use for rejection
     error(id: string, error: Error): void {
-        if (!this.streams.has(id)) {
-            const newStreamState = {
-                id,
-                tokens: [],
-            };
-            this.streams.set(id, newStreamState);
-        }
-        const streamState = this.streams.get(id)!;
-        streamState.reject?.(error);
+        this.getOrCreateStreamState(id).reject(error);
     }
 
     override async selectLanguageModels(request: LanguageModelSelector): Promise<LanguageModel[] | undefined> {

--- a/packages/ai-core/src/browser/index.ts
+++ b/packages/ai-core/src/browser/index.ts
@@ -25,6 +25,7 @@ export * from '../common/ai-core-preferences';
 export * from './ai-settings-service';
 export * from './ai-view-contribution';
 export * from './frontend-language-model-registry';
+export * from './language-model-stream-state';
 export * from './frontend-language-model-alias-registry';
 export * from './frontend-variable-service';
 export * from './prompttemplate-contribution';

--- a/packages/ai-core/src/browser/language-model-stream-state.spec.ts
+++ b/packages/ai-core/src/browser/language-model-stream-state.spec.ts
@@ -1,0 +1,123 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelStreamResponsePart } from '../common';
+import { LanguageModelStreamState } from './language-model-stream-state';
+
+async function collect(state: LanguageModelStreamState): Promise<LanguageModelStreamResponsePart[]> {
+    const parts: LanguageModelStreamResponsePart[] = [];
+    for await (const part of state.getIterable()) {
+        parts.push(part);
+    }
+    return parts;
+}
+
+async function collectError(state: LanguageModelStreamState): Promise<{ parts: LanguageModelStreamResponsePart[], error?: Error }> {
+    const parts: LanguageModelStreamResponsePart[] = [];
+    try {
+        for await (const part of state.getIterable()) {
+            parts.push(part);
+        }
+    } catch (error) {
+        return { parts, error: error as Error };
+    }
+    return { parts };
+}
+
+describe('LanguageModelStreamState', () => {
+
+    it('yields tokens pushed before the consumer starts iterating', async () => {
+        const state = new LanguageModelStreamState('stream-1');
+        state.push({ content: 'Hello' });
+        state.push({ content: ' world' });
+        state.push(undefined);
+
+        expect(await collect(state)).to.deep.equal([{ content: 'Hello' }, { content: ' world' }]);
+    });
+
+    it('yields tokens pushed while the consumer is waiting', async () => {
+        const state = new LanguageModelStreamState('stream-2');
+        const collected = collect(state);
+
+        await Promise.resolve();
+        state.push({ content: 'Hello' });
+        await Promise.resolve();
+        state.push(undefined);
+
+        expect(await collected).to.deep.equal([{ content: 'Hello' }]);
+    });
+
+    // The backend reports a stream failure with `error(...)` and then always
+    // terminates the stream with `send(id, undefined)`. If the error is only
+    // delivered to a currently pending `await`, it is lost whenever the
+    // consumer is not suspended at that exact moment, and the terminator ends
+    // the stream cleanly - which the chat UI renders as a blank assistant turn.
+    it('throws an error reported before the consumer starts iterating', async () => {
+        const state = new LanguageModelStreamState('stream-3');
+        state.reject(new Error('backend exploded'));
+        state.push(undefined);
+
+        const { parts, error } = await collectError(state);
+
+        expect(parts).to.be.empty;
+        expect(error?.message).to.equal('backend exploded');
+    });
+
+    it('throws an error reported after tokens, once the buffered tokens are consumed', async () => {
+        const state = new LanguageModelStreamState('stream-4');
+        state.push({ content: 'partial' });
+        state.reject(new Error('backend exploded'));
+        state.push(undefined);
+
+        const { parts, error } = await collectError(state);
+
+        expect(parts).to.deep.equal([{ content: 'partial' }]);
+        expect(error?.message).to.equal('backend exploded');
+    });
+
+    it('throws an error reported while the consumer is waiting', async () => {
+        const state = new LanguageModelStreamState('stream-5');
+        const collected = collectError(state);
+
+        await Promise.resolve();
+        state.reject(new Error('backend exploded'));
+        state.push(undefined);
+
+        const { error } = await collected;
+        expect(error?.message).to.equal('backend exploded');
+    });
+
+    it('keeps the first error when several are reported', async () => {
+        const state = new LanguageModelStreamState('stream-6');
+        state.reject(new Error('first'));
+        state.reject(new Error('second'));
+        state.push(undefined);
+
+        const { error } = await collectError(state);
+        expect(error?.message).to.equal('first');
+    });
+
+    it('ends without error when the stream terminates normally', async () => {
+        const state = new LanguageModelStreamState('stream-7');
+        state.push({ content: 'done' });
+        state.push(undefined);
+
+        const { parts, error } = await collectError(state);
+        expect(parts).to.deep.equal([{ content: 'done' }]);
+        expect(error).to.be.undefined;
+    });
+});

--- a/packages/ai-core/src/browser/language-model-stream-state.ts
+++ b/packages/ai-core/src/browser/language-model-stream-state.ts
@@ -1,0 +1,86 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageModelStreamResponsePart } from '../common';
+
+/**
+ * Buffers the tokens the backend pushes for a single streamed language model
+ * response and hands them to a consumer as an async iterable.
+ *
+ * Tokens and failures are both recorded in the state rather than handed to a
+ * pending promise directly, because the backend delivers them over RPC at
+ * arbitrary points in time - possibly before the consumer starts iterating, or
+ * while it is busy processing an earlier token. A failure that is only passed
+ * to a currently pending `await` would be dropped in those cases, and since the
+ * backend always terminates a failed stream with an end-of-stream token, the
+ * stream would then end cleanly and the caller would see an empty response
+ * instead of the error.
+ */
+export class LanguageModelStreamState {
+
+    /** Buffered tokens; an `undefined` entry marks the end of the stream. */
+    protected readonly tokens: (LanguageModelStreamResponsePart | undefined)[] = [];
+    protected error: Error | undefined;
+    protected notify: (() => void) | undefined;
+
+    constructor(readonly id: string) { }
+
+    /**
+     * Append a token. `undefined` terminates the stream.
+     */
+    push(token: LanguageModelStreamResponsePart | undefined): void {
+        this.tokens.push(token);
+        this.wake();
+    }
+
+    /**
+     * Record a failure. It is thrown by the iterable after all tokens that were
+     * already buffered have been consumed. Only the first failure is kept.
+     */
+    reject(error: Error): void {
+        if (!this.error) {
+            this.error = error;
+        }
+        this.wake();
+    }
+
+    async *getIterable(): AsyncIterable<LanguageModelStreamResponsePart> {
+        while (true) {
+            if (this.tokens.length > 0) {
+                const token = this.tokens.shift();
+                if (token === undefined) {
+                    // End of stream: report a recorded failure rather than ending silently.
+                    if (this.error) {
+                        throw this.error;
+                    }
+                    return;
+                }
+                yield token;
+                continue;
+            }
+            if (this.error) {
+                throw this.error;
+            }
+            await new Promise<void>(resolve => { this.notify = resolve; });
+        }
+    }
+
+    protected wake(): void {
+        const notify = this.notify;
+        this.notify = undefined;
+        notify?.();
+    }
+}

--- a/packages/cooklang-ai/src/common/cookbot-error.ts
+++ b/packages/cooklang-ai/src/common/cookbot-error.ts
@@ -1,0 +1,132 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { nls } from '@theia/core/lib/common/nls';
+
+/**
+ * The subset of gRPC status codes the Cookbot client reacts to.
+ * Mirrors `grpc.status` from `@grpc/grpc-js`.
+ */
+export enum CookbotGrpcStatus {
+    PermissionDenied = 7,
+    ResourceExhausted = 8,
+    Unavailable = 14,
+    Unauthenticated = 16,
+}
+
+/**
+ * Classification of the errors the Cookbot backend can produce, and their
+ * translation into messages that make sense to the user.
+ *
+ * Only the Node side can classify a failure: gRPC status codes live on the
+ * error object and do not survive the RPC hop to the frontend, where only the
+ * message is preserved.
+ */
+export namespace CookbotError {
+
+    /** The gRPC status code of an error, if it carries one. */
+    export function statusCode(error: unknown): number | undefined {
+        if (error && typeof error === 'object' && 'code' in error) {
+            const code = (error as { code?: unknown }).code;
+            if (typeof code === 'number') {
+                return code;
+            }
+        }
+        return undefined;
+    }
+
+    function messageOf(error: unknown): string {
+        if (error instanceof Error) {
+            return error.message;
+        }
+        return typeof error === 'string' ? error : '';
+    }
+
+    /** The server invalidates idle sessions; the next call then fails with UNAUTHENTICATED. */
+    export function isSessionExpired(error: unknown): boolean {
+        return statusCode(error) === CookbotGrpcStatus.Unauthenticated;
+    }
+
+    /**
+     * A dropped connection rather than a real failure: idle gRPC connections
+     * get closed upstream and the next call fails with UNAVAILABLE (typically
+     * `read ECONNRESET`). Retrying on a fresh channel usually succeeds.
+     */
+    export function isTransientConnection(error: unknown): boolean {
+        return statusCode(error) === CookbotGrpcStatus.Unavailable;
+    }
+
+    /**
+     * The conversation no longer fits into the model's context window, so
+     * resending it cannot help - the user has to start a new chat.
+     */
+    export function isConversationTooLong(error: unknown): boolean {
+        const message = messageOf(error);
+        return /prompt is too long/i.test(message)
+            || /context[ _-]?(length|window)/i.test(message)
+            || /maximum context/i.test(message)
+            || /(conversation|input|history)\s+(is\s+|has\s+become\s+)?too long/i.test(message);
+    }
+
+    /**
+     * Translate a backend failure into an error the user can act on. Transport
+     * level failures are replaced entirely - a raw gRPC status line such as
+     * `14 UNAVAILABLE: read ECONNRESET` means nothing to the user. Errors that
+     * carry a message from the model or the server are kept as they are.
+     */
+    export function toUserFacing(error: unknown): Error {
+        if (isConversationTooLong(error)) {
+            return new Error(nls.localize(
+                'theia/cooklang-ai/error/conversationTooLong',
+                'This conversation has grown too long for Cookbot to continue. Please start a new chat.'
+            ));
+        }
+        switch (statusCode(error)) {
+            case CookbotGrpcStatus.Unavailable:
+                return new Error(nls.localize(
+                    'theia/cooklang-ai/error/connectionLost',
+                    'Lost the connection to Cookbot. Please check your internet connection and try again.'
+                ));
+            case CookbotGrpcStatus.Unauthenticated:
+                return new Error(nls.localize(
+                    'theia/cooklang-ai/error/sessionExpired',
+                    'Your Cookbot session has expired. Please try again, and sign in again if the problem persists.'
+                ));
+            case CookbotGrpcStatus.ResourceExhausted:
+                return new Error(nls.localize(
+                    'theia/cooklang-ai/error/rateLimited',
+                    'Cookbot is busy right now. Please wait a moment and try again.'
+                ));
+            case CookbotGrpcStatus.PermissionDenied:
+                return new Error(nls.localize(
+                    'theia/cooklang-ai/error/permissionDenied',
+                    'Cookbot declined the request. Please make sure you are signed in with an active subscription.'
+                ));
+        }
+        if (statusCode(error) !== undefined) {
+            return new Error(nls.localize(
+                'theia/cooklang-ai/error/requestFailed',
+                'Cookbot could not complete the request. Please try again.'
+            ));
+        }
+        return error instanceof Error ? error : new Error(messageOf(error) || 'Unknown Cookbot error');
+    }
+
+    /** Shown when a response stream completes without producing any content. */
+    export function emptyResponse(): Error {
+        return new Error(nls.localize(
+            'theia/cooklang-ai/error/emptyResponse',
+            'Cookbot returned an empty response. Please try again, or start a new chat if this keeps happening.'
+        ));
+    }
+}

--- a/packages/cooklang-ai/src/common/index.ts
+++ b/packages/cooklang-ai/src/common/index.ts
@@ -19,6 +19,10 @@ export {
     CookbotToolDefinition,
 } from './cookbot-protocol';
 export {
+    CookbotError,
+    CookbotGrpcStatus,
+} from './cookbot-error';
+export {
     CookbotServerToolsPath,
     CookbotServerToolsService,
     CookbotSearchResult,

--- a/packages/cooklang-ai/src/node/cookbot-grpc-client.ts
+++ b/packages/cooklang-ai/src/node/cookbot-grpc-client.ts
@@ -32,6 +32,7 @@ import {
     CookbotFetchResult,
     CookbotConvertResult,
 } from '../common/cookbot-server-tools-protocol';
+import { CookbotError } from '../common/cookbot-error';
 import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
 
 @injectable()
@@ -55,6 +56,21 @@ export class CookbotGrpcClient {
         }
     }
 
+    /**
+     * Drop the current channel and open a fresh one. Used after a transient
+     * connection failure: an idle connection that was closed upstream stays
+     * broken for the next call unless the channel is recreated.
+     */
+    reconnect(): void {
+        try {
+            this.service?.close?.();
+        } catch (error) {
+            console.warn('[Cookbot] Failed to close the gRPC channel, opening a new one anyway:', error);
+        }
+        this.service = undefined;
+        this.connect();
+    }
+
     protected connect(): void {
         const protoPath = path.resolve(__dirname, '../../proto/cookbot.proto');
         const packageDefinition = protoLoader.loadSync(protoPath, {
@@ -75,7 +91,28 @@ export class CookbotGrpcClient {
         this.service = new proto.cookbot.CookbotService(cleanAddress, credentials);
     }
 
+    /**
+     * Run a unary call, retrying it once on a fresh channel when the
+     * connection turns out to have been dropped upstream while idle.
+     */
+    protected async withReconnectRetry<T>(name: string, call: () => Promise<T>): Promise<T> {
+        try {
+            return await call();
+        } catch (error) {
+            if (!CookbotError.isTransientConnection(error)) {
+                throw error;
+            }
+            console.info(`[Cookbot] ${name} lost the connection, reconnecting and retrying once`);
+            this.reconnect();
+            return call();
+        }
+    }
+
     async initialize(recipesDir: string, customInstructions?: string): Promise<CookbotInitResult> {
+        return this.withReconnectRetry('Initialize', () => this.doInitialize(recipesDir, customInstructions));
+    }
+
+    protected async doInitialize(recipesDir: string, customInstructions?: string): Promise<CookbotInitResult> {
         this.ensureConnected();
         const token = await this.authService.getToken();
         return new Promise((resolve, reject) => {
@@ -153,6 +190,10 @@ export class CookbotGrpcClient {
     // ── Server-side tools ────────────────────────────────────────────────
 
     async searchWeb(query: string, maxResults?: number): Promise<CookbotSearchResult[]> {
+        return this.withReconnectRetry('SearchWeb', () => this.doSearchWeb(query, maxResults));
+    }
+
+    protected async doSearchWeb(query: string, maxResults?: number): Promise<CookbotSearchResult[]> {
         this.ensureConnected();
         return new Promise((resolve, reject) => {
             this.service.SearchWeb({
@@ -174,6 +215,10 @@ export class CookbotGrpcClient {
     }
 
     async fetchUrl(url: string): Promise<CookbotFetchResult> {
+        return this.withReconnectRetry('FetchUrl', () => this.doFetchUrl(url));
+    }
+
+    protected async doFetchUrl(url: string): Promise<CookbotFetchResult> {
         this.ensureConnected();
         return new Promise((resolve, reject) => {
             this.service.FetchUrl({
@@ -193,6 +238,10 @@ export class CookbotGrpcClient {
     }
 
     async convertUrlToCooklang(url: string): Promise<CookbotConvertResult> {
+        return this.withReconnectRetry('ConvertUrlToCooklang', () => this.doConvertUrlToCooklang(url));
+    }
+
+    protected async doConvertUrlToCooklang(url: string): Promise<CookbotConvertResult> {
         this.ensureConnected();
         return new Promise((resolve, reject) => {
             this.service.ConvertUrlToCooklang({
@@ -212,6 +261,10 @@ export class CookbotGrpcClient {
     }
 
     async convertTextToCooklang(name: string, text: string): Promise<CookbotConvertResult> {
+        return this.withReconnectRetry('ConvertTextToCooklang', () => this.doConvertTextToCooklang(name, text));
+    }
+
+    protected async doConvertTextToCooklang(name: string, text: string): Promise<CookbotConvertResult> {
         this.ensureConnected();
         return new Promise((resolve, reject) => {
             this.service.ConvertTextToCooklang({

--- a/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
@@ -26,6 +26,11 @@ function sessionExpiredError(): Error {
     );
 }
 
+/** gRPC UNAVAILABLE error as raised when an idle connection was dropped upstream. */
+function connectionResetError(): Error {
+    return Object.assign(new Error('14 UNAVAILABLE: read ECONNRESET'), { code: 14 });
+}
+
 async function* failingStream(error: Error, ...before: CookbotChatChunk[]): AsyncIterable<CookbotChatChunk> {
     for (const chunk of before) {
         yield chunk;
@@ -39,14 +44,31 @@ async function* textStream(text: string): AsyncIterable<CookbotChatChunk> {
     yield { type: 'message_stop' };
 }
 
+async function* emptyStream(): AsyncIterable<CookbotChatChunk> {
+    yield { type: 'message_start', id: 'msg-1', model: 'claude', inputTokens: 7 };
+    yield { type: 'message_delta', stopReason: 'end_turn', outputTokens: 0 };
+    yield { type: 'message_stop' };
+}
+
 class FakeGrpcClient {
     initializeCalls = 0;
+    reconnectCalls = 0;
     sendMessageCalls = 0;
     streams: Array<() => AsyncIterable<CookbotChatChunk>> = [];
+    initializeError: Error | undefined;
 
     async initialize(): Promise<CookbotInitResult> {
         this.initializeCalls++;
+        if (this.initializeError) {
+            const error = this.initializeError;
+            this.initializeError = undefined;
+            throw error;
+        }
         return { success: true, sessionId: `session-${this.initializeCalls}`, serverVersion: 'test' };
+    }
+
+    reconnect(): void {
+        this.reconnectCalls++;
     }
 
     sendMessage(): { stream: AsyncIterable<CookbotChatChunk> } {
@@ -118,7 +140,8 @@ describe('CookbotLanguageModel session expiry', () => {
             thrown = error as Error;
         }
 
-        expect(thrown?.message).to.contain('UNAUTHENTICATED');
+        expect(thrown?.message).to.not.contain('UNAUTHENTICATED');
+        expect(thrown?.message).to.contain('session has expired');
         expect(grpcClient.sendMessageCalls).to.equal(2);
     });
 
@@ -139,14 +162,14 @@ describe('CookbotLanguageModel session expiry', () => {
             thrown = error as Error;
         }
 
-        expect(thrown?.message).to.contain('UNAUTHENTICATED');
+        expect(thrown?.message).to.contain('session has expired');
         expect(grpcClient.sendMessageCalls).to.equal(1);
     });
 
-    it('surfaces non-session errors without retrying', async () => {
+    it('surfaces server errors without retrying', async () => {
         const grpcClient = new FakeGrpcClient();
         grpcClient.streams = [
-            () => failingStream(Object.assign(new Error('14 UNAVAILABLE: connection refused'), { code: 14 })),
+            () => failingStream(new Error('the recipe service exploded')),
         ];
         const model = createModel(grpcClient);
 
@@ -157,8 +180,156 @@ describe('CookbotLanguageModel session expiry', () => {
             thrown = error as Error;
         }
 
-        expect(thrown?.message).to.contain('UNAVAILABLE');
+        expect(thrown?.message).to.equal('the recipe service exploded');
         expect(grpcClient.sendMessageCalls).to.equal(1);
         expect(grpcClient.initializeCalls).to.equal(1);
+    });
+
+    it('does not cache a failed initialization', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.initializeError = new Error('backend down');
+        grpcClient.streams = [() => textStream('Hello')];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+        expect(thrown?.message).to.equal('backend down');
+
+        // A later request must be able to initialize again instead of
+        // re-awaiting the cached, rejected initialization promise.
+        const parts = await collect(model);
+        const texts = parts.filter(p => 'content' in p).map(p => (p as { content: string }).content);
+        expect(texts).to.deep.equal(['Hello']);
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+});
+
+describe('CookbotLanguageModel transient connection errors', () => {
+
+    it('reconnects and retries once on UNAVAILABLE', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(connectionResetError()),
+            () => textStream('Hello'),
+        ];
+        const model = createModel(grpcClient);
+
+        const parts = await collect(model);
+
+        const texts = parts.filter(p => 'content' in p).map(p => (p as { content: string }).content);
+        expect(texts).to.deep.equal(['Hello']);
+        expect(grpcClient.sendMessageCalls).to.equal(2);
+        expect(grpcClient.reconnectCalls).to.equal(1);
+    });
+
+    it('shows a friendly message instead of the raw gRPC status when the retry also fails', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(connectionResetError()),
+            () => failingStream(connectionResetError()),
+        ];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.not.contain('UNAVAILABLE');
+        expect(thrown?.message).to.not.contain('ECONNRESET');
+        expect(thrown?.message).to.contain('connection');
+        expect(grpcClient.sendMessageCalls).to.equal(2);
+    });
+
+    it('does not retry once content was streamed', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(
+                connectionResetError(),
+                { type: 'content_block_start', index: 0, blockType: 'text', text: 'partial' }
+            ),
+        ];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.contain('connection');
+        expect(grpcClient.sendMessageCalls).to.equal(1);
+    });
+
+    it('recovers when the reconnected channel reports an expired session', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(connectionResetError()),
+            () => failingStream(sessionExpiredError()),
+            () => textStream('Hello'),
+        ];
+        const model = createModel(grpcClient);
+
+        const parts = await collect(model);
+
+        const texts = parts.filter(p => 'content' in p).map(p => (p as { content: string }).content);
+        expect(texts).to.deep.equal(['Hello']);
+        expect(grpcClient.sendMessageCalls).to.equal(3);
+        expect(grpcClient.reconnectCalls).to.equal(1);
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+});
+
+describe('CookbotLanguageModel empty responses', () => {
+
+    it('reports an error when the stream produces no content', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [() => emptyStream()];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.contain('empty response');
+        expect(thrown?.message).to.contain('new chat');
+    });
+
+    it('does not report an error when the stream produced content', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [() => textStream('Hello')];
+        const model = createModel(grpcClient);
+
+        const parts = await collect(model);
+        const texts = parts.filter(p => 'content' in p).map(p => (p as { content: string }).content);
+        expect(texts).to.deep.equal(['Hello']);
+    });
+
+    it('suggests starting a new chat when the conversation no longer fits', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.streams = [
+            () => failingStream(new Error('prompt is too long: 210000 tokens > 200000 maximum')),
+        ];
+        const model = createModel(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await collect(model);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).to.contain('too long');
+        expect(thrown?.message).to.contain('new chat');
     });
 });

--- a/packages/cooklang-ai/src/node/cookbot-language-model.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.ts
@@ -23,6 +23,9 @@ import {
     ToolInvocationContext,
     createToolCallError,
     isToolCallContent,
+    isTextResponsePart,
+    isThinkingResponsePart,
+    isToolCallResponsePart,
 } from '@theia/ai-core/lib/common';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { FileUri } from '@theia/core/lib/common/file-uri';
@@ -36,6 +39,7 @@ import {
     CookbotContentPart,
     CookbotToolDefinition,
 } from '../common/cookbot-protocol';
+import { CookbotError } from '../common/cookbot-error';
 
 interface ToolCallback {
     readonly name: string;
@@ -66,7 +70,12 @@ export class CookbotLanguageModel implements LanguageModel {
 
     protected async ensureInitialized(): Promise<void> {
         if (!this.initPromise) {
-            this.initPromise = this.doInitialize();
+            // Drop a failed initialization so the next request can retry it,
+            // instead of awaiting the same rejected promise forever.
+            this.initPromise = this.doInitialize().catch(error => {
+                this.initPromise = undefined;
+                throw error;
+            });
         }
         await this.initPromise;
     }
@@ -119,14 +128,19 @@ export class CookbotLanguageModel implements LanguageModel {
         const asyncIterator = {
             async *[Symbol.asyncIterator](): AsyncIterableIterator<LanguageModelStreamResponsePart> {
                 let sessionRetryDone = false;
+                let connectionRetryDone = false;
+                let contentProduced = false;
                 let toolCalls: ToolCallback[];
                 let currentMessages: CookbotMessageParam[];
                 let currentInputTokens = 0;
                 let currentOutputTokens = 0;
 
-                // The server invalidates idle sessions; the first request after a
-                // long idle then fails with UNAUTHENTICATED (code 16). Re-initialize
-                // and retry once, but only while nothing was streamed to the UI yet.
+                // Two failures are recoverable without bothering the user, as long as
+                // nothing has been streamed to the UI yet:
+                //  - UNAUTHENTICATED (16): the server invalidates idle sessions, so the
+                //    first request after a long idle fails. Re-initialize and retry.
+                //  - UNAVAILABLE (14): an idle connection was dropped upstream (usually
+                //    `read ECONNRESET`). Reconnect and retry.
                 attempt: while (true) {
                     toolCalls = [];
                     let toolCall: ToolCallback | undefined;
@@ -142,6 +156,7 @@ export class CookbotLanguageModel implements LanguageModel {
                             const parts = that.processChunk(chunk, toolCalls, toolCall, currentMessages);
                             for (const part of parts.yields) {
                                 partsYielded = true;
+                                contentProduced = contentProduced || CookbotLanguageModel.isVisibleContent(part);
                                 yield part;
                             }
                             toolCall = parts.toolCall;
@@ -154,7 +169,7 @@ export class CookbotLanguageModel implements LanguageModel {
                         }
                         break;
                     } catch (error: unknown) {
-                        if (error instanceof Error && 'code' in error && (error as { code?: number }).code === 16) {
+                        if (CookbotError.isSessionExpired(error)) {
                             that.initPromise = undefined;
                             if (!sessionRetryDone && !partsYielded) {
                                 sessionRetryDone = true;
@@ -162,8 +177,14 @@ export class CookbotLanguageModel implements LanguageModel {
                                 await that.ensureInitialized();
                                 continue attempt;
                             }
+                        } else if (CookbotError.isTransientConnection(error) && !connectionRetryDone && !partsYielded) {
+                            connectionRetryDone = true;
+                            console.info('[CookbotLM] Connection lost, reconnecting and retrying');
+                            that.grpcClient.reconnect();
+                            continue attempt;
                         }
-                        throw error;
+                        console.error('[CookbotLM] Request failed:', error);
+                        throw CookbotError.toUserFacing(error);
                     }
                 }
 
@@ -234,13 +255,40 @@ export class CookbotLanguageModel implements LanguageModel {
                     );
 
                     for await (const nestedEvent of result.stream) {
+                        contentProduced = contentProduced || CookbotLanguageModel.isVisibleContent(nestedEvent);
                         yield nestedEvent;
                     }
+                }
+
+                // A stream that completes without a single content block is a
+                // failure the user cannot see otherwise - it renders as a blank
+                // assistant turn. Report it instead of yielding nothing.
+                if (!contentProduced && !token?.isCancellationRequested) {
+                    console.error('[CookbotLM] Stream completed without producing any content');
+                    throw CookbotError.emptyResponse();
                 }
             },
         };
 
         return { stream: asyncIterator };
+    }
+
+    /**
+     * Whether a stream part carries something the user can see. Token usage
+     * parts, empty text deltas and bare signature deltas do not count: a
+     * response consisting only of those renders as a blank assistant turn.
+     */
+    protected static isVisibleContent(part: LanguageModelStreamResponsePart): boolean {
+        if (isTextResponsePart(part)) {
+            return part.content.length > 0;
+        }
+        if (isThinkingResponsePart(part)) {
+            return part.thought.length > 0;
+        }
+        if (isToolCallResponsePart(part)) {
+            return part.tool_calls.length > 0;
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Fixes #81 and #80.

## #81 — blank assistant turn, no error shown

`FrontendLanguageModelRegistryImpl.error()` only did `streamState.reject?.(error)`. That reject handle exists **only while the consumer is suspended in `await`**, but the backend reports a failure and then *always* terminates the stream in its `finally`:

```ts
catch (e) { this.frontendDelegateClient.error(id, e); }
finally  { this.frontendDelegateClient.send(id, undefined); }
```

So whenever the error arrived while nothing was awaiting — the normal case when the backend fails fast, before the chat agent even starts iterating — the error was dropped and the `undefined` terminator ended the stream cleanly. Replaying the old code against that ordering:

```
RESULT: stream ended cleanly, parts = [] -> BLANK TURN, no error
```

The buffer is now `LanguageModelStreamState`, which records the failure and throws it from the iterable after the already-buffered tokens drain. The chat agent's existing `handleError` then adds an error part and sets `isError`, which is what makes the retry button appear.

On top of that, in the Cookbot language model:
- a stream that completes without a single visible content block is reported as an error instead of yielding nothing;
- errors meaning the conversation no longer fits the context window suggest starting a new chat;
- a rejected `initialize()` is no longer cached forever in `initPromise` — one failed init used to leave chat permanently dead.

## #80 — raw `14 UNAVAILABLE: read ECONNRESET`

- New `cookbot-error.ts` classifies gRPC failures. Classification has to happen in Node: only `message` survives the RPC hop to the frontend, `code` does not.
- The streaming loop reconnects and retries once on `UNAVAILABLE`, alongside the existing session-expiry retry. If the reconnected channel then reports an expired session, that retry still fires.
- `CookbotGrpcClient.reconnect()` drops and recreates the channel; every unary call (`Initialize`, `SearchWeb`, `FetchUrl`, both converters) goes through `withReconnectRetry`.
- If the retry fails the user sees *"Lost the connection to Cookbot. Please check your internet connection and try again."* — the raw status string only goes to the console.

## Verification

- `@theia/cooklang-ai`: 22 passing (10 new — transient retry, reconnect→session-expiry chaining, empty responses, friendly messages, uncached failed init).
- `language-model-stream-state.spec.ts`: 7 passing, including the exact ordering that produced the blank turn.
- `npx lerna run compile`: all 46 projects. Lint clean.

Note: `npx lerna run test --scope @theia/ai-core` fails on `generic-capabilities-variable-contribution.spec.js` with `The configuration is already set`. I confirmed by stashing that it fails identically on a clean tree — pre-existing, unrelated.