### PR TITLE
Chat: warn before the AI quota runs out, instead of stopping dead at 100%

### DIFF
--- a/docs/superpowers/plans/2026-08-13-chat-quota-warning.md
+++ b/docs/superpowers/plans/2026-08-13-chat-quota-warning.md
@@ -1,0 +1,1078 @@
+# Chat Quota Warning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Warn the user in the chat view when their Cookbot AI credits pass 80% of the billing-cycle allowance, instead of stopping dead at 100% (issue #89).
+
+**Architecture:** Wire the existing-but-never-called `GetUsage` gRPC RPC through a new connection-scoped `CookbotUsageService` (backend → browser RPC), extract the lazy cookbot session bootstrap into a shared `CookbotSessionInitializer`, and render a passive banner above the chat input in `CooklangChatViewWidget`, refreshed on widget attach/show and on chat response completion. Spec: `docs/superpowers/specs/2026-08-13-quota-warning-design.md`.
+
+**Tech Stack:** Theia extension packages (`@theia/cooklang-ai`, `@theia/cooklang-branding`, forked `@theia/ai-chat-ui` CSS), InversifyJS DI, `@grpc/grpc-js` + `@grpc/proto-loader`, mocha/chai via `theiaext test`.
+
+**Conventions that apply to every task:** 4-space indent, single quotes, explicit return types, `undefined` over `null`, property injection, every file starts with the standard cook.md license header (copy it verbatim from any sibling file). All user-facing strings via `nls.localize`.
+
+---
+
+### Task 1: Usage protocol types (`@theia/cooklang-ai` common)
+
+Pure types — no behavior, so no test. This unblocks every later task.
+
+**Files:**
+- Create: `packages/cooklang-ai/src/common/cookbot-usage-protocol.ts`
+- Modify: `packages/cooklang-ai/src/common/index.ts`
+
+- [ ] **Step 1: Create the protocol file**
+
+Create `packages/cooklang-ai/src/common/cookbot-usage-protocol.ts` (license header first, copied from `cookbot-protocol.ts`):
+
+```ts
+export const CookbotUsagePath = '/services/cookbot-usage';
+export const CookbotUsageService = Symbol('CookbotUsageService');
+
+/**
+ * Cookbot AI usage for the current billing cycle, as reported by the
+ * cookbot server's GetUsage RPC.
+ */
+export interface CookbotUsageStats {
+    inputTokensUsed: number;
+    outputTokensUsed: number;
+    tokenLimit: number;
+    billingPeriodStart?: string;
+    billingPeriodEnd?: string;
+    subscriptionTier?: string;
+}
+
+/**
+ * RPC-safe interface — no Event properties (see auth-protocol.ts in
+ * cooklang-account for why). Remote service: interface + symbol on purpose.
+ *
+ * `getUsage` resolves to `undefined` on ANY failure (not logged in, session
+ * init failed, gRPC error): a quota warning must never itself become a
+ * source of user-visible errors.
+ */
+export interface CookbotUsageService {
+    getUsage(): Promise<CookbotUsageStats | undefined>;
+}
+```
+
+- [ ] **Step 2: Export from the common index**
+
+In `packages/cooklang-ai/src/common/index.ts`, append after the `cookbot-server-tools-protocol` export block:
+
+```ts
+export {
+    CookbotUsagePath,
+    CookbotUsageService,
+    CookbotUsageStats,
+} from './cookbot-usage-protocol';
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-ai/src/common/cookbot-usage-protocol.ts packages/cooklang-ai/src/common/index.ts
+git commit -m "feat(ai): add CookbotUsageService protocol types (#89)"
+```
+
+---
+
+### Task 2: Extract `CookbotSessionInitializer` from the language model
+
+`GetUsage` needs a `session_id`, but the cookbot session is created lazily inside `CookbotLanguageModel`. Extract that logic into a shared connection-scoped class so the usage service can bootstrap the session too. TDD: initializer spec first, then the refactor, keeping the existing language-model spec green.
+
+**Files:**
+- Test: `packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts` (create)
+- Create: `packages/cooklang-ai/src/node/cookbot-session-initializer.ts`
+- Modify: `packages/cooklang-ai/src/node/cookbot-language-model.ts`
+- Modify: `packages/cooklang-ai/src/node/cookbot-language-model.spec.ts`
+- Modify: `packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts`
+
+- [ ] **Step 1: Write the failing initializer spec**
+
+Create `packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts` (license header first):
+
+```ts
+import { expect } from 'chai';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+
+class FakeGrpcClient {
+    initializeCalls = 0;
+    failNext = false;
+
+    async initialize(): Promise<unknown> {
+        this.initializeCalls++;
+        if (this.failNext) {
+            this.failNext = false;
+            throw new Error('init failed');
+        }
+        return { success: true, sessionId: `session-${this.initializeCalls}`, serverVersion: 'test' };
+    }
+}
+
+function createInitializer(grpcClient: FakeGrpcClient): CookbotSessionInitializer {
+    const initializer = new CookbotSessionInitializer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).workspaceServer = { getMostRecentlyUsedWorkspace: async () => undefined };
+    return initializer;
+}
+
+describe('CookbotSessionInitializer', () => {
+
+    it('initializes only once across concurrent and repeated callers', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = createInitializer(grpcClient);
+
+        await Promise.all([initializer.ensureInitialized(), initializer.ensureInitialized()]);
+        await initializer.ensureInitialized();
+
+        expect(grpcClient.initializeCalls).to.equal(1);
+    });
+
+    it('retries on the next call after a failed initialization', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.failNext = true;
+        const initializer = createInitializer(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await initializer.ensureInitialized();
+        } catch (error) {
+            thrown = error as Error;
+        }
+        expect(thrown?.message).to.equal('init failed');
+
+        await initializer.ensureInitialized();
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+
+    it('re-initializes after reset', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = createInitializer(grpcClient);
+
+        await initializer.ensureInitialized();
+        initializer.reset();
+        await initializer.ensureInitialized();
+
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai`
+Expected: FAILS with `Cannot find module './cookbot-session-initializer'` (compile error is the failure mode here since the module doesn't exist).
+
+- [ ] **Step 3: Implement `CookbotSessionInitializer`**
+
+Create `packages/cooklang-ai/src/node/cookbot-session-initializer.ts` (license header first). The body of `doInitialize` is moved verbatim from `CookbotLanguageModel.doInitialize`:
+
+```ts
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FileUri } from '@theia/core/lib/common/file-uri';
+import { WorkspaceServer } from '@theia/workspace/lib/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CookbotGrpcClient } from './cookbot-grpc-client';
+
+/**
+ * Creates the cookbot session on demand and shares it between every consumer
+ * of the connection-scoped gRPC client (language model, usage service):
+ * whichever caller runs first creates the session, the others reuse it.
+ */
+@injectable()
+export class CookbotSessionInitializer {
+
+    @inject(CookbotGrpcClient)
+    protected readonly grpcClient: CookbotGrpcClient;
+
+    @inject(WorkspaceServer)
+    protected readonly workspaceServer: WorkspaceServer;
+
+    private initPromise: Promise<void> | undefined;
+
+    async ensureInitialized(): Promise<void> {
+        if (!this.initPromise) {
+            // Drop a failed initialization so the next request can retry it,
+            // instead of awaiting the same rejected promise forever.
+            this.initPromise = this.doInitialize().catch(error => {
+                this.initPromise = undefined;
+                throw error;
+            });
+        }
+        await this.initPromise;
+    }
+
+    /**
+     * Forget the current session so the next call re-initializes. Used when
+     * the server invalidates an idle session (UNAUTHENTICATED).
+     */
+    reset(): void {
+        this.initPromise = undefined;
+    }
+
+    private async doInitialize(): Promise<void> {
+        let recipesDir = '';
+        let customInstructions = '';
+        try {
+            const workspaceUri = await this.workspaceServer.getMostRecentlyUsedWorkspace();
+            if (workspaceUri) {
+                recipesDir = FileUri.fsPath(workspaceUri);
+                const cookMdPath = path.join(recipesDir, 'COOK.md');
+                try {
+                    customInstructions = await fs.promises.readFile(cookMdPath, 'utf-8');
+                } catch {
+                    // COOK.md not present, that's fine
+                }
+            }
+        } catch {
+            // Workspace may not be set yet
+        }
+        await this.grpcClient.initialize(recipesDir, customInstructions);
+    }
+}
+```
+
+- [ ] **Step 4: Refactor `CookbotLanguageModel` to use it**
+
+In `packages/cooklang-ai/src/node/cookbot-language-model.ts`:
+
+1. Remove the imports of `FileUri`, `WorkspaceServer`, `fs`, and `path` (they move to the initializer). Add:
+
+```ts
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+```
+
+2. Replace the `workspaceServer` injection with the initializer — delete:
+
+```ts
+    @inject(WorkspaceServer)
+    protected readonly workspaceServer: WorkspaceServer;
+```
+
+add:
+
+```ts
+    @inject(CookbotSessionInitializer)
+    protected readonly sessionInitializer: CookbotSessionInitializer;
+```
+
+3. Delete the `initPromise` field and the whole `ensureInitialized()` and `doInitialize()` methods (lines defining `private initPromise`, `protected async ensureInitialized`, `private async doInitialize`).
+
+4. In `request()`, replace `await this.ensureInitialized();` with `await this.sessionInitializer.ensureInitialized();`.
+
+5. In the session-expiry retry inside `handleStreamingRequest` (the `catch` block of the `attempt` loop), replace:
+
+```ts
+                        if (CookbotError.isSessionExpired(error)) {
+                            that.initPromise = undefined;
+                            if (!sessionRetryDone && !partsYielded) {
+                                sessionRetryDone = true;
+                                console.info('[CookbotLM] Session expired, re-initializing and retrying');
+                                await that.ensureInitialized();
+                                continue attempt;
+                            }
+                        }
+```
+
+with:
+
+```ts
+                        if (CookbotError.isSessionExpired(error)) {
+                            that.sessionInitializer.reset();
+                            if (!sessionRetryDone && !partsYielded) {
+                                sessionRetryDone = true;
+                                console.info('[CookbotLM] Session expired, re-initializing and retrying');
+                                await that.sessionInitializer.ensureInitialized();
+                                continue attempt;
+                            }
+                        }
+```
+
+- [ ] **Step 5: Update the language-model spec wiring**
+
+In `packages/cooklang-ai/src/node/cookbot-language-model.spec.ts`, add the import:
+
+```ts
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+```
+
+and replace the whole `createModel` function with:
+
+```ts
+function createModel(grpcClient: FakeGrpcClient, errorReporter?: FakeErrorReporter): CookbotLanguageModel {
+    const initializer = new CookbotSessionInitializer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).workspaceServer = { getMostRecentlyUsedWorkspace: async () => undefined };
+    const model = new CookbotLanguageModel();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (model as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (model as any).sessionInitializer = initializer;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (model as any).errorReporter = errorReporter;
+    return model;
+}
+```
+
+- [ ] **Step 6: Bind the initializer in the backend module**
+
+In `packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts`, add the import:
+
+```ts
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+```
+
+and inside `cookbotConnectionModule`, directly after `bind(CookbotGrpcClient).toSelf().inSingletonScope();`, add:
+
+```ts
+    bind(CookbotSessionInitializer).toSelf().inSingletonScope();
+```
+
+- [ ] **Step 7: Compile and run the package tests**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai && npx lerna run test --scope @theia/cooklang-ai`
+Expected: compile exit 0; all specs pass, including the 3 new `CookbotSessionInitializer` tests and the pre-existing `CookbotLanguageModel` session-expiry tests (their `initializeCalls` assertions still hold because the fake gRPC client is shared with the initializer).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cooklang-ai/src/node/cookbot-session-initializer.ts \
+        packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts \
+        packages/cooklang-ai/src/node/cookbot-language-model.ts \
+        packages/cooklang-ai/src/node/cookbot-language-model.spec.ts \
+        packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts
+git commit -m "refactor(ai): extract cookbot session bootstrap into CookbotSessionInitializer (#89)"
+```
+
+---
+
+### Task 3: `CookbotGrpcClient.getUsage()`
+
+The gRPC client has no unit tests today (its service object is loaded dynamically from the .proto); the mapping logic is exercised through the usage-service spec in Task 4 with a stubbed client. This task is implementation + compile only.
+
+**Files:**
+- Modify: `packages/cooklang-ai/src/node/cookbot-grpc-client.ts`
+
+- [ ] **Step 1: Add the unary call**
+
+In `packages/cooklang-ai/src/node/cookbot-grpc-client.ts`, extend the import from `'../common/cookbot-protocol'`'s sibling — add a new import line after the existing `cookbot-server-tools-protocol` import:
+
+```ts
+import { CookbotUsageStats } from '../common/cookbot-usage-protocol';
+```
+
+Then add these methods directly after `getSessionId()`:
+
+```ts
+    async getUsage(): Promise<CookbotUsageStats> {
+        return this.withReconnectRetry('GetUsage', () => this.doGetUsage());
+    }
+
+    protected async doGetUsage(): Promise<CookbotUsageStats> {
+        this.ensureConnected();
+        return new Promise((resolve, reject) => {
+            this.service.GetUsage({
+                sessionId: this.sessionId || '',
+            }, (err: grpc.ServiceError | null, response: any) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve({
+                    inputTokensUsed: response.inputTokensUsed ?? 0,
+                    outputTokensUsed: response.outputTokensUsed ?? 0,
+                    tokenLimit: response.tokenLimit ?? 0,
+                    billingPeriodStart: response.billingPeriodStart || undefined,
+                    billingPeriodEnd: response.billingPeriodEnd || undefined,
+                    subscriptionTier: response.subscriptionTier || undefined,
+                });
+            });
+        });
+    }
+```
+
+(Field names are camelCase because the proto loader runs with `keepCase: false`; `longs: Number` makes the int64 fields plain numbers.)
+
+- [ ] **Step 2: Compile**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cooklang-ai/src/node/cookbot-grpc-client.ts
+git commit -m "feat(ai): wire the GetUsage gRPC call into the cookbot client (#89)"
+```
+
+---
+
+### Task 4: `CookbotUsageServiceImpl` (TDD)
+
+**Files:**
+- Test: `packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts` (create)
+- Create: `packages/cooklang-ai/src/node/cookbot-usage-service.ts`
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts` (license header first):
+
+```ts
+import { expect } from 'chai';
+import { CookbotUsageStats } from '../common/cookbot-usage-protocol';
+import { CookbotUsageServiceImpl } from './cookbot-usage-service';
+
+const SAMPLE_USAGE: CookbotUsageStats = {
+    inputTokensUsed: 700_000,
+    outputTokensUsed: 150_000,
+    tokenLimit: 1_000_000,
+    billingPeriodStart: '2026-08-01T00:00:00Z',
+    billingPeriodEnd: '2026-09-01T00:00:00Z',
+    subscriptionTier: 'pro',
+};
+
+/** gRPC UNAUTHENTICATED error as @grpc/grpc-js surfaces it. */
+function sessionExpiredError(): Error {
+    return Object.assign(
+        new Error('16 UNAUTHENTICATED: Invalid or expired session. Please call Initialize to start a new session.'),
+        { code: 16 }
+    );
+}
+
+class FakeGrpcClient {
+    getUsageCalls = 0;
+    errors: Error[] = [];
+    usage: CookbotUsageStats = SAMPLE_USAGE;
+
+    async getUsage(): Promise<CookbotUsageStats> {
+        this.getUsageCalls++;
+        const error = this.errors.shift();
+        if (error) {
+            throw error;
+        }
+        return this.usage;
+    }
+}
+
+class FakeInitializer {
+    ensureCalls = 0;
+    resetCalls = 0;
+    error: Error | undefined;
+
+    async ensureInitialized(): Promise<void> {
+        this.ensureCalls++;
+        if (this.error) {
+            throw this.error;
+        }
+    }
+
+    reset(): void {
+        this.resetCalls++;
+    }
+}
+
+function createService(grpcClient: FakeGrpcClient, initializer: FakeInitializer): CookbotUsageServiceImpl {
+    const service = new CookbotUsageServiceImpl();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).sessionInitializer = initializer;
+    return service;
+}
+
+describe('CookbotUsageServiceImpl', () => {
+
+    it('bootstraps the session before querying usage', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(initializer.ensureCalls).to.equal(1);
+        expect(usage).to.deep.equal(SAMPLE_USAGE);
+    });
+
+    it('returns undefined when session initialization fails', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = new FakeInitializer();
+        initializer.error = new Error('not logged in');
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(usage).to.equal(undefined);
+        expect(grpcClient.getUsageCalls).to.equal(0);
+    });
+
+    it('returns undefined when the usage query fails', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.errors = [new Error('boom')];
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(usage).to.equal(undefined);
+    });
+
+    it('re-initializes and retries once when the session has expired', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.errors = [sessionExpiredError()];
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(initializer.resetCalls).to.equal(1);
+        expect(grpcClient.getUsageCalls).to.equal(2);
+        expect(usage).to.deep.equal(SAMPLE_USAGE);
+    });
+
+    it('returns undefined when the retry also fails with an expired session', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.errors = [sessionExpiredError(), sessionExpiredError()];
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(usage).to.equal(undefined);
+        expect(grpcClient.getUsageCalls).to.equal(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai`
+Expected: FAILS with `Cannot find module './cookbot-usage-service'`.
+
+- [ ] **Step 3: Implement the service**
+
+Create `packages/cooklang-ai/src/node/cookbot-usage-service.ts` (license header first):
+
+```ts
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { CookbotGrpcClient } from './cookbot-grpc-client';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+import { CookbotError } from '../common/cookbot-error';
+import { CookbotUsageService, CookbotUsageStats } from '../common/cookbot-usage-protocol';
+
+/**
+ * Backend service reporting Cookbot AI usage to the browser via RPC.
+ *
+ * Every failure collapses to `undefined` rather than throwing: the quota
+ * warning is advisory UI, and it must never become a source of user-visible
+ * errors. Failures here are expected states (not logged in, offline, session
+ * expired) and are deliberately not reported to error tracking, consistent
+ * with CookbotError.isExpected on the chat path.
+ */
+@injectable()
+export class CookbotUsageServiceImpl implements CookbotUsageService {
+
+    @inject(CookbotGrpcClient)
+    protected readonly grpcClient: CookbotGrpcClient;
+
+    @inject(CookbotSessionInitializer)
+    protected readonly sessionInitializer: CookbotSessionInitializer;
+
+    async getUsage(): Promise<CookbotUsageStats | undefined> {
+        try {
+            await this.sessionInitializer.ensureInitialized();
+            return await this.queryWithSessionRetry();
+        } catch (error) {
+            console.info('[CookbotUsage] Usage unavailable:', error instanceof Error ? error.message : error);
+            return undefined;
+        }
+    }
+
+    /**
+     * The server invalidates idle sessions; a usage query may be the first
+     * call after a long idle, so retry once on a fresh session — the same
+     * recovery the language model performs for chat requests.
+     */
+    private async queryWithSessionRetry(): Promise<CookbotUsageStats> {
+        try {
+            return await this.grpcClient.getUsage();
+        } catch (error) {
+            if (!CookbotError.isSessionExpired(error)) {
+                throw error;
+            }
+            this.sessionInitializer.reset();
+            await this.sessionInitializer.ensureInitialized();
+            return this.grpcClient.getUsage();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai && npx lerna run test --scope @theia/cooklang-ai`
+Expected: all pass, including the 5 new `CookbotUsageServiceImpl` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang-ai/src/node/cookbot-usage-service.ts packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts
+git commit -m "feat(ai): add CookbotUsageService backend impl (#89)"
+```
+
+---
+
+### Task 5: DI wiring — backend RPC handler + frontend proxy
+
+**Files:**
+- Modify: `packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts`
+- Modify: `packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts`
+
+- [ ] **Step 1: Backend — expose the service on the connection**
+
+In `packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts`, add imports:
+
+```ts
+import { CookbotUsagePath } from '../common/cookbot-usage-protocol';
+import { CookbotUsageServiceImpl } from './cookbot-usage-service';
+```
+
+and inside `cookbotConnectionModule`, after the server-tools `ConnectionHandler` binding, add:
+
+```ts
+    // Usage service — exposed to browser via RPC for the chat quota banner
+    bind(CookbotUsageServiceImpl).toSelf().inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(
+            CookbotUsagePath,
+            () => ctx.container.get(CookbotUsageServiceImpl)
+        )
+    ).inSingletonScope();
+```
+
+- [ ] **Step 2: Frontend — bind the RPC proxy**
+
+In `packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts`, add the import:
+
+```ts
+import { CookbotUsagePath, CookbotUsageService } from '../common/cookbot-usage-protocol';
+```
+
+and after the `CookbotServerToolsService` proxy binding, add:
+
+```ts
+    // Usage — RPC proxy to backend (consumed by the chat quota banner)
+    bind(CookbotUsageService).toDynamicValue(ctx =>
+        ServiceConnectionProvider.createProxy(ctx.container, CookbotUsagePath)
+    ).inSingletonScope();
+```
+
+- [ ] **Step 3: Compile and test**
+
+Run: `npx lerna run compile --scope @theia/cooklang-ai && npx lerna run test --scope @theia/cooklang-ai`
+Expected: exit 0, tests green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
+git commit -m "feat(ai): expose CookbotUsageService over frontend RPC (#89)"
+```
+
+---
+
+### Task 6: Banner state helper in `@theia/cooklang-branding` (TDD)
+
+Pure threshold/label logic in a monaco-free file (a browser spec that transitively imports monaco dies under the test harness — keep this file dependency-free apart from the usage type). This task also gives cooklang-branding its dependency on cooklang-ai and its first spec, so it gains the `test` script now (adding it earlier would abort the whole `test:theia` run on "No test files found").
+
+**Files:**
+- Modify: `packages/cooklang-branding/package.json`
+- Modify: `packages/cooklang-branding/tsconfig.json`
+- Test: `packages/cooklang-branding/src/browser/cookbot-quota-banner-state.spec.ts` (create)
+- Create: `packages/cooklang-branding/src/browser/cookbot-quota-banner-state.ts`
+
+- [ ] **Step 1: Add the dependency, test script, and project reference**
+
+In `packages/cooklang-branding/package.json`:
+- add `"@theia/cooklang-ai": "1.70.0",` to `dependencies` (alphabetical: after `@theia/cooklang-account`);
+- add `"test": "theiaext test",` to `scripts` (between `lint` and `watch`).
+
+In `packages/cooklang-branding/tsconfig.json`, add to `references` (after `../cooklang-account`):
+
+```json
+    { "path": "../cooklang-ai" },
+```
+
+Then run: `npm install`
+Expected: exit 0 (refreshes workspace symlinks and the lockfile).
+
+- [ ] **Step 2: Write the failing spec**
+
+Create `packages/cooklang-branding/src/browser/cookbot-quota-banner-state.spec.ts` (license header first):
+
+```ts
+import { expect } from 'chai';
+import { CookbotUsageStats } from '@theia/cooklang-ai/lib/common';
+import { computeQuotaBannerState } from './cookbot-quota-banner-state';
+
+function usage(overrides: Partial<CookbotUsageStats> = {}): CookbotUsageStats {
+    return {
+        inputTokensUsed: 0,
+        outputTokensUsed: 0,
+        tokenLimit: 1_000_000,
+        billingPeriodEnd: '2026-09-01T00:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('computeQuotaBannerState', () => {
+
+    it('is hidden when usage is unavailable', () => {
+        expect(computeQuotaBannerState(undefined)).to.equal(undefined);
+    });
+
+    it('is hidden when the limit is missing or zero', () => {
+        expect(computeQuotaBannerState(usage({ tokenLimit: 0, inputTokensUsed: 999 }))).to.equal(undefined);
+    });
+
+    it('is hidden below the warning threshold', () => {
+        expect(computeQuotaBannerState(usage({ inputTokensUsed: 700_000, outputTokensUsed: 99_999 }))).to.equal(undefined);
+    });
+
+    it('warns from exactly 80%, counting input and output tokens together', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 700_000, outputTokensUsed: 100_000 }));
+        expect(state).to.deep.equal({ level: 'warning', percentUsed: 80, resetsOn: '2026-09-01T00:00:00Z' });
+    });
+
+    it('reports whole percent, rounded down, and passes the reset date through', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 876_543 }));
+        expect(state).to.deep.equal({ level: 'warning', percentUsed: 87, resetsOn: '2026-09-01T00:00:00Z' });
+    });
+
+    it('is exhausted at exactly 100%', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 1_000_000 }));
+        expect(state?.level).to.equal('exhausted');
+        expect(state?.percentUsed).to.equal(100);
+    });
+
+    it('caps the reported percent at 100 when over the limit', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 1_500_000 }));
+        expect(state).to.deep.equal({ level: 'exhausted', percentUsed: 100, resetsOn: '2026-09-01T00:00:00Z' });
+    });
+
+    it('omits the reset date when the server did not send one', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 900_000, billingPeriodEnd: undefined }));
+        expect(state).to.deep.equal({ level: 'warning', percentUsed: 90, resetsOn: undefined });
+    });
+});
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `npx lerna run compile --scope @theia/cooklang-branding`
+Expected: FAILS with `Cannot find module './cookbot-quota-banner-state'`.
+
+- [ ] **Step 4: Implement the helper**
+
+Create `packages/cooklang-branding/src/browser/cookbot-quota-banner-state.ts` (license header first):
+
+```ts
+import { CookbotUsageStats } from '@theia/cooklang-ai/lib/common';
+
+/**
+ * Mirrors USAGE_WARNING_THRESHOLD_PERCENT in the cookbot server's
+ * chat_service.rs, so client warning and server logging stay consistent.
+ */
+export const QUOTA_WARNING_THRESHOLD = 0.8;
+
+/**
+ * What the chat quota banner should show. `undefined` means: show nothing.
+ * Kept free of widget and localization concerns so it stays unit-testable
+ * in a monaco-free spec.
+ */
+export interface CookbotQuotaBannerState {
+    level: 'warning' | 'exhausted';
+    /** Whole percent of the allowance used, rounded down, capped at 100. */
+    percentUsed: number;
+    /** ISO date the cycle resets (billing_period_end), when the server sent one. */
+    resetsOn: string | undefined;
+}
+
+export function computeQuotaBannerState(usage: CookbotUsageStats | undefined): CookbotQuotaBannerState | undefined {
+    if (!usage || usage.tokenLimit <= 0) {
+        return undefined;
+    }
+    const fraction = (usage.inputTokensUsed + usage.outputTokensUsed) / usage.tokenLimit;
+    if (fraction < QUOTA_WARNING_THRESHOLD) {
+        return undefined;
+    }
+    return {
+        level: fraction >= 1 ? 'exhausted' : 'warning',
+        percentUsed: Math.min(100, Math.floor(fraction * 100)),
+        resetsOn: usage.billingPeriodEnd,
+    };
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx lerna run compile --scope @theia/cooklang-branding && npx lerna run test --scope @theia/cooklang-branding`
+Expected: compile exit 0; all 8 specs pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cooklang-branding/package.json packages/cooklang-branding/tsconfig.json \
+        packages/cooklang-branding/src/browser/cookbot-quota-banner-state.ts \
+        packages/cooklang-branding/src/browser/cookbot-quota-banner-state.spec.ts \
+        package-lock.json
+git commit -m "feat(branding): add quota banner threshold logic (#89)"
+```
+
+---
+
+### Task 7: Banner UI in `CooklangChatViewWidget` + CSS
+
+DOM banner pinned above the chat input, refreshed on attach/show and on chat response completion. No unit test — this is DOM/widget glue over the already-tested helper; it is verified by compile, lint, and the manual smoke test in Task 8.
+
+**Files:**
+- Modify: `packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts`
+- Modify: `packages/ai-chat-ui/src/browser/style/index.css`
+
+- [ ] **Step 1: Extend the widget**
+
+In `packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts`:
+
+1. Add imports (after the existing ones):
+
+```ts
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Message } from '@theia/core/lib/browser';
+import { ChatModel, ChatResponseModel, isActiveSessionChangedEvent } from '@theia/ai-chat/lib/common';
+import { CookbotUsageService } from '@theia/cooklang-ai/lib/common';
+import { AccountCommands } from '@theia/cooklang-account/lib/browser/account-contribution';
+import { computeQuotaBannerState, CookbotQuotaBannerState } from './cookbot-quota-banner-state';
+```
+
+Note: no `CommandService` import is needed — the base class (`ChatViewWidget` in `@theia/ai-chat-ui`) already injects `commandService` as a protected member, used below for the Open Account action.
+
+2. Add fields after `private webBaseUrl: string = DEFAULT_WEB_BASE_URL;`:
+
+```ts
+    @inject(CookbotUsageService)
+    protected readonly cookbotUsageService: CookbotUsageService;
+
+    private quotaBanner: HTMLDivElement;
+    private quotaBannerState: CookbotQuotaBannerState | undefined;
+    private readonly usageTracking = new DisposableCollection();
+```
+
+3. In `init()`, after the `gateOverlay` setup block, add:
+
+```ts
+        this.quotaBanner = document.createElement('div');
+        this.quotaBanner.className = 'ai-chat-quota-banner';
+        this.quotaBanner.style.display = 'none';
+
+        this.trackModelForUsage(this.chatSession.model);
+        this.toDispose.push(this.chatService.onSessionEvent(event => {
+            // Runs after the base class's own listener, so chatSession is
+            // already switched to the new active session here.
+            if (isActiveSessionChangedEvent(event)) {
+                this.trackModelForUsage(this.chatSession.model);
+            }
+        }));
+        this.toDispose.push(this.usageTracking);
+```
+
+4. Add these methods at the end of the class:
+
+```ts
+    protected override onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        // The banner sits between the chat tree and the input inside the
+        // widget's flex column, outside the PanelLayout's own widgets.
+        if (!this.quotaBanner.isConnected) {
+            this.node.insertBefore(this.quotaBanner, this.inputWidget.node);
+        }
+        this.refreshUsage();
+    }
+
+    protected override onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.refreshUsage();
+    }
+
+    private trackModelForUsage(model: ChatModel): void {
+        this.usageTracking.dispose();
+        this.usageTracking.push(model.onDidChange(event => {
+            if (event.kind === 'addResponse') {
+                this.watchResponseCompletion(event.response);
+            }
+        }));
+    }
+
+    /**
+     * Refresh once per exchange, when the response settles — streaming
+     * deltas must not each trigger a usage query.
+     */
+    private watchResponseCompletion(response: ChatResponseModel): void {
+        const listener = response.onDidChange(() => {
+            if (response.isComplete || response.isCanceled || response.isError) {
+                listener.dispose();
+                this.refreshUsage();
+            }
+        });
+        this.usageTracking.push(listener);
+    }
+
+    private refreshUsage(): void {
+        this.cookbotUsageService.getUsage().then(usageStats => {
+            this.quotaBannerState = computeQuotaBannerState(usageStats);
+            this.renderQuotaBanner();
+        }).catch(error => {
+            // The backend already collapses expected failures to undefined;
+            // anything surfacing here is RPC noise not worth a banner change.
+            console.info('[Chat] Could not refresh Cookbot usage:', error);
+        });
+    }
+
+    private renderQuotaBanner(): void {
+        const state = this.quotaBannerState;
+        const gated = this.authState.status !== 'logged-in' || !this.hasAiFeature;
+        if (!state || gated) {
+            this.quotaBanner.style.display = 'none';
+            return;
+        }
+        this.quotaBanner.replaceChildren();
+        this.quotaBanner.classList.toggle('exhausted', state.level === 'exhausted');
+
+        const message = document.createElement('span');
+        message.className = 'ai-chat-quota-banner-message';
+        const resetsOn = state.resetsOn ? new Date(state.resetsOn).toLocaleDateString() : undefined;
+        if (state.level === 'exhausted') {
+            message.textContent = resetsOn
+                ? nls.localize('theia/ai-chat/quota/exhaustedWithDate', 'Your Cookbot AI credits are used up until {0}.', resetsOn)
+                : nls.localize('theia/ai-chat/quota/exhausted', 'Your Cookbot AI credits for this billing cycle are used up.');
+        } else {
+            message.textContent = resetsOn
+                ? nls.localize('theia/ai-chat/quota/warningWithDate', "You've used {0}% of your Cookbot AI credits this cycle — resets {1}.", state.percentUsed, resetsOn)
+                : nls.localize('theia/ai-chat/quota/warning', "You've used {0}% of your Cookbot AI credits this cycle.", state.percentUsed);
+        }
+
+        const account = document.createElement('a');
+        account.className = 'ai-chat-quota-banner-link';
+        account.textContent = nls.localize('theia/ai-chat/quota/openAccount', 'Open Account');
+        account.addEventListener('click', () => {
+            this.commandService.executeCommand(AccountCommands.OPEN_VIEW.id);
+        });
+
+        const upgrade = document.createElement('a');
+        upgrade.className = 'ai-chat-quota-banner-link';
+        upgrade.textContent = nls.localize('theia/ai-chat/quota/upgrade', 'Upgrade');
+        upgrade.addEventListener('click', () => {
+            this.startUpgradeFlow();
+        });
+
+        this.quotaBanner.append(message, account, upgrade);
+        this.quotaBanner.style.display = 'flex';
+    }
+```
+
+5. Keep the banner consistent with the gate: at the end of `showGateScreen(...)` (both return paths go through the top — add it right after `this.gateOverlay.replaceChildren();`):
+
+```ts
+        this.quotaBanner.style.display = 'none';
+```
+
+and in `updateGating()`, in the ungated branch, after the `for (const widget of layout)` loop, add:
+
+```ts
+        this.renderQuotaBanner();
+```
+
+- [ ] **Step 2: Add the CSS**
+
+In `packages/ai-chat-ui/src/browser/style/index.css`, directly after the `.ai-chat-gate-note` rule block, add (4-space indent to match the neighboring gate rules; theme colors only, no hard-coded values):
+
+```css
+/* Chat quota banner — warns when Cookbot AI credits near/at the cycle limit */
+.ai-chat-quota-banner {
+    display: none;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0 12px 4px 12px;
+    padding: 6px 10px;
+    font-size: 12px;
+    border-radius: 4px;
+    background-color: var(--theia-inputValidation-warningBackground);
+    border: 1px solid var(--theia-inputValidation-warningBorder);
+}
+
+.ai-chat-quota-banner.exhausted {
+    background-color: var(--theia-inputValidation-errorBackground);
+    border-color: var(--theia-inputValidation-errorBorder);
+}
+
+.ai-chat-quota-banner-link {
+    cursor: pointer;
+    text-decoration: underline;
+    color: var(--theia-textLink-foreground);
+    white-space: nowrap;
+}
+```
+
+- [ ] **Step 3: Compile and lint**
+
+Run: `npx lerna run compile --scope @theia/cooklang-branding && npx lerna run lint --scope @theia/cooklang-branding --scope @theia/ai-chat-ui`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts packages/ai-chat-ui/src/browser/style/index.css
+git commit -m "feat(branding): show quota banner in chat view past 80% usage (#89)"
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Compile everything and run the affected packages' tests**
+
+Run: `npm run compile && npx lerna run test --scope @theia/cooklang-ai --scope @theia/cooklang-branding`
+Expected: exit 0, all specs green.
+
+- [ ] **Step 2: Lint the touched packages**
+
+Run: `npx lerna run lint --scope @theia/cooklang-ai --scope @theia/cooklang-branding --scope @theia/ai-chat-ui`
+Expected: exit 0.
+
+- [ ] **Step 3: Manual smoke test (requires a local cookbot server)**
+
+Only possible with a local cookbot running (`COOKBOT_ADDRESS=127.0.0.1:50052`); if unavailable, note that in the final report instead of skipping silently.
+
+```bash
+cd app && npm run bundle && npm run start:electron
+```
+
+Walkthrough:
+1. Log in, open the AI Chat view — with usage below 80% no banner appears.
+2. With the local server's token limit configured low, chat until crossing 80% — after the response completes, the warning banner appears above the input with percent and reset date; "Open Account" opens the Account view.
+3. Cross 100% — the banner switches to the exhausted style/message, and a new message still fails with the #86 error text (banner and error coexist).
+4. Log out — the gate screen shows and no banner is visible.
+
+- [ ] **Step 4: Update the issue**
+
+Do not close #89 automatically; the final PR description should reference it with `Closes #89` and mention the discovery that `GetUsage` already existed in the proto.

--- a/docs/superpowers/plans/2026-08-13-chat-quota-warning.md
+++ b/docs/superpowers/plans/2026-08-13-chat-quota-warning.md
@@ -997,7 +997,7 @@ Note: no `CommandService` import is needed — the base class (`ChatViewWidget` 
 and in `updateGating()`, in the ungated branch, after the `for (const widget of layout)` loop, add:
 
 ```ts
-        this.renderQuotaBanner();
+        this.refreshUsage();
 ```
 
 - [ ] **Step 2: Add the CSS**

--- a/docs/superpowers/plans/2026-08-13-chat-quota-warning.md
+++ b/docs/superpowers/plans/2026-08-13-chat-quota-warning.md
@@ -533,6 +533,7 @@ describe('CookbotUsageServiceImpl', () => {
 
         const usage = await service.getUsage();
 
+        expect(initializer.ensureCalls).to.equal(2);
         expect(initializer.resetCalls).to.equal(1);
         expect(grpcClient.getUsageCalls).to.equal(2);
         expect(usage).to.deep.equal(SAMPLE_USAGE);

--- a/docs/superpowers/specs/2026-08-13-quota-warning-design.md
+++ b/docs/superpowers/specs/2026-08-13-quota-warning-design.md
@@ -1,0 +1,104 @@
+# Quota warning before Cookbot stops dead
+
+**Issue:** [cook-md/editor#89](https://github.com/cook-md/editor/issues/89)
+**Date:** 2026-08-13
+**Status:** Approved
+
+## Problem
+
+Cookbot works normally until the billing-cycle token allowance is spent, then
+every message fails immediately. #86 made the failure message accurate, but the
+experience is still: works, works, works, hard stop. The server computes an 80%
+warning threshold and only logs it; the editor never warns the user.
+
+## Key findings
+
+- The `GetUsage` RPC already exists in `packages/cooklang-ai/proto/cookbot.proto`
+  and returns `input_tokens_used`, `output_tokens_used`, `token_limit`, and
+  `billing_period_start/end`. The editor's gRPC client never calls it. No proto
+  or server change is needed.
+- `SubscriptionState.aiCreditsRemaining` (cook.md web API) has no total, so a
+  percentage is not computable from it, and it is cached up to 5 minutes on the
+  backend plus indefinitely on the frontend. It is not used for this feature.
+- `CooklangChatViewWidget` (cooklang-branding) already subclasses the upstream
+  chat widget, injects `SubscriptionFrontendService`, and manages a DOM overlay
+  — the natural home for the banner.
+- `GetUsage` requires a `session_id`; the cookbot session is currently created
+  lazily by `CookbotLanguageModel` on the first chat message.
+
+## Decisions
+
+- **Data source:** the existing `GetUsage` gRPC RPC (accurate, fresh, gives a
+  real percentage matching the server's 80% threshold).
+- **Warning UI:** a passive banner pinned in the chat view — not a toast. It
+  stays while over threshold and disappears when the cycle resets, so "once per
+  cycle" needs no persistence bookkeeping.
+- **Plumbing:** a new dedicated `CookbotUsageService` RPC rather than extending
+  `CookbotServerToolsService`, keeping "server tools" meaning Claude tools.
+
+## Design
+
+### 1. Backend: expose `GetUsage` (packages/cooklang-ai)
+
+- **`CookbotGrpcClient.getUsage()`** — new unary call wrapping the `GetUsage`
+  proto RPC, using the same `withReconnectRetry` pattern as the other unary
+  calls. Returns `{ inputTokensUsed, outputTokensUsed, tokenLimit,
+  billingPeriodStart, billingPeriodEnd, subscriptionTier }`.
+- **Session bootstrap:** extract the lazy-initialize logic (workspace dir +
+  COOK.md read + `initialize`) out of `CookbotLanguageModel` into a shared,
+  connection-scoped `CookbotSessionInitializer` class used by both the language
+  model and the usage service, so whichever runs first creates the session and
+  the other reuses it. If initialization fails (not logged in, no network),
+  `getUsage` returns `undefined` — it never throws to the UI.
+- **`CookbotUsageService`** — new RPC protocol at `/services/cookbot-usage`
+  plus a backend impl bound with an `RpcConnectionHandler` inside the existing
+  `cookbotConnectionModule`, reusing the connection-scoped `CookbotGrpcClient`.
+  Single method: `getUsage(): Promise<CookbotUsageStats | undefined>`.
+
+### 2. Frontend: banner in the chat view (packages/cooklang-branding)
+
+- `cooklang-branding` gains a dependency on `@theia/cooklang-ai` (no cycle —
+  cooklang-ai does not depend on branding).
+- **`CooklangChatViewWidget`** owns a slim banner element pinned above the chat
+  input, hidden by default.
+- **Refresh triggers:** on widget activation/show, and whenever a chat response
+  completes (via `ChatService`; streaming deltas do not trigger refreshes).
+  No timers, no polling.
+- **Thresholds** (percent = `(inputTokensUsed + outputTokensUsed) / tokenLimit`):
+  - `< 80%`, `tokenLimit <= 0`, or usage unavailable → banner hidden. Unknown
+    usage never shows a false warning.
+  - `>= 80%` and `< 100%` → warning state: "You've used ~85% of your Cookbot AI
+    credits this cycle — resets Sep 1" with an "Open Account" action (existing
+    Account view command) and an upgrade link.
+  - `>= 100%` → exhausted state: "Your Cookbot AI credits are used up until
+    Sep 1" with the same actions. Complements the per-message error from #86
+    with something persistent.
+- The 80% constant lives client-side, mirroring the server's
+  `USAGE_WARNING_THRESHOLD_PERCENT`.
+- Styling per project guidelines: CSS classes in the branding stylesheet,
+  `--theia-*` color variables only, all strings via `nls.localize`.
+
+### 3. Error handling
+
+- Every failure path in the usage query (no auth, init failure, gRPC error,
+  missing/zero limit) collapses to `undefined` → hidden banner. Failures are
+  logged with `console.info/warn`, not reported to Sentry — they are expected
+  states, consistent with `CookbotError.isExpected`.
+- Usage refresh is fire-and-forget from the widget; a slow query never blocks
+  chat rendering.
+
+### 4. Testing
+
+- **Unit (node):** `CookbotUsageServiceImpl` with a stubbed gRPC client —
+  session bootstrap on demand, `UsageStats` mapping, error → `undefined`.
+- **Unit (browser):** threshold/label logic extracted into a pure helper,
+  e.g. `computeQuotaBannerState(usage): { level: 'none' | 'warning' |
+  'exhausted'; percent; resetsOn }`, kept in a monaco-free file so the spec
+  runs under the test harness.
+- **Manual:** run the dev app against a local cookbot (`COOKBOT_ADDRESS`) with
+  a low token limit and walk usage through 80% and 100%.
+
+## Out of scope
+
+- Proto/server changes, toast notifications, an always-visible credits meter,
+  and any change to `aiCreditsRemaining` or the Account view.

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
     },
     "app": {
       "name": "@cook-md/editor-app",
-      "version": "0.1.0-alpha.36",
+      "version": "0.1.0-alpha.37",
       "license": "(EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0) AND AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception",
       "dependencies": {
         "@theia/ai-chat": "1.70.0",
@@ -29606,6 +29606,7 @@
         "@theia/ai-chat-ui": "1.70.0",
         "@theia/ai-core": "1.70.0",
         "@theia/cooklang-account": "1.70.0",
+        "@theia/cooklang-ai": "1.70.0",
         "@theia/core": "1.70.0",
         "@theia/monaco": "1.70.0",
         "tslib": "^2.6.2"

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1672,6 +1672,32 @@ div:last-child>.theia-ChatNode {
     margin-top: 8px;
 }
 
+/* Chat quota banner — warns when Cookbot AI credits near/at the cycle limit */
+.ai-chat-quota-banner {
+    display: none;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 0 12px 4px 12px;
+    padding: 6px 10px;
+    font-size: 12px;
+    border-radius: 4px;
+    background-color: var(--theia-inputValidation-warningBackground);
+    border: 1px solid var(--theia-inputValidation-warningBorder);
+}
+
+.ai-chat-quota-banner.exhausted {
+    background-color: var(--theia-inputValidation-errorBackground);
+    border-color: var(--theia-inputValidation-errorBorder);
+}
+
+.ai-chat-quota-banner-link {
+    cursor: pointer;
+    text-decoration: underline;
+    color: var(--theia-textLink-foreground);
+    white-space: nowrap;
+}
+
 .theia-ChatInputOptions .option.toggled {
   border: var(--theia-border-width) var(--theia-inputOption-activeBorder) solid;
   background-color: var(--theia-inputOption-activeBackground);

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1691,6 +1691,11 @@ div:last-child>.theia-ChatNode {
     border-color: var(--theia-inputValidation-errorBorder);
 }
 
+.ai-chat-quota-banner-message {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
 .ai-chat-quota-banner-link {
     cursor: pointer;
     text-decoration: underline;

--- a/packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
+++ b/packages/cooklang-ai/src/browser/cooklang-ai-frontend-module.ts
@@ -17,6 +17,7 @@ import { Agent, bindToolProvider } from '@theia/ai-core/lib/common';
 import { PreferenceContribution } from '@theia/core/lib/common/preferences/preference-schema';
 import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { CookbotServerToolsPath, CookbotServerToolsService } from '../common/cookbot-server-tools-protocol';
+import { CookbotUsagePath, CookbotUsageService } from '../common/cookbot-usage-protocol';
 import { CookbotChatAgent } from './cookbot-chat-agent';
 import {
     CookbotSearchWebTool, CookbotFetchUrlTool, CookbotConvertUrlTool, CookbotConvertTextTool,
@@ -50,6 +51,11 @@ export default new ContainerModule(bind => {
     // Server tools — RPC proxy to backend
     bind(CookbotServerToolsService).toDynamicValue(ctx =>
         ServiceConnectionProvider.createProxy(ctx.container, CookbotServerToolsPath)
+    ).inSingletonScope();
+
+    // Usage — RPC proxy to backend (consumed by the chat quota banner)
+    bind(CookbotUsageService).toDynamicValue(ctx =>
+        ServiceConnectionProvider.createProxy(ctx.container, CookbotUsagePath)
     ).inSingletonScope();
 
     // Workspace function scope (shared helper for all file tools)

--- a/packages/cooklang-ai/src/common/cookbot-usage-protocol.ts
+++ b/packages/cooklang-ai/src/common/cookbot-usage-protocol.ts
@@ -1,0 +1,40 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+export const CookbotUsagePath = '/services/cookbot-usage';
+export const CookbotUsageService = Symbol('CookbotUsageService');
+
+/**
+ * Cookbot AI usage for the current billing cycle, as reported by the
+ * cookbot server's GetUsage RPC.
+ */
+export interface CookbotUsageStats {
+    inputTokensUsed: number;
+    outputTokensUsed: number;
+    tokenLimit: number;
+    billingPeriodStart?: string;
+    billingPeriodEnd?: string;
+    subscriptionTier?: string;
+}
+
+/**
+ * RPC-safe interface — no Event properties (see auth-protocol.ts in
+ * cooklang-account for why). Remote service: interface + symbol on purpose.
+ *
+ * `getUsage` resolves to `undefined` on ANY failure (not logged in, session
+ * init failed, gRPC error): a quota warning must never itself become a
+ * source of user-visible errors.
+ */
+export interface CookbotUsageService {
+    getUsage(): Promise<CookbotUsageStats | undefined>;
+}

--- a/packages/cooklang-ai/src/common/index.ts
+++ b/packages/cooklang-ai/src/common/index.ts
@@ -29,3 +29,8 @@ export {
     CookbotFetchResult,
     CookbotConvertResult,
 } from './cookbot-server-tools-protocol';
+export {
+    CookbotUsagePath,
+    CookbotUsageService,
+    CookbotUsageStats,
+} from './cookbot-usage-protocol';

--- a/packages/cooklang-ai/src/node/cookbot-grpc-client.ts
+++ b/packages/cooklang-ai/src/node/cookbot-grpc-client.ts
@@ -32,6 +32,7 @@ import {
     CookbotFetchResult,
     CookbotConvertResult,
 } from '../common/cookbot-server-tools-protocol';
+import { CookbotUsageStats } from '../common/cookbot-usage-protocol';
 import { CookbotError } from '../common/cookbot-error';
 import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
 
@@ -150,6 +151,32 @@ export class CookbotGrpcClient {
 
     getSessionId(): string | undefined {
         return this.sessionId;
+    }
+
+    async getUsage(): Promise<CookbotUsageStats> {
+        return this.withReconnectRetry('GetUsage', () => this.doGetUsage());
+    }
+
+    protected async doGetUsage(): Promise<CookbotUsageStats> {
+        this.ensureConnected();
+        return new Promise((resolve, reject) => {
+            this.service.GetUsage({
+                sessionId: this.sessionId || '',
+            }, (err: grpc.ServiceError | null, response: any) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve({
+                    inputTokensUsed: response.inputTokensUsed ?? 0,
+                    outputTokensUsed: response.outputTokensUsed ?? 0,
+                    tokenLimit: response.tokenLimit ?? 0,
+                    billingPeriodStart: response.billingPeriodStart || undefined,
+                    billingPeriodEnd: response.billingPeriodEnd || undefined,
+                    subscriptionTier: response.subscriptionTier || undefined,
+                });
+            });
+        });
     }
 
     sendMessage(

--- a/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
@@ -15,6 +15,7 @@ import { expect } from 'chai';
 import { LanguageModelStreamResponse, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core/lib/common';
 import { CookbotChatChunk, CookbotInitResult } from '../common/cookbot-protocol';
 import { CookbotLanguageModel } from './cookbot-language-model';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
 
 // ── Test fakes ──────────────────────────────────────────────────────────
 
@@ -96,11 +97,16 @@ class FakeErrorReporter {
 }
 
 function createModel(grpcClient: FakeGrpcClient, errorReporter?: FakeErrorReporter): CookbotLanguageModel {
+    const initializer = new CookbotSessionInitializer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).workspaceServer = { getMostRecentlyUsedWorkspace: async () => undefined };
     const model = new CookbotLanguageModel();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (model as any).grpcClient = grpcClient;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (model as any).workspaceServer = { getMostRecentlyUsedWorkspace: async () => undefined };
+    (model as any).sessionInitializer = initializer;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (model as any).errorReporter = errorReporter;
     return model;

--- a/packages/cooklang-ai/src/node/cookbot-language-model.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.ts
@@ -28,11 +28,8 @@ import {
     isToolCallResponsePart,
 } from '@theia/ai-core/lib/common';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
-import { FileUri } from '@theia/core/lib/common/file-uri';
-import { WorkspaceServer } from '@theia/workspace/lib/common';
-import * as fs from 'fs';
-import * as path from 'path';
 import { CookbotGrpcClient } from './cookbot-grpc-client';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
 import {
     CookbotChatChunk,
     CookbotMessageParam,
@@ -64,50 +61,16 @@ export class CookbotLanguageModel implements LanguageModel {
     @inject(CookbotGrpcClient)
     protected readonly grpcClient: CookbotGrpcClient;
 
-    @inject(WorkspaceServer)
-    protected readonly workspaceServer: WorkspaceServer;
+    @inject(CookbotSessionInitializer)
+    protected readonly sessionInitializer: CookbotSessionInitializer;
 
     // Optional: error reporting is a separate extension, and the language model
     // must keep working when it is absent.
     @inject(ErrorReporter) @optional()
     protected readonly errorReporter?: ErrorReporter;
 
-    private initPromise: Promise<void> | undefined;
-
-    protected async ensureInitialized(): Promise<void> {
-        if (!this.initPromise) {
-            // Drop a failed initialization so the next request can retry it,
-            // instead of awaiting the same rejected promise forever.
-            this.initPromise = this.doInitialize().catch(error => {
-                this.initPromise = undefined;
-                throw error;
-            });
-        }
-        await this.initPromise;
-    }
-
-    private async doInitialize(): Promise<void> {
-        let recipesDir = '';
-        let customInstructions = '';
-        try {
-            const workspaceUri = await this.workspaceServer.getMostRecentlyUsedWorkspace();
-            if (workspaceUri) {
-                recipesDir = FileUri.fsPath(workspaceUri);
-                const cookMdPath = path.join(recipesDir, 'COOK.md');
-                try {
-                    customInstructions = await fs.promises.readFile(cookMdPath, 'utf-8');
-                } catch {
-                    // COOK.md not present, that's fine
-                }
-            }
-        } catch {
-            // Workspace may not be set yet
-        }
-        await this.grpcClient.initialize(recipesDir, customInstructions);
-    }
-
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {
-        await this.ensureInitialized();
+        await this.sessionInitializer.ensureInitialized();
         return this.handleStreamingRequest(request, cancellationToken);
     }
 
@@ -176,11 +139,11 @@ export class CookbotLanguageModel implements LanguageModel {
                         break;
                     } catch (error: unknown) {
                         if (CookbotError.isSessionExpired(error)) {
-                            that.initPromise = undefined;
+                            that.sessionInitializer.reset();
                             if (!sessionRetryDone && !partsYielded) {
                                 sessionRetryDone = true;
                                 console.info('[CookbotLM] Session expired, re-initializing and retrying');
-                                await that.ensureInitialized();
+                                await that.sessionInitializer.ensureInitialized();
                                 continue attempt;
                             }
                         } else if (CookbotError.isTransientConnection(error) && !connectionRetryDone && !partsYielded) {

--- a/packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts
@@ -17,9 +17,16 @@ import { CookbotSessionInitializer } from './cookbot-session-initializer';
 class FakeGrpcClient {
     initializeCalls = 0;
     failNext = false;
+    /** When set, `initialize` awaits this before resolving/rejecting, letting a test control when a call settles. */
+    nextInitializeBlocksOn: Promise<void> | undefined;
 
     async initialize(): Promise<unknown> {
         this.initializeCalls++;
+        if (this.nextInitializeBlocksOn) {
+            const blocker = this.nextInitializeBlocksOn;
+            this.nextInitializeBlocksOn = undefined;
+            await blocker;
+        }
         if (this.failNext) {
             this.failNext = false;
             throw new Error('init failed');
@@ -74,6 +81,30 @@ describe('CookbotSessionInitializer', () => {
         initializer.reset();
         await initializer.ensureInitialized();
 
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+
+    it('a stale failed initialization does not clobber a newer in-flight one', async () => {
+        const grpcClient = new FakeGrpcClient();
+        let rejectFirst!: (error: Error) => void;
+        grpcClient.nextInitializeBlocksOn = new Promise<void>((_resolve, reject) => { rejectFirst = reject; });
+        const initializer = createInitializer(grpcClient);
+
+        const first = initializer.ensureInitialized();
+        initializer.reset();
+        const second = initializer.ensureInitialized();
+
+        rejectFirst(new Error('stale failure'));
+        let thrown: Error | undefined;
+        try {
+            await first;
+        } catch (error) {
+            thrown = error as Error;
+        }
+        expect(thrown?.message).to.equal('stale failure');
+
+        await second;
+        await initializer.ensureInitialized();
         expect(grpcClient.initializeCalls).to.equal(2);
     });
 });

--- a/packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-session-initializer.spec.ts
@@ -1,0 +1,79 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+
+class FakeGrpcClient {
+    initializeCalls = 0;
+    failNext = false;
+
+    async initialize(): Promise<unknown> {
+        this.initializeCalls++;
+        if (this.failNext) {
+            this.failNext = false;
+            throw new Error('init failed');
+        }
+        return { success: true, sessionId: `session-${this.initializeCalls}`, serverVersion: 'test' };
+    }
+}
+
+function createInitializer(grpcClient: FakeGrpcClient): CookbotSessionInitializer {
+    const initializer = new CookbotSessionInitializer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (initializer as any).workspaceServer = { getMostRecentlyUsedWorkspace: async () => undefined };
+    return initializer;
+}
+
+describe('CookbotSessionInitializer', () => {
+
+    it('initializes only once across concurrent and repeated callers', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = createInitializer(grpcClient);
+
+        await Promise.all([initializer.ensureInitialized(), initializer.ensureInitialized()]);
+        await initializer.ensureInitialized();
+
+        expect(grpcClient.initializeCalls).to.equal(1);
+    });
+
+    it('retries on the next call after a failed initialization', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.failNext = true;
+        const initializer = createInitializer(grpcClient);
+
+        let thrown: Error | undefined;
+        try {
+            await initializer.ensureInitialized();
+        } catch (error) {
+            thrown = error as Error;
+        }
+        expect(thrown?.message).to.equal('init failed');
+
+        await initializer.ensureInitialized();
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+
+    it('re-initializes after reset', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = createInitializer(grpcClient);
+
+        await initializer.ensureInitialized();
+        initializer.reset();
+        await initializer.ensureInitialized();
+
+        expect(grpcClient.initializeCalls).to.equal(2);
+    });
+});

--- a/packages/cooklang-ai/src/node/cookbot-session-initializer.ts
+++ b/packages/cooklang-ai/src/node/cookbot-session-initializer.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FileUri } from '@theia/core/lib/common/file-uri';
+import { WorkspaceServer } from '@theia/workspace/lib/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import { CookbotGrpcClient } from './cookbot-grpc-client';
+
+/**
+ * Creates the cookbot session on demand and shares it between every consumer
+ * of the connection-scoped gRPC client (language model, usage service):
+ * whichever caller runs first creates the session, the others reuse it.
+ */
+@injectable()
+export class CookbotSessionInitializer {
+
+    @inject(CookbotGrpcClient)
+    protected readonly grpcClient: CookbotGrpcClient;
+
+    @inject(WorkspaceServer)
+    protected readonly workspaceServer: WorkspaceServer;
+
+    private initPromise: Promise<void> | undefined;
+
+    async ensureInitialized(): Promise<void> {
+        if (!this.initPromise) {
+            // Drop a failed initialization so the next request can retry it,
+            // instead of awaiting the same rejected promise forever.
+            this.initPromise = this.doInitialize().catch(error => {
+                this.initPromise = undefined;
+                throw error;
+            });
+        }
+        await this.initPromise;
+    }
+
+    /**
+     * Forget the current session so the next call re-initializes. Used when
+     * the server invalidates an idle session (UNAUTHENTICATED).
+     */
+    reset(): void {
+        this.initPromise = undefined;
+    }
+
+    private async doInitialize(): Promise<void> {
+        let recipesDir = '';
+        let customInstructions = '';
+        try {
+            const workspaceUri = await this.workspaceServer.getMostRecentlyUsedWorkspace();
+            if (workspaceUri) {
+                recipesDir = FileUri.fsPath(workspaceUri);
+                const cookMdPath = path.join(recipesDir, 'COOK.md');
+                try {
+                    customInstructions = await fs.promises.readFile(cookMdPath, 'utf-8');
+                } catch {
+                    // COOK.md not present, that's fine
+                }
+            }
+        } catch {
+            // Workspace may not be set yet
+        }
+        await this.grpcClient.initialize(recipesDir, customInstructions);
+    }
+}

--- a/packages/cooklang-ai/src/node/cookbot-session-initializer.ts
+++ b/packages/cooklang-ai/src/node/cookbot-session-initializer.ts
@@ -37,11 +37,19 @@ export class CookbotSessionInitializer {
     async ensureInitialized(): Promise<void> {
         if (!this.initPromise) {
             // Drop a failed initialization so the next request can retry it,
-            // instead of awaiting the same rejected promise forever.
-            this.initPromise = this.doInitialize().catch(error => {
-                this.initPromise = undefined;
+            // instead of awaiting the same rejected promise forever. Capture
+            // the promise locally and only clear the field if it is still the
+            // current one - a `reset()` plus a newer in-flight init may have
+            // replaced it by the time this stale promise settles, and
+            // clobbering that newer promise would let a third caller start a
+            // redundant, concurrent initialization.
+            const promise: Promise<void> = this.doInitialize().catch(error => {
+                if (this.initPromise === promise) {
+                    this.initPromise = undefined;
+                }
                 throw error;
             });
+            this.initPromise = promise;
         }
         await this.initPromise;
     }

--- a/packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts
@@ -117,6 +117,7 @@ describe('CookbotUsageServiceImpl', () => {
 
         const usage = await service.getUsage();
 
+        expect(initializer.ensureCalls).to.equal(2);
         expect(initializer.resetCalls).to.equal(1);
         expect(grpcClient.getUsageCalls).to.equal(2);
         expect(usage).to.deep.equal(SAMPLE_USAGE);

--- a/packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-usage-service.spec.ts
@@ -1,0 +1,136 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { CookbotUsageStats } from '../common/cookbot-usage-protocol';
+import { CookbotUsageServiceImpl } from './cookbot-usage-service';
+
+const SAMPLE_USAGE: CookbotUsageStats = {
+    inputTokensUsed: 700_000,
+    outputTokensUsed: 150_000,
+    tokenLimit: 1_000_000,
+    billingPeriodStart: '2026-08-01T00:00:00Z',
+    billingPeriodEnd: '2026-09-01T00:00:00Z',
+    subscriptionTier: 'pro',
+};
+
+/** gRPC UNAUTHENTICATED error as @grpc/grpc-js surfaces it. */
+function sessionExpiredError(): Error {
+    return Object.assign(
+        new Error('16 UNAUTHENTICATED: Invalid or expired session. Please call Initialize to start a new session.'),
+        { code: 16 }
+    );
+}
+
+class FakeGrpcClient {
+    getUsageCalls = 0;
+    errors: Error[] = [];
+    usage: CookbotUsageStats = SAMPLE_USAGE;
+
+    async getUsage(): Promise<CookbotUsageStats> {
+        this.getUsageCalls++;
+        const error = this.errors.shift();
+        if (error) {
+            throw error;
+        }
+        return this.usage;
+    }
+}
+
+class FakeInitializer {
+    ensureCalls = 0;
+    resetCalls = 0;
+    error: Error | undefined;
+
+    async ensureInitialized(): Promise<void> {
+        this.ensureCalls++;
+        if (this.error) {
+            throw this.error;
+        }
+    }
+
+    reset(): void {
+        this.resetCalls++;
+    }
+}
+
+function createService(grpcClient: FakeGrpcClient, initializer: FakeInitializer): CookbotUsageServiceImpl {
+    const service = new CookbotUsageServiceImpl();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).grpcClient = grpcClient;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).sessionInitializer = initializer;
+    return service;
+}
+
+describe('CookbotUsageServiceImpl', () => {
+
+    it('bootstraps the session before querying usage', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(initializer.ensureCalls).to.equal(1);
+        expect(usage).to.deep.equal(SAMPLE_USAGE);
+    });
+
+    it('returns undefined when session initialization fails', async () => {
+        const grpcClient = new FakeGrpcClient();
+        const initializer = new FakeInitializer();
+        initializer.error = new Error('not logged in');
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(usage).to.equal(undefined);
+        expect(grpcClient.getUsageCalls).to.equal(0);
+    });
+
+    it('returns undefined when the usage query fails', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.errors = [new Error('boom')];
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(usage).to.equal(undefined);
+    });
+
+    it('re-initializes and retries once when the session has expired', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.errors = [sessionExpiredError()];
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(initializer.resetCalls).to.equal(1);
+        expect(grpcClient.getUsageCalls).to.equal(2);
+        expect(usage).to.deep.equal(SAMPLE_USAGE);
+    });
+
+    it('returns undefined when the retry also fails with an expired session', async () => {
+        const grpcClient = new FakeGrpcClient();
+        grpcClient.errors = [sessionExpiredError(), sessionExpiredError()];
+        const initializer = new FakeInitializer();
+        const service = createService(grpcClient, initializer);
+
+        const usage = await service.getUsage();
+
+        expect(usage).to.equal(undefined);
+        expect(grpcClient.getUsageCalls).to.equal(2);
+    });
+});

--- a/packages/cooklang-ai/src/node/cookbot-usage-service.ts
+++ b/packages/cooklang-ai/src/node/cookbot-usage-service.ts
@@ -1,0 +1,65 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { CookbotGrpcClient } from './cookbot-grpc-client';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
+import { CookbotError } from '../common/cookbot-error';
+import { CookbotUsageService, CookbotUsageStats } from '../common/cookbot-usage-protocol';
+
+/**
+ * Backend service reporting Cookbot AI usage to the browser via RPC.
+ *
+ * Every failure collapses to `undefined` rather than throwing: the quota
+ * warning is advisory UI, and it must never become a source of user-visible
+ * errors. Failures here are expected states (not logged in, offline, session
+ * expired) and are deliberately not reported to error tracking, consistent
+ * with CookbotError.isExpected on the chat path.
+ */
+@injectable()
+export class CookbotUsageServiceImpl implements CookbotUsageService {
+
+    @inject(CookbotGrpcClient)
+    protected readonly grpcClient: CookbotGrpcClient;
+
+    @inject(CookbotSessionInitializer)
+    protected readonly sessionInitializer: CookbotSessionInitializer;
+
+    async getUsage(): Promise<CookbotUsageStats | undefined> {
+        try {
+            await this.sessionInitializer.ensureInitialized();
+            return await this.queryWithSessionRetry();
+        } catch (error) {
+            console.info('[CookbotUsage] Usage unavailable:', error instanceof Error ? error.message : error);
+            return undefined;
+        }
+    }
+
+    /**
+     * The server invalidates idle sessions; a usage query may be the first
+     * call after a long idle, so retry once on a fresh session — the same
+     * recovery the language model performs for chat requests.
+     */
+    private async queryWithSessionRetry(): Promise<CookbotUsageStats> {
+        try {
+            return await this.grpcClient.getUsage();
+        } catch (error) {
+            if (!CookbotError.isSessionExpired(error)) {
+                throw error;
+            }
+            this.sessionInitializer.reset();
+            await this.sessionInitializer.ensureInitialized();
+            return this.grpcClient.getUsage();
+        }
+    }
+}

--- a/packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts
+++ b/packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts
@@ -19,6 +19,7 @@ import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { CookbotServerToolsPath } from '../common/cookbot-server-tools-protocol';
 import { CookbotGrpcClient } from './cookbot-grpc-client';
 import { CookbotLanguageModel } from './cookbot-language-model';
+import { CookbotSessionInitializer } from './cookbot-session-initializer';
 import { CookbotLanguageModelProvider } from './cookbot-language-model-provider';
 import { CookbotServerToolsServiceImpl } from './cookbot-server-tools-service';
 
@@ -29,6 +30,7 @@ import { CookbotServerToolsServiceImpl } from './cookbot-server-tools-service';
  */
 const cookbotConnectionModule = ConnectionContainerModule.create(({ bind }) => {
     bind(CookbotGrpcClient).toSelf().inSingletonScope();
+    bind(CookbotSessionInitializer).toSelf().inSingletonScope();
     bind(CookbotLanguageModel).toSelf().inSingletonScope();
     bind(CookbotLanguageModelProvider).toSelf().inSingletonScope();
 

--- a/packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts
+++ b/packages/cooklang-ai/src/node/cooklang-ai-backend-module.ts
@@ -17,11 +17,13 @@ import { ConnectionHandler, RpcConnectionHandler } from '@theia/core/lib/common/
 import { LanguageModelProvider } from '@theia/ai-core/lib/common';
 import { AuthService } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { CookbotServerToolsPath } from '../common/cookbot-server-tools-protocol';
+import { CookbotUsagePath } from '../common/cookbot-usage-protocol';
 import { CookbotGrpcClient } from './cookbot-grpc-client';
 import { CookbotLanguageModel } from './cookbot-language-model';
 import { CookbotSessionInitializer } from './cookbot-session-initializer';
 import { CookbotLanguageModelProvider } from './cookbot-language-model-provider';
 import { CookbotServerToolsServiceImpl } from './cookbot-server-tools-service';
+import { CookbotUsageServiceImpl } from './cookbot-usage-service';
 
 /**
  * Connection-scoped bindings for the Cookbot language model.
@@ -40,6 +42,15 @@ const cookbotConnectionModule = ConnectionContainerModule.create(({ bind }) => {
         new RpcConnectionHandler(
             CookbotServerToolsPath,
             () => ctx.container.get(CookbotServerToolsServiceImpl)
+        )
+    ).inSingletonScope();
+
+    // Usage service — exposed to browser via RPC for the chat quota banner
+    bind(CookbotUsageServiceImpl).toSelf().inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(
+            CookbotUsagePath,
+            () => ctx.container.get(CookbotUsageServiceImpl)
         )
     ).inSingletonScope();
 

--- a/packages/cooklang-branding/package.json
+++ b/packages/cooklang-branding/package.json
@@ -7,6 +7,7 @@
     "@theia/ai-chat-ui": "1.70.0",
     "@theia/ai-core": "1.70.0",
     "@theia/cooklang-account": "1.70.0",
+    "@theia/cooklang-ai": "1.70.0",
     "@theia/core": "1.70.0",
     "@theia/monaco": "1.70.0",
     "tslib": "^2.6.2"
@@ -31,6 +32,7 @@
     "clean": "theiaext clean",
     "compile": "theiaext compile",
     "lint": "theiaext lint",
+    "test": "theiaext test",
     "watch": "theiaext watch"
   },
   "devDependencies": {

--- a/packages/cooklang-branding/src/browser/cookbot-quota-banner-state.spec.ts
+++ b/packages/cooklang-branding/src/browser/cookbot-quota-banner-state.spec.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { CookbotUsageStats } from '@theia/cooklang-ai/lib/common';
+import { computeQuotaBannerState } from './cookbot-quota-banner-state';
+
+function usage(overrides: Partial<CookbotUsageStats> = {}): CookbotUsageStats {
+    return {
+        inputTokensUsed: 0,
+        outputTokensUsed: 0,
+        tokenLimit: 1_000_000,
+        billingPeriodEnd: '2026-09-01T00:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('computeQuotaBannerState', () => {
+
+    it('is hidden when usage is unavailable', () => {
+        expect(computeQuotaBannerState(undefined)).to.equal(undefined);
+    });
+
+    it('is hidden when the limit is missing or zero', () => {
+        expect(computeQuotaBannerState(usage({ tokenLimit: 0, inputTokensUsed: 999 }))).to.equal(undefined);
+    });
+
+    it('is hidden below the warning threshold', () => {
+        expect(computeQuotaBannerState(usage({ inputTokensUsed: 700_000, outputTokensUsed: 99_999 }))).to.equal(undefined);
+    });
+
+    it('warns from exactly 80%, counting input and output tokens together', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 700_000, outputTokensUsed: 100_000 }));
+        expect(state).to.deep.equal({ level: 'warning', percentUsed: 80, resetsOn: '2026-09-01T00:00:00Z' });
+    });
+
+    it('reports whole percent, rounded down, and passes the reset date through', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 876_543 }));
+        expect(state).to.deep.equal({ level: 'warning', percentUsed: 87, resetsOn: '2026-09-01T00:00:00Z' });
+    });
+
+    it('is exhausted at exactly 100%', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 1_000_000 }));
+        expect(state?.level).to.equal('exhausted');
+        expect(state?.percentUsed).to.equal(100);
+    });
+
+    it('caps the reported percent at 100 when over the limit', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 1_500_000 }));
+        expect(state).to.deep.equal({ level: 'exhausted', percentUsed: 100, resetsOn: '2026-09-01T00:00:00Z' });
+    });
+
+    it('omits the reset date when the server did not send one', () => {
+        const state = computeQuotaBannerState(usage({ inputTokensUsed: 900_000, billingPeriodEnd: undefined }));
+        expect(state).to.deep.equal({ level: 'warning', percentUsed: 90, resetsOn: undefined });
+    });
+});

--- a/packages/cooklang-branding/src/browser/cookbot-quota-banner-state.ts
+++ b/packages/cooklang-branding/src/browser/cookbot-quota-banner-state.ts
@@ -1,0 +1,48 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { CookbotUsageStats } from '@theia/cooklang-ai/lib/common';
+
+/**
+ * Mirrors USAGE_WARNING_THRESHOLD_PERCENT in the cookbot server's
+ * chat_service.rs, so client warning and server logging stay consistent.
+ */
+export const QUOTA_WARNING_THRESHOLD = 0.8;
+
+/**
+ * What the chat quota banner should show. `undefined` means: show nothing.
+ * Kept free of widget and localization concerns so it stays unit-testable
+ * in a monaco-free spec.
+ */
+export interface CookbotQuotaBannerState {
+    level: 'warning' | 'exhausted';
+    /** Whole percent of the allowance used, rounded down, capped at 100. */
+    percentUsed: number;
+    /** ISO date the cycle resets (billing_period_end), when the server sent one. */
+    resetsOn: string | undefined;
+}
+
+export function computeQuotaBannerState(usage: CookbotUsageStats | undefined): CookbotQuotaBannerState | undefined {
+    if (!usage || usage.tokenLimit <= 0) {
+        return undefined;
+    }
+    const fraction = (usage.inputTokensUsed + usage.outputTokensUsed) / usage.tokenLimit;
+    if (fraction < QUOTA_WARNING_THRESHOLD) {
+        return undefined;
+    }
+    return {
+        level: fraction >= 1 ? 'exhausted' : 'warning',
+        percentUsed: Math.min(100, Math.floor(fraction * 100)),
+        resetsOn: usage.billingPeriodEnd,
+    };
+}

--- a/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
+++ b/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
@@ -19,6 +19,12 @@ import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { AuthState } from '@theia/cooklang-account/lib/common/auth-protocol';
 import { AuthContribution, CookmdLoginCommand } from '@theia/cooklang-account/lib/browser/auth-contribution';
 import { SubscriptionFrontendService } from '@theia/cooklang-account/lib/browser/subscription-frontend-service';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Message } from '@theia/core/lib/browser';
+import { ChatModel, ChatResponseModel, isActiveSessionChangedEvent } from '@theia/ai-chat/lib/common';
+import { CookbotUsageService } from '@theia/cooklang-ai/lib/common';
+import { AccountCommands } from '@theia/cooklang-account/lib/browser/account-contribution';
+import { computeQuotaBannerState, CookbotQuotaBannerState } from './cookbot-quota-banner-state';
 
 const DEFAULT_WEB_BASE_URL = 'https://cook.md';
 
@@ -42,6 +48,13 @@ export class CooklangChatViewWidget extends ChatViewWidget {
     private gateOverlay: HTMLDivElement;
     private webBaseUrl: string = DEFAULT_WEB_BASE_URL;
 
+    @inject(CookbotUsageService)
+    protected readonly cookbotUsageService: CookbotUsageService;
+
+    private quotaBanner: HTMLDivElement;
+    private quotaBannerState: CookbotQuotaBannerState | undefined;
+    private readonly usageTracking = new DisposableCollection();
+
     @postConstruct()
     protected override init(): void {
         super.init();
@@ -50,6 +63,20 @@ export class CooklangChatViewWidget extends ChatViewWidget {
         this.gateOverlay.className = 'ai-chat-gate-overlay';
         this.gateOverlay.style.display = 'none';
         this.node.prepend(this.gateOverlay);
+
+        this.quotaBanner = document.createElement('div');
+        this.quotaBanner.className = 'ai-chat-quota-banner';
+        this.quotaBanner.style.display = 'none';
+
+        this.trackModelForUsage(this.chatSession.model);
+        this.toDispose.push(this.chatService.onSessionEvent(event => {
+            // Runs after the base class's own listener, so chatSession is
+            // already switched to the new active session here.
+            if (isActiveSessionChangedEvent(event)) {
+                this.trackModelForUsage(this.chatSession.model);
+            }
+        }));
+        this.toDispose.push(this.usageTracking);
 
         this.authState = this.authContribution.authState;
         this.checkAiFeature();
@@ -95,6 +122,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
                 widget.show();
             }
         }
+        this.renderQuotaBanner();
     }
 
     private showGateScreen(type: 'login' | 'upgrade'): void {
@@ -107,6 +135,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
 
         this.gateOverlay.style.display = 'flex';
         this.gateOverlay.replaceChildren();
+        this.quotaBanner.style.display = 'none';
 
         const icon = document.createElement('div');
         icon.className = 'ai-chat-gate-icon';
@@ -164,5 +193,95 @@ export class CooklangChatViewWidget extends ChatViewWidget {
             // Timeout, state mismatch, or superseded flow — gate will stay as-is.
             console.warn('Upgrade flow did not complete:', err);
         }
+    }
+
+    protected override onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        // The banner sits between the chat tree and the input inside the
+        // widget's flex column, outside the PanelLayout's own widgets.
+        if (!this.quotaBanner.isConnected) {
+            this.node.insertBefore(this.quotaBanner, this.inputWidget.node);
+        }
+        this.refreshUsage();
+    }
+
+    protected override onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.refreshUsage();
+    }
+
+    private trackModelForUsage(model: ChatModel): void {
+        this.usageTracking.dispose();
+        this.usageTracking.push(model.onDidChange(event => {
+            if (event.kind === 'addResponse') {
+                this.watchResponseCompletion(event.response);
+            }
+        }));
+    }
+
+    /**
+     * Refresh once per exchange, when the response settles — streaming
+     * deltas must not each trigger a usage query.
+     */
+    private watchResponseCompletion(response: ChatResponseModel): void {
+        const listener = response.onDidChange(() => {
+            if (response.isComplete || response.isCanceled || response.isError) {
+                listener.dispose();
+                this.refreshUsage();
+            }
+        });
+        this.usageTracking.push(listener);
+    }
+
+    private refreshUsage(): void {
+        this.cookbotUsageService.getUsage().then(usageStats => {
+            this.quotaBannerState = computeQuotaBannerState(usageStats);
+            this.renderQuotaBanner();
+        }).catch(error => {
+            // The backend already collapses expected failures to undefined;
+            // anything surfacing here is RPC noise not worth a banner change.
+            console.info('[Chat] Could not refresh Cookbot usage:', error);
+        });
+    }
+
+    private renderQuotaBanner(): void {
+        const state = this.quotaBannerState;
+        const gated = this.authState.status !== 'logged-in' || !this.hasAiFeature;
+        if (!state || gated) {
+            this.quotaBanner.style.display = 'none';
+            return;
+        }
+        this.quotaBanner.replaceChildren();
+        this.quotaBanner.classList.toggle('exhausted', state.level === 'exhausted');
+
+        const message = document.createElement('span');
+        message.className = 'ai-chat-quota-banner-message';
+        const resetsOn = state.resetsOn ? new Date(state.resetsOn).toLocaleDateString() : undefined;
+        if (state.level === 'exhausted') {
+            message.textContent = resetsOn
+                ? nls.localize('theia/ai-chat/quota/exhaustedWithDate', 'Your Cookbot AI credits are used up until {0}.', resetsOn)
+                : nls.localize('theia/ai-chat/quota/exhausted', 'Your Cookbot AI credits for this billing cycle are used up.');
+        } else {
+            message.textContent = resetsOn
+                ? nls.localize('theia/ai-chat/quota/warningWithDate', 'You\'ve used {0}% of your Cookbot AI credits this cycle — resets {1}.', state.percentUsed, resetsOn)
+                : nls.localize('theia/ai-chat/quota/warning', 'You\'ve used {0}% of your Cookbot AI credits this cycle.', state.percentUsed);
+        }
+
+        const account = document.createElement('a');
+        account.className = 'ai-chat-quota-banner-link';
+        account.textContent = nls.localize('theia/ai-chat/quota/openAccount', 'Open Account');
+        account.addEventListener('click', () => {
+            this.commandService.executeCommand(AccountCommands.OPEN_VIEW.id);
+        });
+
+        const upgrade = document.createElement('a');
+        upgrade.className = 'ai-chat-quota-banner-link';
+        upgrade.textContent = nls.localizeByDefault('Upgrade');
+        upgrade.addEventListener('click', () => {
+            this.startUpgradeFlow();
+        });
+
+        this.quotaBanner.append(message, account, upgrade);
+        this.quotaBanner.style.display = 'flex';
     }
 }

--- a/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
+++ b/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
@@ -240,6 +240,10 @@ export class CooklangChatViewWidget extends ChatViewWidget {
     }
 
     private refreshUsage(): void {
+        if (this.authState.status !== 'logged-in' || !this.hasAiFeature) {
+            this.quotaBanner.style.display = 'none';
+            return;
+        }
         const seq = ++this.usageRequestSeq;
         this.cookbotUsageService.getUsage().then(usageStats => {
             if (seq !== this.usageRequestSeq || this.isDisposed) {

--- a/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
+++ b/packages/cooklang-branding/src/browser/cooklang-chat-view-widget.ts
@@ -54,6 +54,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
     private quotaBanner: HTMLDivElement;
     private quotaBannerState: CookbotQuotaBannerState | undefined;
     private readonly usageTracking = new DisposableCollection();
+    private usageRequestSeq = 0;
 
     @postConstruct()
     protected override init(): void {
@@ -67,6 +68,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
         this.quotaBanner = document.createElement('div');
         this.quotaBanner.className = 'ai-chat-quota-banner';
         this.quotaBanner.style.display = 'none';
+        this.quotaBanner.setAttribute('role', 'status');
 
         this.trackModelForUsage(this.chatSession.model);
         this.toDispose.push(this.chatService.onSessionEvent(event => {
@@ -122,7 +124,7 @@ export class CooklangChatViewWidget extends ChatViewWidget {
                 widget.show();
             }
         }
-        this.renderQuotaBanner();
+        this.refreshUsage();
     }
 
     private showGateScreen(type: 'login' | 'upgrade'): void {
@@ -224,6 +226,10 @@ export class CooklangChatViewWidget extends ChatViewWidget {
      * deltas must not each trigger a usage query.
      */
     private watchResponseCompletion(response: ChatResponseModel): void {
+        if (response.isComplete || response.isCanceled || response.isError) {
+            this.refreshUsage();
+            return;
+        }
         const listener = response.onDidChange(() => {
             if (response.isComplete || response.isCanceled || response.isError) {
                 listener.dispose();
@@ -234,7 +240,11 @@ export class CooklangChatViewWidget extends ChatViewWidget {
     }
 
     private refreshUsage(): void {
+        const seq = ++this.usageRequestSeq;
         this.cookbotUsageService.getUsage().then(usageStats => {
+            if (seq !== this.usageRequestSeq || this.isDisposed) {
+                return;
+            }
             this.quotaBannerState = computeQuotaBannerState(usageStats);
             this.renderQuotaBanner();
         }).catch(error => {
@@ -256,7 +266,8 @@ export class CooklangChatViewWidget extends ChatViewWidget {
 
         const message = document.createElement('span');
         message.className = 'ai-chat-quota-banner-message';
-        const resetsOn = state.resetsOn ? new Date(state.resetsOn).toLocaleDateString() : undefined;
+        const parsedReset = state.resetsOn ? new Date(state.resetsOn) : undefined;
+        const resetsOn = parsedReset && !isNaN(parsedReset.getTime()) ? parsedReset.toLocaleDateString() : undefined;
         if (state.level === 'exhausted') {
             message.textContent = resetsOn
                 ? nls.localize('theia/ai-chat/quota/exhaustedWithDate', 'Your Cookbot AI credits are used up until {0}.', resetsOn)
@@ -267,21 +278,30 @@ export class CooklangChatViewWidget extends ChatViewWidget {
                 : nls.localize('theia/ai-chat/quota/warning', 'You\'ve used {0}% of your Cookbot AI credits this cycle.', state.percentUsed);
         }
 
-        const account = document.createElement('a');
-        account.className = 'ai-chat-quota-banner-link';
-        account.textContent = nls.localize('theia/ai-chat/quota/openAccount', 'Open Account');
-        account.addEventListener('click', () => {
+        const account = this.createQuotaBannerAction(nls.localize('theia/ai-chat/quota/openAccount', 'Open Account'), () => {
             this.commandService.executeCommand(AccountCommands.OPEN_VIEW.id);
         });
-
-        const upgrade = document.createElement('a');
-        upgrade.className = 'ai-chat-quota-banner-link';
-        upgrade.textContent = nls.localizeByDefault('Upgrade');
-        upgrade.addEventListener('click', () => {
+        const upgrade = this.createQuotaBannerAction(nls.localizeByDefault('Upgrade'), () => {
             this.startUpgradeFlow();
         });
 
         this.quotaBanner.append(message, account, upgrade);
         this.quotaBanner.style.display = 'flex';
+    }
+
+    private createQuotaBannerAction(label: string, run: () => void): HTMLAnchorElement {
+        const link = document.createElement('a');
+        link.className = 'ai-chat-quota-banner-link';
+        link.textContent = label;
+        link.setAttribute('role', 'link');
+        link.tabIndex = 0;
+        link.addEventListener('click', () => run());
+        link.addEventListener('keydown', event => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                run();
+            }
+        });
+        return link;
     }
 }

--- a/packages/cooklang-branding/tsconfig.json
+++ b/packages/cooklang-branding/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../ai-chat-ui" },
     { "path": "../ai-core" },
     { "path": "../cooklang-account" },
+    { "path": "../cooklang-ai" },
     { "path": "../core" },
     { "path": "../monaco" }
   ]


### PR DESCRIPTION
Closes #89

## Summary

- Wires the **existing but never-called `GetUsage` gRPC RPC** into the editor (the issue assumed a proto change would be needed for an accurate signal — it wasn't: the RPC already returns tokens used, the limit, and the billing period). No server or proto changes.
- Extracts the lazy cookbot session bootstrap from `CookbotLanguageModel` into a shared, connection-scoped `CookbotSessionInitializer` (with a fix for a latent single-flight race), so the new usage query and chat share one session.
- Adds `CookbotUsageServiceImpl` + `/services/cookbot-usage` RPC: collapses every failure (not logged in, offline, expired session) to `undefined` — the quota warning can never itself become a source of user-visible errors. Retries once on session expiry, same as the chat path.
- Shows a **passive banner** in the chat view above the input: warning state from 80% (mirroring the server's `USAGE_WARNING_THRESHOLD_PERCENT`), exhausted state at 100% complementing the per-message error from #86, with reset date, Open Account, and Upgrade actions. Refreshes on view attach/show and once per settled chat response — no polling, no toasts, and "once per cycle" falls out of the banner being passive state. Hidden whenever usage is unknown (never a false warning) or the view is gated.
- Threshold/label logic lives in a pure, monaco-free helper (`computeQuotaBannerState`) with its own spec — the first spec in `@theia/cooklang-branding`, so that package also gains its `test` script.

Design spec and implementation plan are included under `docs/superpowers/`.

## Test Plan

- [x] `@theia/cooklang-ai`: 62 specs passing (session initializer incl. stale-failure race, usage service incl. expiry retry, existing language-model suites)
- [x] `@theia/cooklang-branding`: 8 specs passing (threshold boundaries: exactly 80%, exactly 100%, cap >100%, zero limit, missing reset date)
- [x] Full monorepo compile (47 projects) + lint on the three touched packages
- [ ] Manual smoke test against a local cookbot with a low token limit (walk usage through 80% and 100%) — **not yet run**; no local server was available during development. The failure mode if the server misbehaves is a hidden banner, never an error.