### PR TITLE
fix: harden startup and keybinding paths against errors seen in alpha.38

### DIFF
--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -574,6 +574,19 @@ describe('keybindings', () => {
 
         disable();
     });
+
+    it('should ignore a keyboard event whose key cannot be determined', () => {
+        // Some layouts/IMEs deliver events with no usable `code`, `keyCode` or `keyIdentifier`.
+        // `KeyCode.createKeyCode` throws on those, and `run` is invoked straight from a `keydown`
+        // listener, so anything it throws escapes as an unhandled error.
+        const mockEvent = new KeyboardEvent('keydown', { key: 'Process' });
+        Object.defineProperty(mockEvent, 'code', { value: '' });
+        Object.defineProperty(mockEvent, 'keyCode', { value: 0 });
+        Object.defineProperty(mockEvent, 'target', { value: document.createElement('div') });
+
+        expect(() => KeyCode.createKeyCode(mockEvent)).to.throw();
+        expect(() => keybindingRegistry.run(mockEvent)).to.not.throw();
+    });
 });
 
 const TEST_COMMAND: Command = {

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -576,6 +576,9 @@ describe('keybindings', () => {
     });
 
     it('should ignore a keyboard event whose key cannot be determined', () => {
+        // Ensure JSDOM is enabled for this test since it uses KeyboardEvent and document
+        const disable = enableJSDOM();
+
         // Some layouts/IMEs deliver events with no usable `code`, `keyCode` or `keyIdentifier`.
         // `KeyCode.createKeyCode` throws on those, and `run` is invoked straight from a `keydown`
         // listener, so anything it throws escapes as an unhandled error.
@@ -586,6 +589,8 @@ describe('keybindings', () => {
 
         expect(() => KeyCode.createKeyCode(mockEvent)).to.throw();
         expect(() => keybindingRegistry.run(mockEvent)).to.not.throw();
+
+        disable();
     });
 });
 

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -645,7 +645,16 @@ export class KeybindingRegistry {
         }
 
         const eventDispatch = this.corePreferences['keyboard.dispatch'];
-        const keyCode = KeyCode.createKeyCode(event, eventDispatch);
+        let keyCode: KeyCode;
+        try {
+            keyCode = KeyCode.createKeyCode(event, eventDispatch);
+        } catch (e) {
+            /* Some keyboard layouts and IMEs produce events we cannot map to a key (no usable
+               `code`, `keyCode` or `keyIdentifier`). No keybinding can match such an event, so
+               drop it instead of throwing out of the `keydown` listener. */
+            console.debug('Ignoring a keyboard event with an undeterminable key.', e);
+            return;
+        }
         /* Keycode is only a modifier, next keycode will be modifier + key.
            Ignore this one.  */
         if (keyCode.isModifierOnly()) {

--- a/packages/core/src/common/resource.ts
+++ b/packages/core/src/common/resource.ts
@@ -212,14 +212,21 @@ export class DefaultResourceProvider {
      */
     async get(uri: URI): Promise<Resource> {
         const resolvers = this.resolversProvider.getContributions();
+        // Keep why each resolver declined: without it the rejection below says only that nothing
+        // handled the URI, which hides the actual failure (a provider that is not registered yet,
+        // a missing config directory, a permission error, ...) from logs and error reports.
+        const errors: unknown[] = [];
         for (const resolver of resolvers) {
             try {
                 return await resolver.resolve(uri);
             } catch (err) {
-                // no-op
+                errors.push(err);
             }
         }
-        return Promise.reject(new Error(`A resource provider for '${uri.toString()}' is not registered.`));
+        return Promise.reject(new Error(
+            `A resource provider for '${uri.toString()}' is not registered.`,
+            { cause: errors.length === 1 ? errors[0] : errors }
+        ));
     }
 
 }

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -387,10 +387,15 @@ export class ElectronMainApplication {
 
         const showWindowAndCloseSplashScreen = () => {
             cancelTokenSource.cancel();
-            if (!mainWindow.isVisible()) {
+            // The timers outlive the windows: if the user quits while the splash screen is up,
+            // both windows are already destroyed by the time `maxDuration` elapses and any call
+            // into them throws `Object has been destroyed`.
+            if (!mainWindow.isDestroyed() && !mainWindow.isVisible()) {
                 mainWindow.show();
             }
-            splashScreenWindow.close();
+            if (!splashScreenWindow.isDestroyed()) {
+                splashScreenWindow.close();
+            }
         };
         TheiaRendererAPI.onApplicationStateChanged(mainWindow.webContents, state => {
             if (state === 'ready') {

--- a/packages/monaco/src/browser/monaco-resolved-keybinding.ts
+++ b/packages/monaco/src/browser/monaco-resolved-keybinding.ts
@@ -77,7 +77,11 @@ export class MonacoResolvedKeybinding extends ResolvedKeybinding {
     }
 
     getDispatchChords(): (string | null)[] {
-        return this.keySequence.map(keyCode => USLayoutResolvedKeybinding.getDispatchStr(this.toKeybinding(keyCode)));
+        return this.keySequence.map(keyCode => {
+            const chord = this.toKeybinding(keyCode);
+            // eslint-disable-next-line no-null/no-null
+            return chord ? USLayoutResolvedKeybinding.getDispatchStr(chord) : null;
+        });
     }
 
     getSingleModifierDispatchChords(): (SingleModifierChord | null)[] {
@@ -103,13 +107,21 @@ export class MonacoResolvedKeybinding extends ResolvedKeybinding {
         return null; // eslint-disable-line no-null/no-null
     }
 
-    private toKeybinding(keyCode: KeyCode): KeyCodeChord {
+    /**
+     * `undefined` for a modifier-only chord: `KeyCode.createKeyCode` deliberately leaves `key`
+     * unset for those (see `KeyCode` in `@theia/core`), so there is no key code to map. Callers
+     * must not assume a chord is always produced, cf. `getSingleModifierDispatchPart` above.
+     */
+    private toKeybinding(keyCode: KeyCode): KeyCodeChord | undefined {
+        if (keyCode.key?.keyCode === undefined) {
+            return undefined;
+        }
         return new KeyCodeChord(
             keyCode.ctrl,
             keyCode.shift,
             keyCode.alt,
             keyCode.meta,
-            KEY_CODE_MAP[keyCode.key!.keyCode]
+            KEY_CODE_MAP[keyCode.key.keyCode]
         );
     }
 

--- a/packages/toolbar/src/browser/toolbar-storage-provider.ts
+++ b/packages/toolbar/src/browser/toolbar-storage-provider.ts
@@ -77,7 +77,12 @@ export class ToolbarStorageProvider implements Disposable {
 
     @postConstruct()
     protected init(): void {
-        this.doInit();
+        // Not awaited on purpose (`@postConstruct` must stay synchronous), so the rejection has to
+        // be handled here: without a toolbar config the toolbar falls back to its defaults, which
+        // is not worth surfacing as an unhandled rejection.
+        this.doInit().catch(e => {
+            console.error(`Failed to initialize the toolbar configuration from '${this.USER_TOOLBAR_URI}'.`, e);
+        });
     }
 
     protected async doInit(): Promise<void> {


### PR DESCRIPTION
Fixes the five real issues [Sentry](https://cooklang-va.sentry.io/issues/?project=4511898607091712) reported against `0.1.0-alpha.38` in the first hours of telemetry from real users. All were unhandled errors, none crashed the app.

| Issue | Error | Events |
|---|---|---|
| [EDITOR-2](https://cooklang-va.sentry.io/issues/EDITOR-2) | `TypeError: Object has been destroyed` | 3 |
| [EDITOR-3](https://cooklang-va.sentry.io/issues/EDITOR-3) | `A resource provider for 'user-storage:/user/toolbar.json' is not registered` | 2 |
| [EDITOR-4](https://cooklang-va.sentry.io/issues/EDITOR-4) / [EDITOR-6](https://cooklang-va.sentry.io/issues/EDITOR-6) | `Cannot read properties of undefined (reading 'keyCode')` | 2 |
| [EDITOR-5](https://cooklang-va.sentry.io/issues/EDITOR-5) | `Cannot get key code from the keyboard event` | 1 |

### Splash screen — EDITOR-2

The `maxDuration` timer outlives the windows it closes. Quitting during startup destroys both windows, and `splashScreenWindow.close()` then throws. Guarded with `isDestroyed()` — including `mainWindow.isVisible()` on the same path, which fails the same way; the reported frame was just whichever ran first.

### Monaco keybinding dispatch — EDITOR-4 / EDITOR-6

`KeyCode.createKeyCode` deliberately leaves `key` unset for modifier-only chords, so the `keyCode.key!` assertion in `toKeybinding` is not sound. It now returns `undefined` and `getDispatchChords` emits `null`, which its `(string | null)[]` signature already allows — the same handling `getSingleModifierDispatchPart` directly above it already applies to this case.

### Keybinding registry — EDITOR-5

Some layouts and IMEs deliver events with no usable `code`, `keyCode` or `keyIdentifier`. `KeyCode.createKeyCode` throws on those, and `KebindingRegistry.run` is called straight from a `keydown` listener, so the error escapes unhandled. No keybinding can match such an event, so it is dropped. Both EDITOR-5 and EDITOR-4/6 came from one user in France on Windows 10 within the same second — likely one keypress hitting two listeners.

### Toolbar storage — EDITOR-3

`@postConstruct init()` left `doInit()` floating, so a failure to resolve the config surfaced as an unhandled rejection; it is now handled (the toolbar already falls back to its defaults).

`DefaultResourceProvider.get` also swallowed every resolver error before reporting that nothing handled the URI — which is why the Sentry report says nothing about the underlying cause. They are now attached as the error's `cause`.

**This is the part I am least confident about.** The catch makes the symptom benign and the next occurrence diagnosable, but it does not fix *why* the `user-storage:` provider was unavailable at that moment. That needs the cause data this PR adds.

## Verification

- `lerna run compile` passes for `@theia/core`, `@theia/monaco`, `@theia/toolbar`; `eslint` clean on all touched files.
- Both root causes confirmed empirically against the compiled code — a modifier-only event yields `key === undefined`, and an event with no usable `code`/`keyCode` throws out of `createKeyCode`.
- Added a regression test in `keybinding.spec.ts` for the unmappable-event case.

⚠️ **The test suite was not run.** This machine has Node 20.11.1 and the repo requires ≥ 22, so mocha refuses to start. The new test is type-checked and compiles but has never executed — please confirm CI is green before merging.

The splash-screen and toolbar fixes are defensive guards validated by inspection; neither race was reproduced locally.
