### PR TITLE
feat(telemetry): add commands to send a test error to Sentry

### DIFF
--- a/packages/cooklang-telemetry/src/browser/cooklang-telemetry-frontend-module.ts
+++ b/packages/cooklang-telemetry/src/browser/cooklang-telemetry-frontend-module.ts
@@ -13,9 +13,12 @@
 
 import * as Sentry from '@sentry/electron/renderer';
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { CommandContribution } from '@theia/core';
 import { FrontendApplicationContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { PreferenceContribution } from '@theia/core/lib/common/preferences/preference-schema';
 import { TelemetryConsentServer, telemetryConsentPath } from '../common/telemetry-consent-server';
+import { TelemetryDiagnostics, telemetryDiagnosticsPath } from '../common/telemetry-diagnostics';
+import { TelemetryDiagnosticsContribution } from './telemetry-diagnostics-contribution';
 import { TelemetryConsentWriter } from './telemetry-consent-writer';
 import { TelemetryPreferencesSchema } from './telemetry-preferences';
 
@@ -32,4 +35,10 @@ export default new ContainerModule(bind => {
     ).inSingletonScope();
     bind(TelemetryConsentWriter).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TelemetryConsentWriter);
+
+    bind(TelemetryDiagnostics).toDynamicValue(context =>
+        context.container.get(WebSocketConnectionProvider).createProxy<TelemetryDiagnostics>(telemetryDiagnosticsPath)
+    ).inSingletonScope();
+    bind(TelemetryDiagnosticsContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(TelemetryDiagnosticsContribution);
 });

--- a/packages/cooklang-telemetry/src/browser/telemetry-diagnostics-contribution.ts
+++ b/packages/cooklang-telemetry/src/browser/telemetry-diagnostics-contribution.ts
@@ -1,0 +1,74 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry, MessageService } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { TelemetryDiagnostics } from '../common/telemetry-diagnostics';
+
+export const SendTestErrorFromRendererCommand = Command.toLocalizedCommand(
+    {
+        id: 'cooklang.telemetry.sendTestError.renderer',
+        category: 'Cook Editor',
+        label: 'Send Test Error to Sentry (Window)'
+    },
+    'theia/cooklang-telemetry/sendTestError/renderer'
+);
+
+export const SendTestErrorFromBackendCommand = Command.toLocalizedCommand(
+    {
+        id: 'cooklang.telemetry.sendTestError.backend',
+        category: 'Cook Editor',
+        label: 'Send Test Error to Sentry (Backend)'
+    },
+    'theia/cooklang-telemetry/sendTestError/backend'
+);
+
+/**
+ * Deliberate errors for confirming that reporting works in a packaged build.
+ *
+ * These are the only practical way to verify the backend path: the obvious
+ * lever from outside the app - an unreachable server - produces an expected
+ * failure that is intentionally not reported.
+ */
+@injectable()
+export class TelemetryDiagnosticsContribution implements CommandContribution {
+
+    @inject(TelemetryDiagnostics)
+    protected readonly diagnostics: TelemetryDiagnostics;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(SendTestErrorFromRendererCommand, {
+            execute: () => this.throwInRenderer()
+        });
+        registry.registerCommand(SendTestErrorFromBackendCommand, {
+            execute: () => this.reportFromBackend()
+        });
+    }
+
+    protected throwInRenderer(): void {
+        this.messageService.info('Throwing a test error in this window. It should appear in Sentry shortly.');
+        // Deferred so it becomes an unhandled error rather than being caught by
+        // the command invocation, which is what the renderer SDK reports.
+        setTimeout(() => {
+            throw new Error('Cook Editor test error (renderer). Triggered deliberately to verify error reporting.');
+        });
+    }
+
+    protected async reportFromBackend(): Promise<void> {
+        await this.diagnostics.triggerTestError();
+        this.messageService.info('Reported a test error from the backend. It should appear in Sentry shortly.');
+    }
+}

--- a/packages/cooklang-telemetry/src/common/telemetry-diagnostics.ts
+++ b/packages/cooklang-telemetry/src/common/telemetry-diagnostics.ts
@@ -1,0 +1,32 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+export const telemetryDiagnosticsPath = '/services/cooklang-telemetry-diagnostics';
+
+/**
+ * Lets a maintainer confirm that error reporting actually reaches Sentry from a
+ * packaged build.
+ *
+ * Without this there is no way to trigger a reportable failure in the backend
+ * from outside the app: the obvious lever - pointing at an unreachable server -
+ * produces UNAVAILABLE, which is classified as an expected outcome and
+ * deliberately not reported.
+ */
+export const TelemetryDiagnostics = Symbol('TelemetryDiagnostics');
+export interface TelemetryDiagnostics {
+    /**
+     * Report a deliberate error from the backend process, through the same path
+     * real caught failures use.
+     */
+    triggerTestError(): Promise<void>;
+}

--- a/packages/cooklang-telemetry/src/node/cooklang-telemetry-backend-module.ts
+++ b/packages/cooklang-telemetry/src/node/cooklang-telemetry-backend-module.ts
@@ -17,10 +17,12 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common/messaging';
 import { DEV_OVERRIDE_ENV_VAR, buildOptions, shouldInitialize } from '../common/telemetry-options';
 import { TelemetryConsentServer, telemetryConsentPath } from '../common/telemetry-consent-server';
+import { TelemetryDiagnostics, telemetryDiagnosticsPath } from '../common/telemetry-diagnostics';
 import { ErrorReporter } from '../common/error-reporter';
 import { readErrorReportingConsent } from './telemetry-consent-file';
 import { TelemetryConsentServerImpl } from './telemetry-consent-server-impl';
 import { SentryErrorReporter } from './sentry-error-reporter';
+import { TelemetryDiagnosticsImpl } from './telemetry-diagnostics-impl';
 
 // Initialized at module load, before any container binding runs, so that an
 // error thrown during backend startup is still captured. The forked backend is
@@ -61,5 +63,11 @@ export default new ContainerModule(bind => {
     bind(TelemetryConsentServer).toService(TelemetryConsentServerImpl);
     bind(ConnectionHandler).toDynamicValue(context =>
         new RpcConnectionHandler(telemetryConsentPath, () => context.container.get(TelemetryConsentServer))
+    ).inSingletonScope();
+
+    bind(TelemetryDiagnosticsImpl).toSelf().inSingletonScope();
+    bind(TelemetryDiagnostics).toService(TelemetryDiagnosticsImpl);
+    bind(ConnectionHandler).toDynamicValue(context =>
+        new RpcConnectionHandler(telemetryDiagnosticsPath, () => context.container.get(TelemetryDiagnostics))
     ).inSingletonScope();
 });

--- a/packages/cooklang-telemetry/src/node/telemetry-diagnostics-impl.spec.ts
+++ b/packages/cooklang-telemetry/src/node/telemetry-diagnostics-impl.spec.ts
@@ -1,0 +1,56 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { TelemetryDiagnosticsImpl } from './telemetry-diagnostics-impl';
+
+class RecordingErrorReporter {
+    readonly reported: Array<{ error: unknown, tags?: Record<string, string> }> = [];
+    reportUnexpected(error: unknown, tags?: Record<string, string>): void {
+        this.reported.push({ error, tags });
+    }
+}
+
+function createDiagnostics(reporter: RecordingErrorReporter): TelemetryDiagnosticsImpl {
+    const diagnostics = new TelemetryDiagnosticsImpl();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (diagnostics as any).errorReporter = reporter;
+    return diagnostics;
+}
+
+describe('TelemetryDiagnosticsImpl', () => {
+
+    // The point of this command is to exercise the same path real caught
+    // failures take, so a broken reporting pipeline shows up here.
+    it('reports through the error reporter', async () => {
+        const reporter = new RecordingErrorReporter();
+        await createDiagnostics(reporter).triggerTestError();
+
+        expect(reporter.reported).to.have.lengthOf(1);
+        expect((reporter.reported[0].error as Error).message).to.contain('test error');
+    });
+
+    // So a maintainer can tell a verification event apart from a real one.
+    it('tags the event as a deliberate test', async () => {
+        const reporter = new RecordingErrorReporter();
+        await createDiagnostics(reporter).triggerTestError();
+
+        expect(reporter.reported[0].tags).to.include({ testError: 'true' });
+    });
+
+    it('does not throw, so the command reports success to the user', async () => {
+        const reporter = new RecordingErrorReporter();
+        await createDiagnostics(reporter).triggerTestError();
+        expect(reporter.reported).to.have.lengthOf(1);
+    });
+});

--- a/packages/cooklang-telemetry/src/node/telemetry-diagnostics-impl.ts
+++ b/packages/cooklang-telemetry/src/node/telemetry-diagnostics-impl.ts
@@ -1,0 +1,33 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ErrorReporter } from '../common/error-reporter';
+import { TelemetryDiagnostics } from '../common/telemetry-diagnostics';
+
+@injectable()
+export class TelemetryDiagnosticsImpl implements TelemetryDiagnostics {
+
+    @inject(ErrorReporter)
+    protected readonly errorReporter: ErrorReporter;
+
+    async triggerTestError(): Promise<void> {
+        // Reported rather than thrown, so this exercises the explicit-capture
+        // path that real caught failures use - the one that would otherwise
+        // never be verified.
+        this.errorReporter.reportUnexpected(
+            new Error('Cook Editor test error (backend). Triggered deliberately to verify error reporting.'),
+            { component: 'telemetry-diagnostics', testError: 'true' }
+        );
+    }
+}


### PR DESCRIPTION
Follow-up to #90.

## Why

When #90 merged, **backend and Electron-main reporting shipped unverified** — not because anyone skipped a step, but because there was no way to trigger a reportable failure from outside the app.

The obvious lever doesn't work:

```
COOKBOT_ADDRESS=127.0.0.1:1 '/Applications/Cook Editor.app/Contents/MacOS/Cook Editor'
```

That produces `14 UNAVAILABLE`, which `CookbotError.isExpected` correctly classifies as a normal outcome and deliberately does **not** report. You get the friendly "connection lost" message and an empty Sentry — right behaviour, useless as a test.

So two of three processes were shipping on code inspection, and every future release would have been in the same position.

## What this adds

Two commands in the palette under **Cook Editor**:

- `Send Test Error to Sentry (Window)` — throws inside a `setTimeout` so it becomes a genuinely unhandled renderer error, which is what the renderer SDK reports.
- `Send Test Error to Sentry (Backend)` — goes through `ErrorReporter.reportUnexpected`, the **same explicit-capture path real caught failures use**. That is the path that would otherwise never be exercised.

Backend events are tagged `testError=true` so a verification event is distinguishable from a real one in the dashboard.

## Electron main is still not covered

Being explicit rather than implying three-of-three. Reaching the main process from the renderer needs a new IPC channel plus `contextBridge` exposure — more plumbing than a diagnostic warrants right now. Main-process JS errors are still caught by `@sentry/electron/main`'s unhandled-exception handling; it is only the *deliberate* trigger that is missing.

## Tests

3 new unit tests (31 total in the package): that the backend command reports through the reporter at all, that it tags the event as a test, and that it does not throw so the command can report success to the user.

`npm run compile` — 47 projects. Lint clean.

## Verifying after this merges

Install a packaged build, then run both commands from the palette and confirm two events arrive tagged `processType: renderer` and `processType: backend`. Then toggle **Send Error Reports** off, restart, run them again, and confirm nothing arrives — which also verifies the opt-out, still unverified from #90.