### PR TITLE
fix: do not tell developers to run nvm when the repo has no nvm

### DIFF
--- a/dev-packages/private-test-setup/test-setup.js
+++ b/dev-packages/private-test-setup/test-setup.js
@@ -26,7 +26,8 @@ const nodeMajor = Number(process.versions.node.split('.')[0]);
 if (nodeMajor < MINIMUM_NODE_MAJOR) {
     throw new Error(
         `Theia tests require Node.js >= ${MINIMUM_NODE_MAJOR}, but this is Node ${process.versions.node}. `
-        + 'Run `nvm use` (see .nvmrc) and try again.'
+        + 'Switch to a supported version and try again - `.nvmrc` records the expected major. '
+        + 'Any installation method works (nvm, fnm, nix, brew); the repo does not standardise on one.'
     );
 }
 


### PR DESCRIPTION
Small follow-up to #85.

The Node version guard I added there says:

> Theia tests require Node.js >= 22, but this is Node 20.19.1. Run `nvm use` (see .nvmrc) and try again.

Nothing in this repo installs or standardises on nvm. On this machine Node comes from nix, so the guard names a command the developer does not have — it identifies the problem correctly and then gives advice that cannot be followed. I hit exactly this while trying to act on my own error message.

Now:

> Theia tests require Node.js >= 22, but this is Node 20.19.1. Switch to a supported version and try again - `.nvmrc` records the expected major. Any installation method works (nvm, fnm, nix, brew); the repo does not standardise on one.

`.nvmrc` stays, since it is a widely understood way to record the expected major and several version managers read it — it just is not a claim that nvm is required.

Verified by running the guard on Node 20 and reading the message it prints.