### PR TITLE
feat(cooklang): renderTemplate templateUri + listReportTemplates tool

### DIFF
--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -45,6 +45,7 @@ import { ReportWidgetPresenter } from './report-widget-presenter';
 import { MermaidRenderer } from './mermaid-renderer';
 import { bindToolProvider } from '@theia/ai-core/lib/common';
 import { RenderTemplateTool } from './render-template-tool';
+import { ListReportTemplatesTool } from './list-report-templates-tool';
 import { bindCooklangPreferences } from '../common';
 
 export default new ContainerModule(bind => {
@@ -109,6 +110,7 @@ export default new ContainerModule(bind => {
 
     // AI render tool (picked up by the cookbot agent via ToolInvocationRegistry)
     bindToolProvider(RenderTemplateTool, bind);
+    bindToolProvider(ListReportTemplatesTool, bind);
 
     // Report command and context menu
     bind(ReportContribution).toSelf().inSingletonScope();

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -40,6 +40,7 @@ import { ReportContribution } from './report-contribution';
 import { ReportExportContribution } from './report-export-contribution';
 import { ReportConfigService } from './report-config-service';
 import { ReportPresenter } from './report-presenter';
+import { ReportTemplateFinder } from './report-template-finder';
 import { ReportWidgetPresenter } from './report-widget-presenter';
 import { MermaidRenderer } from './mermaid-renderer';
 import { bindToolProvider } from '@theia/ai-core/lib/common';
@@ -99,6 +100,7 @@ export default new ContainerModule(bind => {
 
     // Report config + presenter (shared by the command and the AI render tool)
     bind(ReportConfigService).toSelf().inSingletonScope();
+    bind(ReportTemplateFinder).toSelf().inSingletonScope();
     bind(ReportWidgetPresenter).toSelf().inSingletonScope();
     bind(ReportPresenter).toService(ReportWidgetPresenter);
 

--- a/packages/cooklang/src/browser/list-report-templates-tool.spec.ts
+++ b/packages/cooklang/src/browser/list-report-templates-tool.spec.ts
@@ -1,0 +1,124 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+// The tool transitively imports `ReportTemplateFinder` → `WorkspaceService`,
+// which needs browser globals at require time. Same jsdom preamble as the
+// sibling report specs.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { ListReportTemplatesTool } from './list-report-templates-tool';
+import { WorkspaceReportTemplate } from './report-template-finder';
+
+after(() => disableJSDOM());
+
+class FakeFinder {
+    templates: WorkspaceReportTemplate[] = [];
+    async findWorkspaceTemplates(): Promise<WorkspaceReportTemplate[]> {
+        return this.templates;
+    }
+}
+
+interface ListResult {
+    templates: Array<{ path: string; uri: string; name: string; directory?: string; outputFormat: string }>;
+    builtIn: Array<{ id: string; label: string }>;
+}
+
+function createTool(): { tool: ListReportTemplatesTool; finder: FakeFinder } {
+    const tool = new ListReportTemplatesTool();
+    const finder = new FakeFinder();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (tool as any).templateFinder = finder;
+    return { tool, finder };
+}
+
+async function invoke(tool: ListReportTemplatesTool): Promise<ListResult> {
+    const result = await tool.getTool().handler('{}');
+    return JSON.parse(result as string);
+}
+
+describe('ListReportTemplatesTool', () => {
+
+    it('exposes the tool under the id listReportTemplates with no required parameters', () => {
+        const { tool } = createTool();
+        const def = tool.getTool();
+        expect(def.id).to.equal('listReportTemplates');
+        expect(def.name).to.equal('listReportTemplates');
+        expect(def.parameters.required ?? []).to.deep.equal([]);
+    });
+
+    it('lists workspace templates with path, name, directory and inferred outputFormat', async () => {
+        const { tool, finder } = createTool();
+        finder.templates = [
+            {
+                id: 'workspace:file:///ws/config/reports/balanced-diet.jinja',
+                label: 'balanced-diet.jinja',
+                uri: 'file:///ws/config/reports/balanced-diet.jinja',
+                path: 'config/reports/balanced-diet.jinja',
+                directory: 'config/reports',
+            },
+            {
+                id: 'workspace:file:///ws/menu.html.jinja',
+                label: 'menu.html.jinja',
+                uri: 'file:///ws/menu.html.jinja',
+                path: 'menu.html.jinja',
+            },
+        ];
+        const result = await invoke(tool);
+        expect(result.templates).to.deep.equal([
+            {
+                path: 'config/reports/balanced-diet.jinja',
+                uri: 'file:///ws/config/reports/balanced-diet.jinja',
+                name: 'balanced-diet.jinja',
+                directory: 'config/reports',
+                outputFormat: 'markdown',
+            },
+            {
+                path: 'menu.html.jinja',
+                uri: 'file:///ws/menu.html.jinja',
+                name: 'menu.html.jinja',
+                outputFormat: 'html',
+            },
+        ]);
+    });
+
+    it('falls back to the uri as path for templates outside every workspace root', async () => {
+        const { tool, finder } = createTool();
+        finder.templates = [{
+            id: 'workspace:file:///elsewhere/cost.jinja',
+            label: 'cost.jinja',
+            uri: 'file:///elsewhere/cost.jinja',
+        }];
+        const result = await invoke(tool);
+        expect(result.templates[0].path).to.equal('file:///elsewhere/cost.jinja');
+    });
+
+    it('always includes the built-in templates', async () => {
+        const { tool } = createTool();
+        const result = await invoke(tool);
+        expect(result.templates).to.deep.equal([]);
+        expect(result.builtIn).to.deep.equal([
+            { id: 'builtin:ingredients', label: 'Ingredients List (built-in)' },
+            { id: 'builtin:shopping-list', label: 'Shopping List (built-in)' },
+        ]);
+    });
+});

--- a/packages/cooklang/src/browser/list-report-templates-tool.ts
+++ b/packages/cooklang/src/browser/list-report-templates-tool.ts
@@ -38,7 +38,8 @@ export class ListReportTemplatesTool implements ToolProvider {
                 + 'workspace (by convention under config/reports/) plus the editor\'s built-in templates. Call this BEFORE '
                 + 'authoring a new report template — if an existing one fits the request, render it with renderTemplate '
                 + 'using templateUri (a workspace template\'s `path` or `uri`, or a built-in `id`) instead of writing a new one. '
-                + 'Returns { templates: [{ path, uri, name, directory, outputFormat }], builtIn: [{ id, label }] }; '
+                + 'Returns { templates: [{ path, uri, name, directory (absent at the workspace root), outputFormat }], builtIn: [{ id, label }] }; '
+                + 'in multi-root workspaces pass `uri` rather than `path`. '
                 + '`outputFormat` (markdown | html | text) is inferred from the file name\'s inner extension.',
             parameters: {
                 type: 'object',

--- a/packages/cooklang/src/browser/list-report-templates-tool.ts
+++ b/packages/cooklang/src/browser/list-report-templates-tool.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
+import { ReportTemplates } from '../common';
+import { ReportTemplateFinder } from './report-template-finder';
+
+/**
+ * AI tool listing the report templates cookbot can render by reference:
+ * every `*.jinja|j2|jinja2` file in the workspace plus the built-ins. Read-only,
+ * so it auto-executes. Pairs with `renderTemplate`'s `templateUri` argument.
+ */
+@injectable()
+export class ListReportTemplatesTool implements ToolProvider {
+
+    static ID = 'listReportTemplates';
+
+    @inject(ReportTemplateFinder)
+    protected readonly templateFinder: ReportTemplateFinder;
+
+    getTool(): ToolRequest {
+        return {
+            id: ListReportTemplatesTool.ID,
+            name: ListReportTemplatesTool.ID,
+            displayName: 'List Report Templates',
+            description: 'List the Jinja2 report templates available to render: every *.jinja / *.j2 / *.jinja2 file in the '
+                + 'workspace (by convention under config/reports/) plus the editor\'s built-in templates. Call this BEFORE '
+                + 'authoring a new report template — if an existing one fits the request, render it with renderTemplate '
+                + 'using templateUri (a workspace template\'s `path` or `uri`, or a built-in `id`) instead of writing a new one. '
+                + 'Returns { templates: [{ path, uri, name, directory, outputFormat }], builtIn: [{ id, label }] }; '
+                + '`outputFormat` (markdown | html | text) is inferred from the file name\'s inner extension.',
+            parameters: {
+                type: 'object',
+                properties: {},
+            },
+            handler: async () => this.execute(),
+        };
+    }
+
+    protected async execute(): Promise<string> {
+        const templates = (await this.templateFinder.findWorkspaceTemplates()).map(template => ({
+            path: template.path ?? template.uri,
+            uri: template.uri,
+            name: template.label,
+            directory: template.directory,
+            outputFormat: ReportTemplates.outputFormat(template.label),
+        }));
+        const builtIn = ReportTemplates.BUILT_IN.map(template => ({ id: template.id, label: template.label }));
+        return JSON.stringify({ templates, builtIn });
+    }
+}

--- a/packages/cooklang/src/browser/render-template-tool.spec.ts
+++ b/packages/cooklang/src/browser/render-template-tool.spec.ts
@@ -40,9 +40,9 @@ class FakeConfigService {
     getActiveCooklangUri(): URI | undefined { return this.activeUri; }
     resolveWorkspaceUri(arg: string): URI | undefined {
         if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(arg) || arg.startsWith('/')) {
-            return new URI(arg);
+            return new URI(arg).normalizePath();
         }
-        return this.workspaceRoot ? this.workspaceRoot.resolve(arg) : undefined;
+        return this.workspaceRoot ? this.workspaceRoot.resolve(arg).normalizePath() : undefined;
     }
     async buildConfigJson(scale: number = 1): Promise<string> {
         this.lastScale = scale;
@@ -283,6 +283,25 @@ describe('RenderTemplateTool', () => {
             expect(shown.templateUri).to.equal('file:///ws/config/reports/nutrition.html.jinja');
             expect(shown.inlineTemplateContent).to.equal(undefined);
             expect(shown.outputFormat).to.equal(undefined);
+        });
+
+        it('uses the normalized uri in the workspace tab id so ./ paths share the QuickPick tab', async () => {
+            const { tool, config, files, presenter } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/config/reports/cost.jinja', 'TPL');
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            await invoke(tool, { templateUri: './config/reports/cost.jinja', recipeUri: 'cake.cook', show: true });
+            expect(presenter.shown[0].templateId).to.equal('workspace:file:///ws/config/reports/cost.jinja');
+            expect(presenter.shown[0].templateUri).to.equal('file:///ws/config/reports/cost.jinja');
+        });
+
+        it('accepts a bare absolute path as templateUri', async () => {
+            const { tool, language, files } = createTool();
+            files.files.set('file:///abs/cost.jinja', 'ABS TPL');
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            const result = await invoke(tool, { templateUri: '/abs/cost.jinja', recipeUri: 'file:///ws/cake.cook' });
+            expect(result.output).to.equal('RENDERED');
+            expect(language.calls[0].template).to.equal('ABS TPL');
         });
 
         it('passes an explicit outputFormat through for a templateUri tab', async () => {

--- a/packages/cooklang/src/browser/render-template-tool.spec.ts
+++ b/packages/cooklang/src/browser/render-template-tool.spec.ts
@@ -38,7 +38,7 @@ class FakeConfigService {
     workspaceRoot: URI | undefined;
     lastScale: number | undefined;
     getActiveCooklangUri(): URI | undefined { return this.activeUri; }
-    resolveRecipeUri(arg: string): URI | undefined {
+    resolveWorkspaceUri(arg: string): URI | undefined {
         if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(arg) || arg.startsWith('/')) {
             return new URI(arg);
         }

--- a/packages/cooklang/src/browser/render-template-tool.spec.ts
+++ b/packages/cooklang/src/browser/render-template-tool.spec.ts
@@ -104,19 +104,27 @@ async function invoke(tool: RenderTemplateTool, args: object): Promise<{ output?
 
 describe('RenderTemplateTool', () => {
 
-    it('exposes the tool under the id renderTemplate with templateContent required', () => {
+    it('exposes the tool under the id renderTemplate with templateContent and templateUri both optional', () => {
         const { tool } = createTool();
         const def = tool.getTool();
         expect(def.id).to.equal('renderTemplate');
         expect(def.name).to.equal('renderTemplate');
-        expect(def.parameters.required).to.deep.equal(['templateContent']);
+        expect(def.parameters.required ?? []).to.deep.equal([]);
+        expect(Object.keys(def.parameters.properties)).to.include.members(['templateContent', 'templateUri']);
     });
 
-    it('errors when templateContent is missing', async () => {
+    it('errors when neither templateContent nor templateUri is given', async () => {
         const { tool, config } = createTool();
         config.activeUri = new URI('file:///ws/recipe.cook');
         const result = await invoke(tool, {});
-        expect(result.error).to.match(/templateContent is required/);
+        expect(result.error).to.match(/exactly one of templateContent or templateUri/);
+    });
+
+    it('errors when both templateContent and templateUri are given', async () => {
+        const { tool, config } = createTool();
+        config.activeUri = new URI('file:///ws/recipe.cook');
+        const result = await invoke(tool, { templateContent: 'x', templateUri: 'config/reports/cost.jinja' });
+        expect(result.error).to.match(/exactly one of templateContent or templateUri/);
     });
 
     it('errors when no recipeUri is given and no recipe is active', async () => {
@@ -209,5 +217,102 @@ describe('RenderTemplateTool', () => {
         files.files.set('file:///ws/cake.cook', 'r');
         const result = await invoke(tool, { templateContent: 't', recipeUri: 'file:///ws/cake.cook' });
         expect(result.error).to.match(/Render failed: addon crashed/);
+    });
+
+    describe('templateUri', () => {
+
+        it('renders a workspace-relative template file against the recipe', async () => {
+            const { tool, config, language, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/config/reports/cost.jinja', 'COST TPL');
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            const result = await invoke(tool, { templateUri: 'config/reports/cost.jinja', recipeUri: 'cake.cook' });
+            expect(result.output).to.equal('RENDERED');
+            expect(language.calls[0].template).to.equal('COST TPL');
+            expect(language.calls[0].recipe).to.equal('recipe');
+        });
+
+        it('renders a built-in template by id', async () => {
+            const { tool, language, files } = createTool();
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            const result = await invoke(tool, { templateUri: 'builtin:ingredients', recipeUri: 'file:///ws/cake.cook' });
+            expect(result.output).to.equal('RENDERED');
+            expect(language.calls[0].template).to.contain('for ingredient in ingredients');
+        });
+
+        it('errors on an unknown built-in id and lists the known ones', async () => {
+            const { tool, files } = createTool();
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            const result = await invoke(tool, { templateUri: 'builtin:nope', recipeUri: 'file:///ws/cake.cook' });
+            expect(result.error).to.match(/Unknown built-in template 'builtin:nope'/);
+            expect(result.error).to.contain('builtin:ingredients');
+        });
+
+        it('errors when a relative templateUri is given but no workspace is open', async () => {
+            const { tool, files } = createTool();
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            const result = await invoke(tool, { templateUri: 'config/reports/cost.jinja', recipeUri: 'file:///ws/cake.cook' });
+            expect(result.error).to.match(/Could not resolve templateUri/);
+        });
+
+        it('errors when templateUri is not a template file', async () => {
+            const { tool, files } = createTool();
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            files.files.set('file:///ws/notes.txt', 'x');
+            const result = await invoke(tool, { templateUri: 'file:///ws/notes.txt', recipeUri: 'file:///ws/cake.cook' });
+            expect(result.error).to.match(/templateUri must be a \.jinja\/\.j2\/\.jinja2 file/);
+        });
+
+        it('errors when the template file cannot be read', async () => {
+            const { tool, files } = createTool();
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            const result = await invoke(tool, { templateUri: 'file:///ws/missing.jinja', recipeUri: 'file:///ws/cake.cook' });
+            expect(result.error).to.match(/Could not read template/);
+        });
+
+        it('opens the workspace-bound report tab (no inline content, format inferred) when show is true', async () => {
+            const { tool, files, presenter } = createTool();
+            files.files.set('file:///ws/config/reports/nutrition.html.jinja', 'TPL');
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            await invoke(tool, { templateUri: 'file:///ws/config/reports/nutrition.html.jinja', recipeUri: 'file:///ws/cake.cook', show: true });
+            expect(presenter.shown).to.have.length(1);
+            const shown = presenter.shown[0];
+            expect(shown.uri).to.equal('file:///ws/cake.cook');
+            expect(shown.templateId).to.equal('workspace:file:///ws/config/reports/nutrition.html.jinja');
+            expect(shown.templateLabel).to.equal('nutrition.html.jinja');
+            expect(shown.templateUri).to.equal('file:///ws/config/reports/nutrition.html.jinja');
+            expect(shown.inlineTemplateContent).to.equal(undefined);
+            expect(shown.outputFormat).to.equal(undefined);
+        });
+
+        it('passes an explicit outputFormat through for a templateUri tab', async () => {
+            const { tool, files, presenter } = createTool();
+            files.files.set('file:///ws/cost.jinja', 'TPL');
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            await invoke(tool, { templateUri: 'file:///ws/cost.jinja', recipeUri: 'file:///ws/cake.cook', show: true, outputFormat: 'text' });
+            expect(presenter.shown[0].outputFormat).to.equal('text');
+        });
+
+        it('opens a built-in tab under the built-in id when show is true', async () => {
+            const { tool, files, presenter } = createTool();
+            files.files.set('file:///ws/cake.cook', 'recipe');
+            await invoke(tool, { templateUri: 'builtin:shopping-list', recipeUri: 'file:///ws/cake.cook', show: true });
+            const shown = presenter.shown[0];
+            expect(shown.templateId).to.equal('builtin:shopping-list');
+            expect(shown.templateLabel).to.equal('Shopping List (built-in)');
+            expect(shown.templateUri).to.equal(undefined);
+            expect(shown.inlineTemplateContent).to.equal(undefined);
+        });
+
+        it('still opens the inline tab with markdown default for templateContent', async () => {
+            const { tool, files, presenter } = createTool();
+            files.files.set('file:///ws/cake.cook', 'r');
+            await invoke(tool, { templateContent: 'TPL', recipeUri: 'file:///ws/cake.cook', show: true });
+            const shown = presenter.shown[0];
+            expect(shown.templateId).to.equal('inline:renderTemplate');
+            expect(shown.templateLabel).to.equal('AI Template');
+            expect(shown.inlineTemplateContent).to.equal('TPL');
+            expect(shown.outputFormat).to.equal('markdown');
+        });
     });
 });

--- a/packages/cooklang/src/browser/render-template-tool.ts
+++ b/packages/cooklang/src/browser/render-template-tool.ts
@@ -15,12 +15,13 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import URI from '@theia/core/lib/common/uri';
-import { CooklangLanguageService, CooklangUri, ReportOutputFormat } from '../common';
+import { CooklangLanguageService, CooklangUri, ReportOutputFormat, ReportTemplates } from '../common';
 import { ReportConfigService } from './report-config-service';
 import { ReportPresenter } from './report-presenter';
 
 interface RenderTemplateArgs {
     templateContent?: string;
+    templateUri?: string;
     recipeUri?: string;
     show?: boolean;
     outputFormat?: ReportOutputFormat;
@@ -28,12 +29,30 @@ interface RenderTemplateArgs {
 }
 
 /**
+ * A template resolved from the tool arguments: its source plus the identity a
+ * Report tab needs to stay bound to it (workspace file, built-in, or inline).
+ */
+interface ResolvedTemplate {
+    content: string;
+    templateId: string;
+    templateLabel: string;
+    templateUri?: string;
+    inlineTemplateContent?: string;
+    /** Format to force on the tab; undefined lets the widget infer it from the file name. */
+    defaultOutputFormat?: ReportOutputFormat;
+}
+
+const BUILT_IN_PREFIX = 'builtin:';
+
+/**
  * AI tool that renders a Jinja2 report template against a `.cook`/`.menu` file
- * and returns `{ output }` or `{ error }`. Rendering is read-only, so the tool
- * auto-executes (no changeset/approval). Saving templates is handled separately
- * by the user-reviewed `suggestFileContent` tool.
+ * and returns `{ output }` or `{ error }`. The template is either inline
+ * (`templateContent`) or a reference (`templateUri`: a workspace `.jinja` file
+ * or a `builtin:*` id). Rendering is read-only, so the tool auto-executes (no
+ * changeset/approval). Saving templates is handled separately by the
+ * user-reviewed `suggestFileContent` tool.
  *
- * Kept free of `@theia/monaco` imports (recipe reads go through `FileService`;
+ * Kept free of `@theia/monaco` imports (file reads go through `FileService`;
  * the report tab goes through `ReportPresenter`) so it is unit-testable.
  */
 @injectable()
@@ -59,18 +78,30 @@ export class RenderTemplateTool implements ToolProvider {
             name: RenderTemplateTool.ID,
             displayName: 'Render Template',
             description: 'Render a Cooklang Jinja2 report template against a recipe (.cook) or menu (.menu) file and '
-                + 'return the rendered output. Use it to compute values (cost, nutrition, ingredient counts), to validate '
-                + 'a template you are authoring (inspect the error and fix it), or to present a finished report to the '
-                + 'user (set show=true). Available template context: `ingredients` (each with `.name`, `.quantity`), '
-                + '`metadata` (incl. `metadata.title`), and `scale`; filters include `aisled()`, `db()`, '
-                + '`excluding_pantry()`, `sort`, `titleize`, `default`. To save a template for reuse, write it as a '
-                + '`.jinja` file with the suggestFileContent tool (convention: config/reports/).',
+                + 'return the rendered output. Pass EXACTLY ONE of templateUri (a saved workspace template such as '
+                + '"config/reports/nutrition.md.jinja", or a built-in id like "builtin:shopping-list" — see '
+                + 'listReportTemplates) or templateContent (inline source while authoring or for a one-off report). '
+                + 'Prefer templateUri whenever a suitable template already exists: the Report tab then stays bound to '
+                + 'the file (re-renders on edit) and the file name decides markdown/html/text output. Use it to compute '
+                + 'values (cost, nutrition, ingredient counts), to validate a template you are authoring (inspect the '
+                + 'error and fix it), or to present a finished report to the user (set show=true). Available template '
+                + 'context: `ingredients` (each with `.name`, `.quantity`), `metadata` (incl. `metadata.title`), and '
+                + '`scale`; filters include `aisled()`, `db()`, `excluding_pantry()`, `sort`, `titleize`, `default`. '
+                + 'To save a template for reuse, write it as a `.jinja` file with the suggestFileContent tool '
+                + '(convention: config/reports/), then render it by templateUri once the user has applied it.',
             parameters: {
                 type: 'object',
                 properties: {
                     templateContent: {
                         type: 'string',
-                        description: 'The Jinja2 template source to render.',
+                        description: 'Inline Jinja2 template source. Mutually exclusive with templateUri.',
+                    },
+                    templateUri: {
+                        type: 'string',
+                        description: 'A saved template to render: a workspace-relative path to a .jinja/.j2/.jinja2 file '
+                            + '(e.g. "config/reports/cost.jinja"; absolute path or file:// URI also works), or a built-in id '
+                            + '("builtin:ingredients", "builtin:shopping-list"). Renders the file\'s saved content on disk. '
+                            + 'Mutually exclusive with templateContent.',
                     },
                     recipeUri: {
                         type: 'string',
@@ -85,14 +116,14 @@ export class RenderTemplateTool implements ToolProvider {
                     outputFormat: {
                         type: 'string',
                         enum: ['markdown', 'html', 'text'],
-                        description: "Display format when show is true: 'markdown', 'html', or 'text'. Default 'markdown'.",
+                        description: "Display format when show is true: 'markdown', 'html', or 'text'. Defaults to 'markdown' for "
+                            + 'templateContent, and to the format implied by the file name for templateUri.',
                     },
                     scale: {
                         type: 'number',
                         description: 'Recipe scale factor. Default 1.',
                     },
                 },
-                required: ['templateContent'],
             },
             handler: async (argString: string) => this.execute(argString),
         };
@@ -105,8 +136,16 @@ export class RenderTemplateTool implements ToolProvider {
         } catch {
             return this.fail('Invalid arguments: expected a JSON object.');
         }
-        if (!args.templateContent) {
-            return this.fail('templateContent is required.');
+        const hasContent = !!args.templateContent;
+        const hasUri = !!args.templateUri;
+        if (hasContent === hasUri) {
+            return this.fail('Pass exactly one of templateContent or templateUri.');
+        }
+        const template = args.templateContent
+            ? this.inlineTemplate(args.templateContent)
+            : await this.resolveTemplate(args.templateUri ?? '');
+        if ('error' in template) {
+            return this.fail(template.error);
         }
         let recipeUri: URI | undefined;
         if (args.recipeUri) {
@@ -133,7 +172,7 @@ export class RenderTemplateTool implements ToolProvider {
         const configJson = await this.reportConfigService.buildConfigJson(args.scale ?? 1, recipeUri);
         let resultJson: string;
         try {
-            resultJson = await this.languageService.renderReport(recipeContent, args.templateContent, configJson);
+            resultJson = await this.languageService.renderReport(recipeContent, template.content, configJson);
         } catch (e) {
             return this.fail(`Render failed: ${this.message(e)}`);
         }
@@ -143,10 +182,11 @@ export class RenderTemplateTool implements ToolProvider {
                 try {
                     await this.reportPresenter.show({
                         uri: recipeUri.toString(),
-                        templateId: 'inline:renderTemplate',
-                        templateLabel: 'AI Template',
-                        inlineTemplateContent: args.templateContent,
-                        outputFormat: args.outputFormat ?? 'markdown',
+                        templateId: template.templateId,
+                        templateLabel: template.templateLabel,
+                        templateUri: template.templateUri,
+                        inlineTemplateContent: template.inlineTemplateContent,
+                        outputFormat: args.outputFormat ?? template.defaultOutputFormat,
                         configJson,
                     });
                 } catch (e) {
@@ -156,6 +196,52 @@ export class RenderTemplateTool implements ToolProvider {
         }
         // renderReport already returns `{ output }` | `{ error }`; pass through.
         return resultJson;
+    }
+
+    protected inlineTemplate(content: string): ResolvedTemplate {
+        return {
+            content,
+            templateId: 'inline:renderTemplate',
+            templateLabel: 'AI Template',
+            inlineTemplateContent: content,
+            defaultOutputFormat: 'markdown',
+        };
+    }
+
+    /**
+     * Resolves `templateUri`: a `builtin:*` id, or a workspace-relative path /
+     * absolute path / file URI of a `.jinja|.j2|.jinja2` file read from disk.
+     */
+    protected async resolveTemplate(ref: string): Promise<ResolvedTemplate | { error: string }> {
+        if (ref.startsWith(BUILT_IN_PREFIX)) {
+            const builtIn = ReportTemplates.byId(ref);
+            if (!builtIn) {
+                const known = ReportTemplates.BUILT_IN.map(template => template.id).join(', ');
+                return { error: `Unknown built-in template '${ref}'. Known built-ins: ${known}.` };
+            }
+            return { content: builtIn.content, templateId: builtIn.id, templateLabel: builtIn.label };
+        }
+        const uri = this.reportConfigService.resolveWorkspaceUri(ref);
+        if (!uri) {
+            return {
+                error: `Could not resolve templateUri '${ref}': it is a relative path but no workspace is open. `
+                    + 'Pass a workspace-relative path, an absolute path, a file:// URI, or a builtin: id.',
+            };
+        }
+        if (!ReportTemplates.isTemplateFile(uri.path.base)) {
+            return { error: `templateUri must be a ${ReportTemplates.FILE_EXTENSIONS.join('/')} file, got: ${uri.path.base}` };
+        }
+        try {
+            const content = (await this.fileService.read(uri)).value;
+            return {
+                content,
+                templateId: `workspace:${uri.toString()}`,
+                templateLabel: uri.path.base,
+                templateUri: uri.toString(),
+            };
+        } catch (e) {
+            return { error: `Could not read template ${uri.toString()}: ${this.message(e)}` };
+        }
     }
 
     protected fail(message: string): string {

--- a/packages/cooklang/src/browser/render-template-tool.ts
+++ b/packages/cooklang/src/browser/render-template-tool.ts
@@ -110,7 +110,7 @@ export class RenderTemplateTool implements ToolProvider {
         }
         let recipeUri: URI | undefined;
         if (args.recipeUri) {
-            recipeUri = this.reportConfigService.resolveRecipeUri(args.recipeUri);
+            recipeUri = this.reportConfigService.resolveWorkspaceUri(args.recipeUri);
             if (!recipeUri) {
                 return this.fail(`Could not resolve recipeUri '${args.recipeUri}': it is a relative path but no workspace is open. `
                     + 'Pass a workspace-relative path, an absolute path, or a file:// URI.');

--- a/packages/cooklang/src/browser/render-template-tool.ts
+++ b/packages/cooklang/src/browser/render-template-tool.ts
@@ -100,7 +100,7 @@ export class RenderTemplateTool implements ToolProvider {
                         type: 'string',
                         description: 'A saved template to render: a workspace-relative path to a .jinja/.j2/.jinja2 file '
                             + '(e.g. "config/reports/cost.jinja"; absolute path or file:// URI also works), or a built-in id '
-                            + '("builtin:ingredients", "builtin:shopping-list"). Renders the file\'s saved content on disk. '
+                            + '("builtin:ingredients", "builtin:shopping-list"). Renders the file\'s saved content on disk (unsaved editor edits are not included). '
                             + 'Mutually exclusive with templateContent.',
                     },
                     recipeUri: {

--- a/packages/cooklang/src/browser/report-config-service.spec.ts
+++ b/packages/cooklang/src/browser/report-config-service.spec.ts
@@ -155,28 +155,28 @@ describe('ReportConfigService#buildConfigJson', () => {
     });
 });
 
-describe('ReportConfigService#resolveRecipeUri', () => {
+describe('ReportConfigService#resolveWorkspaceUri', () => {
 
     it('resolves a workspace-relative path against the workspace root', () => {
         const { service } = createService(new URI('file:///ws'));
-        const uri = service.resolveRecipeUri('Baking/Napoleon.cook');
+        const uri = service.resolveWorkspaceUri('Baking/Napoleon.cook');
         expect(uri?.toString()).to.equal('file:///ws/Baking/Napoleon.cook');
     });
 
     it('passes through a full file:// URI unchanged', () => {
         const { service } = createService(new URI('file:///ws'));
-        const uri = service.resolveRecipeUri('file:///elsewhere/cake.cook');
+        const uri = service.resolveWorkspaceUri('file:///elsewhere/cake.cook');
         expect(uri?.toString()).to.equal('file:///elsewhere/cake.cook');
     });
 
     it('treats an absolute filesystem path as a file URI', () => {
         const { service } = createService(new URI('file:///ws'));
-        const uri = service.resolveRecipeUri('/Users/me/recipes/cake.cook');
+        const uri = service.resolveWorkspaceUri('/Users/me/recipes/cake.cook');
         expect(uri?.toString()).to.equal('file:///Users/me/recipes/cake.cook');
     });
 
     it('returns undefined for a relative path when no workspace is open', () => {
         const { service } = createService(undefined);
-        expect(service.resolveRecipeUri('Baking/Napoleon.cook')).to.equal(undefined);
+        expect(service.resolveWorkspaceUri('Baking/Napoleon.cook')).to.equal(undefined);
     });
 });

--- a/packages/cooklang/src/browser/report-config-service.spec.ts
+++ b/packages/cooklang/src/browser/report-config-service.spec.ts
@@ -179,4 +179,10 @@ describe('ReportConfigService#resolveWorkspaceUri', () => {
         const { service } = createService(undefined);
         expect(service.resolveWorkspaceUri('Baking/Napoleon.cook')).to.equal(undefined);
     });
+
+    it('normalizes ./ and ../ segments in a relative path', () => {
+        const { service } = createService(new URI('file:///ws'));
+        expect(service.resolveWorkspaceUri('./config/reports/x.jinja')?.toString()).to.equal('file:///ws/config/reports/x.jinja');
+        expect(service.resolveWorkspaceUri('config/../config/reports/x.jinja')?.toString()).to.equal('file:///ws/config/reports/x.jinja');
+    });
 });

--- a/packages/cooklang/src/browser/report-config-service.ts
+++ b/packages/cooklang/src/browser/report-config-service.ts
@@ -104,10 +104,10 @@ export class ReportConfigService {
      */
     resolveWorkspaceUri(pathOrUri: string): URI | undefined {
         if (this.hasScheme(pathOrUri) || pathOrUri.startsWith('/')) {
-            return new URI(pathOrUri);
+            return new URI(pathOrUri).normalizePath();
         }
         const root = this.workspaceService.tryGetRoots()[0];
-        return root ? root.resource.resolve(pathOrUri) : undefined;
+        return root ? root.resource.resolve(pathOrUri).normalizePath() : undefined;
     }
 
     /** True when the string starts with a URI scheme like `file:`. */

--- a/packages/cooklang/src/browser/report-config-service.ts
+++ b/packages/cooklang/src/browser/report-config-service.ts
@@ -95,18 +95,19 @@ export class ReportConfigService {
     }
 
     /**
-     * Resolves a recipe URI supplied as a tool argument. Accepts a full URI
-     * string (e.g. `file:///…`), an absolute filesystem path, or — preferred —
-     * a path relative to the workspace root (e.g. `Baking/Napoleon.cook`).
-     * Relative paths are resolved against the first workspace root; returns
-     * `undefined` only when a relative path is given but no workspace is open.
+     * Resolves a file reference supplied as a tool argument (recipe or
+     * template). Accepts a full URI string (e.g. `file:///…`), an absolute
+     * filesystem path, or — preferred — a path relative to the workspace root
+     * (e.g. `Baking/Napoleon.cook`, `config/reports/cost.jinja`). Relative
+     * paths are resolved against the first workspace root; returns `undefined`
+     * only when a relative path is given but no workspace is open.
      */
-    resolveRecipeUri(recipeUriArg: string): URI | undefined {
-        if (this.hasScheme(recipeUriArg) || recipeUriArg.startsWith('/')) {
-            return new URI(recipeUriArg);
+    resolveWorkspaceUri(pathOrUri: string): URI | undefined {
+        if (this.hasScheme(pathOrUri) || pathOrUri.startsWith('/')) {
+            return new URI(pathOrUri);
         }
         const root = this.workspaceService.tryGetRoots()[0];
-        return root ? root.resource.resolve(recipeUriArg) : undefined;
+        return root ? root.resource.resolve(pathOrUri) : undefined;
     }
 
     /** True when the string starts with a URI scheme like `file:`. */

--- a/packages/cooklang/src/browser/report-contribution.ts
+++ b/packages/cooklang/src/browser/report-contribution.ts
@@ -17,13 +17,11 @@ import { MenuModelRegistry, MenuContribution } from '@theia/core/lib/common/menu
 import { QuickPickService, QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
 import { nls } from '@theia/core/lib/common/nls';
 import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
-import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
-import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-import URI from '@theia/core/lib/common/uri';
 import { ReportTemplates, BuiltInReportTemplate } from '../common';
 import { ReportWidgetOptions } from './report-widget-types';
 import { ReportConfigService } from './report-config-service';
 import { ReportPresenter } from './report-presenter';
+import { ReportTemplateFinder } from './report-template-finder';
 
 // ---------------------------------------------------------------------------
 // Commands
@@ -56,11 +54,8 @@ export class ReportContribution implements CommandContribution, MenuContribution
     @inject(QuickPickService)
     protected readonly quickPickService: QuickPickService;
 
-    @inject(FileSearchService)
-    protected readonly fileSearchService: FileSearchService;
-
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
+    @inject(ReportTemplateFinder)
+    protected readonly templateFinder: ReportTemplateFinder;
 
     @inject(ReportConfigService)
     protected readonly reportConfigService: ReportConfigService;
@@ -147,41 +142,14 @@ export class ReportContribution implements CommandContribution, MenuContribution
             : template.label;
     }
 
-    /**
-     * Finds template files (*.jinja|j2|jinja2) anywhere in the workspace via
-     * the ripgrep-backed file search (respects .gitignore).
-     */
+    /** Workspace templates as QuickPick entries; the finder does the searching. */
     protected async findWorkspaceTemplates(): Promise<ReportTemplatePick[]> {
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length === 0) {
-            return [];
-        }
-        let matches: string[];
-        try {
-            matches = await this.fileSearchService.find('', {
-                rootUris: roots.map(root => root.resource.toString()),
-                includePatterns: ReportTemplates.FILE_EXTENSIONS.map(ext => `**/*${ext}`),
-                useGitIgnore: true,
-                fuzzyMatch: false,
-                limit: 200,
-            });
-        } catch (error) {
-            console.warn('[cooklang] Report template search failed:', error);
-            return [];
-        }
-        return matches
-            .filter(match => ReportTemplates.isTemplateFile(match))
-            .map(match => {
-                const uri = new URI(match);
-                const root = roots.find(candidate => candidate.resource.isEqualOrParent(uri));
-                const parentDir = root ? root.resource.relative(uri.parent)?.toString() : undefined;
-                return {
-                    id: `workspace:${uri.toString()}`,
-                    label: uri.path.base,
-                    uri: uri.toString(),
-                    description: parentDir || undefined,
-                };
-            })
-            .sort((a, b) => a.label.localeCompare(b.label));
+        const templates = await this.templateFinder.findWorkspaceTemplates();
+        return templates.map(template => ({
+            id: template.id,
+            label: template.label,
+            uri: template.uri,
+            description: template.directory,
+        }));
     }
 }

--- a/packages/cooklang/src/browser/report-template-finder.spec.ts
+++ b/packages/cooklang/src/browser/report-template-finder.spec.ts
@@ -1,0 +1,114 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+// `ReportTemplateFinder` injects `WorkspaceService`, whose module evaluates
+// browser globals at require time. Set up jsdom before importing it — mirrors
+// the sibling `report-config-service.spec.ts`.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { ReportTemplateFinder } from './report-template-finder';
+
+after(() => disableJSDOM());
+
+class FakeFileSearchService {
+    results: string[] = [];
+    lastOptions: object | undefined;
+    throwError: Error | undefined;
+    async find(_pattern: string, options: object): Promise<string[]> {
+        this.lastOptions = options;
+        if (this.throwError) { throw this.throwError; }
+        return this.results;
+    }
+}
+
+class FakeWorkspaceService {
+    constructor(protected readonly root?: URI) { }
+    tryGetRoots(): Array<{ resource: URI }> {
+        return this.root ? [{ resource: this.root }] : [];
+    }
+}
+
+function createFinder(root: URI | undefined): { finder: ReportTemplateFinder; search: FakeFileSearchService } {
+    const finder = new ReportTemplateFinder();
+    const search = new FakeFileSearchService();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (finder as any).fileSearchService = search;
+    (finder as any).workspaceService = new FakeWorkspaceService(root);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return { finder, search };
+}
+
+describe('ReportTemplateFinder', () => {
+
+    it('returns an empty list when no workspace is open', async () => {
+        const { finder, search } = createFinder(undefined);
+        search.results = ['file:///ws/config/reports/cost.jinja'];
+        expect(await finder.findWorkspaceTemplates()).to.deep.equal([]);
+    });
+
+    it('maps search hits to workspace templates with relative path and directory, sorted by label', async () => {
+        const { finder, search } = createFinder(new URI('file:///ws'));
+        search.results = [
+            'file:///ws/config/reports/nutrition.md.jinja',
+            'file:///ws/config/reports/balanced-diet.jinja',
+            'file:///ws/root.j2',
+        ];
+        const templates = await finder.findWorkspaceTemplates();
+        expect(templates.map(t => t.label)).to.deep.equal(['balanced-diet.jinja', 'nutrition.md.jinja', 'root.j2']);
+        expect(templates[0]).to.deep.equal({
+            id: 'workspace:file:///ws/config/reports/balanced-diet.jinja',
+            label: 'balanced-diet.jinja',
+            uri: 'file:///ws/config/reports/balanced-diet.jinja',
+            path: 'config/reports/balanced-diet.jinja',
+            directory: 'config/reports',
+        });
+        expect(templates[2].path).to.equal('root.j2');
+        expect(templates[2].directory).to.equal(undefined);
+    });
+
+    it('drops hits that are not template files', async () => {
+        const { finder, search } = createFinder(new URI('file:///ws'));
+        search.results = ['file:///ws/notes.txt', 'file:///ws/cost.jinja'];
+        const templates = await finder.findWorkspaceTemplates();
+        expect(templates.map(t => t.label)).to.deep.equal(['cost.jinja']);
+    });
+
+    it('searches every template extension under the workspace roots, respecting .gitignore', async () => {
+        const { finder, search } = createFinder(new URI('file:///ws'));
+        await finder.findWorkspaceTemplates();
+        expect(search.lastOptions).to.deep.include({
+            rootUris: ['file:///ws'],
+            includePatterns: ['**/*.jinja', '**/*.j2', '**/*.jinja2'],
+            useGitIgnore: true,
+            fuzzyMatch: false,
+            limit: 200,
+        });
+    });
+
+    it('returns an empty list when the search fails', async () => {
+        const { finder, search } = createFinder(new URI('file:///ws'));
+        search.throwError = new Error('rg missing');
+        expect(await finder.findWorkspaceTemplates()).to.deep.equal([]);
+    });
+});

--- a/packages/cooklang/src/browser/report-template-finder.ts
+++ b/packages/cooklang/src/browser/report-template-finder.ts
@@ -1,0 +1,83 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import URI from '@theia/core/lib/common/uri';
+import { ReportTemplates } from '../common';
+
+/** A Jinja2 report template file found in the workspace. */
+export interface WorkspaceReportTemplate {
+    /** Report-tab template id: `workspace:<uri>`. */
+    id: string;
+    /** File basename, e.g. `balanced-diet.jinja`. */
+    label: string;
+    /** URI string of the template file. */
+    uri: string;
+    /** Workspace-relative path (`config/reports/balanced-diet.jinja`); undefined when outside every root. */
+    path?: string;
+    /** Workspace-relative parent directory (`config/reports`); undefined at the root or outside every root. */
+    directory?: string;
+}
+
+/**
+ * Finds report template files (*.jinja|j2|jinja2) anywhere in the workspace
+ * via the ripgrep-backed file search (respects .gitignore). Shared by the
+ * "Render Report" QuickPick and the `listReportTemplates` AI tool.
+ */
+@injectable()
+export class ReportTemplateFinder {
+
+    @inject(FileSearchService)
+    protected readonly fileSearchService: FileSearchService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    async findWorkspaceTemplates(): Promise<WorkspaceReportTemplate[]> {
+        const roots = this.workspaceService.tryGetRoots();
+        if (roots.length === 0) {
+            return [];
+        }
+        let matches: string[];
+        try {
+            matches = await this.fileSearchService.find('', {
+                rootUris: roots.map(root => root.resource.toString()),
+                includePatterns: ReportTemplates.FILE_EXTENSIONS.map(ext => `**/*${ext}`),
+                useGitIgnore: true,
+                fuzzyMatch: false,
+                limit: 200,
+            });
+        } catch (error) {
+            console.warn('[cooklang] Report template search failed:', error);
+            return [];
+        }
+        return matches
+            .filter(match => ReportTemplates.isTemplateFile(match))
+            .map(match => {
+                const uri = new URI(match);
+                const root = roots.find(candidate => candidate.resource.isEqualOrParent(uri));
+                const path = root ? root.resource.relative(uri)?.toString() : undefined;
+                const directory = root ? root.resource.relative(uri.parent)?.toString() : undefined;
+                return {
+                    id: `workspace:${uri.toString()}`,
+                    label: uri.path.base,
+                    uri: uri.toString(),
+                    path: path || undefined,
+                    directory: directory || undefined,
+                };
+            })
+            .sort((a, b) => a.label.localeCompare(b.label));
+    }
+}


### PR DESCRIPTION
Lets cookbot render saved report templates (and the two built-ins) by reference, and discover which templates exist — so it can present evaluations in the same workspace-bound Report tab the *Cooklang: Render Report…* command opens, instead of an ephemeral `inline:` tab that requires re-pasting the template source.

Spec/plan live in cook.md: `docs/superpowers/specs/2026-08-18-cookbot-report-rendering-design.md`, `docs/superpowers/plans/2026-08-18-cookbot-report-rendering.md`. Pairs with cook-md/cook-md#307 (cookbot prompts) — ship this first.

**Changes (`packages/cooklang`)**
- `renderTemplate`: new `templateUri` argument — workspace-relative path / absolute / `file://` to a `.jinja|.j2|.jinja2`, or `builtin:ingredients` / `builtin:shopping-list`. Exactly one of `templateContent` / `templateUri`. With `show:true` the tab is `workspace:<uri>` (label = filename, `templateUri` set, format inferred from the filename unless `outputFormat` given) so it is shared with the QuickPick's tab and live-re-renders on edit; built-ins open under their id; inline behaviour unchanged.
- New `listReportTemplates` tool → `{ templates: [{ path, uri, name, directory, outputFormat }], builtIn: [{ id, label }] }`, backed by a new `ReportTemplateFinder` extracted from `ReportContribution` (QuickPick behaviour unchanged).
- `ReportConfigService.resolveRecipeUri` → `resolveWorkspaceUri`, now `.normalizePath()`ed so `./config/reports/x.jinja` yields the same URI/tab id as the QuickPick.

**Verification**
- `npx lerna run compile|test|lint --scope @theia/cooklang`: 86 passing (63 baseline + 23), lint clean.
- `theia build --mode development` in `app/`: compiles.
- Not done here: launching the app and exercising the tools through cookbot chat (needs a Pro login) — see the checklist in the plan's Task 5/11.