### PR TITLE
Sync gated on entitlement; payment_required status; upgrade flow

### DIFF
--- a/packages/cooklang-account/package.json
+++ b/packages/cooklang-account/package.json
@@ -23,6 +23,7 @@
     "clean": "theiaext clean",
     "compile": "theiaext compile",
     "lint": "theiaext lint",
+    "test": "theiaext test",
     "watch": "theiaext watch"
   },
   "devDependencies": {

--- a/packages/cooklang-account/src/browser/account-widget.spec.ts
+++ b/packages/cooklang-account/src/browser/account-widget.spec.ts
@@ -1,0 +1,284 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import * as React from 'react';
+import { AccountWidget } from './account-widget';
+import { SubscriptionState } from '../common/subscription-protocol';
+import { SyncStatus } from '../common/sync-protocol';
+
+after(() => disableJSDOM());
+
+/** Recursively collects every React element in `node` matching `predicate`. */
+function collect(node: React.ReactNode, predicate: (el: React.ReactElement) => boolean, out: React.ReactElement[] = []): React.ReactElement[] {
+    // eslint-disable-next-line no-null/no-null
+    if (node === null || node === undefined || typeof node !== 'object') {
+        return out;
+    }
+    if (Array.isArray(node)) {
+        node.forEach(child => collect(child, predicate, out));
+        return out;
+    }
+    if (React.isValidElement(node)) {
+        if (predicate(node)) {
+            out.push(node);
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const children = (node.props as any)?.children;
+        if (children !== undefined) {
+            collect(children, predicate, out);
+        }
+    }
+    return out;
+}
+
+/** Flattens all text content under `node` (mirrors what a viewer would read). */
+function textContent(node: React.ReactNode): string {
+    // eslint-disable-next-line no-null/no-null
+    if (node === null || node === undefined || typeof node === 'boolean') {
+        return '';
+    }
+    if (typeof node === 'string' || typeof node === 'number') {
+        return String(node);
+    }
+    if (Array.isArray(node)) {
+        return node.map(textContent).join('');
+    }
+    if (React.isValidElement(node)) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return textContent((node.props as any)?.children);
+    }
+    return '';
+}
+
+function makeSubscription(features: string[]): SubscriptionState {
+    return {
+        status: 'active',
+        hasAccess: true,
+        features,
+        planName: 'Cook Pro',
+        aiCreditsRemaining: 100,
+        billingPeriodEnd: undefined,
+    };
+}
+
+function createWidget(syncStatus: SyncStatus): AccountWidget {
+    const widget = new AccountWidget();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (widget as any).syncStatus = syncStatus;
+    return widget;
+}
+
+function renderSyncSection(widget: AccountWidget, subscription: SubscriptionState): React.ReactNode {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (widget as any).renderSyncSection(subscription, 'Idle');
+}
+
+const IDLE_STATUS: SyncStatus = { status: 'idle', lastSyncedAt: undefined, error: undefined };
+
+describe('AccountWidget sync section gating', () => {
+
+    it('renders the live toggle unchanged when the plan includes sync', () => {
+        const widget = createWidget(IDLE_STATUS);
+        const tree = renderSyncSection(widget, makeSubscription(['sync', 'ai']));
+
+        expect(collect(tree, el => el.props.className === 'theia-account-sync-toggle')).to.have.length(1);
+        expect(textContent(tree)).to.not.include('Cook Basic');
+        expect(textContent(tree)).to.not.include('Sync needs a plan');
+    });
+
+    it('locks the section behind an Upgrade button when the plan lacks sync', () => {
+        const widget = createWidget(IDLE_STATUS);
+        const tree = renderSyncSection(widget, makeSubscription([]));
+
+        expect(collect(tree, el => el.props.className === 'theia-account-sync-toggle')).to.have.length(0);
+        expect(textContent(tree)).to.include('Sync runs on our servers');
+        expect(textContent(tree)).to.include('Cook Basic');
+
+        const buttons = collect(tree, el => el.type === 'button');
+        expect(buttons).to.have.length(1);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(buttons[0].props.onClick).to.equal((widget as any).handleUpgrade);
+    });
+
+    it('shows "Sync needs a plan" (not the generic error row) when the native status is payment_required, even though the plan lists sync', () => {
+        const widget = createWidget({ status: 'payment_required', lastSyncedAt: undefined, error: 'raw sync error text' });
+        const tree = renderSyncSection(widget, makeSubscription(['sync']));
+
+        expect(collect(tree, el => el.props.className === 'theia-account-sync-toggle')).to.have.length(0);
+        expect(textContent(tree)).to.include('Sync needs a plan');
+        expect(textContent(tree)).to.not.include('raw sync error text');
+
+        const buttons = collect(tree, el => el.type === 'button');
+        expect(buttons).to.have.length(2);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(buttons[0].props.onClick).to.equal((widget as any).handleUpgrade);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(buttons[1].props.onClick).to.equal((widget as any).restartSync);
+    });
+
+    it('prefers the locked-plan view over payment_required when both apply', () => {
+        // features lacks 'sync' AND the runtime status is payment_required —
+        // the plan gate should win since there is nothing to "need a plan"
+        // for beyond what upgrading already offers.
+        const widget = createWidget({ status: 'payment_required', lastSyncedAt: undefined, error: undefined });
+        const tree = renderSyncSection(widget, makeSubscription([]));
+
+        expect(textContent(tree)).to.include('Cook Basic');
+    });
+});
+
+describe('AccountWidget upgrade flow reuse', () => {
+
+    class FakeSubscriptionFrontendService {
+        startUpgradeFlowCalls = 0;
+        refreshCalls = 0;
+        awaitResult: { status: 'ok' | 'cancelled' } = { status: 'ok' };
+        async startUpgradeFlow(): Promise<string> {
+            this.startUpgradeFlowCalls++;
+            return 'https://cook.md/pricing?callback=...';
+        }
+        async awaitUpgradeCallback(): Promise<{ status: 'ok' | 'cancelled' }> {
+            return this.awaitResult;
+        }
+        async refresh(): Promise<void> {
+            this.refreshCalls++;
+        }
+    }
+
+    class FakeWindowService {
+        openedUrls: string[] = [];
+        openNewWindow(url: string): void {
+            this.openedUrls.push(url);
+        }
+    }
+
+    class FakeSyncService {
+        enableSyncCalls = 0;
+        status: SyncStatus = { status: 'idle', lastSyncedAt: undefined, error: undefined };
+        async enableSync(): Promise<void> {
+            this.enableSyncCalls++;
+            this.status = { status: 'idle', lastSyncedAt: undefined, error: undefined };
+        }
+        async disableSync(): Promise<void> { /* unused in these tests */ }
+        async isSyncEnabled(): Promise<boolean> {
+            return true;
+        }
+        async getSyncStatus(): Promise<SyncStatus> {
+            return this.status;
+        }
+    }
+
+    it('the locked sync section\'s Upgrade button drives the same startUpgradeFlow/refresh cycle as the AI upgrade CTA', async () => {
+        const widget = createWidget(IDLE_STATUS);
+        const subscriptionFrontendService = new FakeSubscriptionFrontendService();
+        const windowService = new FakeWindowService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).subscriptionFrontendService = subscriptionFrontendService;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).windowService = windowService;
+
+        const tree = renderSyncSection(widget, makeSubscription([]));
+        const [button] = collect(tree, el => el.type === 'button');
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (button.props as any).onClick();
+
+        expect(subscriptionFrontendService.startUpgradeFlowCalls).to.equal(1);
+        expect(windowService.openedUrls).to.have.length(1);
+        expect(subscriptionFrontendService.refreshCalls).to.equal(1);
+    });
+
+    it('restarts native sync after an upgrade resolves a payment_required state (post-payment dead-end fix)', async () => {
+        const widget = createWidget({ status: 'payment_required', lastSyncedAt: undefined, error: undefined });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).syncEnabled = true;
+        const subscriptionFrontendService = new FakeSubscriptionFrontendService();
+        const windowService = new FakeWindowService();
+        const syncService = new FakeSyncService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).subscriptionFrontendService = subscriptionFrontendService;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).windowService = windowService;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).syncService = syncService;
+
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (widget as any).handleUpgrade();
+
+            expect(subscriptionFrontendService.refreshCalls).to.equal(1);
+            expect(syncService.enableSyncCalls).to.equal(
+                1,
+                'resolving payment_required must restart the native sync task, not just refresh subscription features'
+            );
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (widget as any).stopSyncPolling();
+        }
+    });
+
+    it('does not restart sync on a plain upgrade that was never payment_required', async () => {
+        const widget = createWidget(IDLE_STATUS);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).syncEnabled = true;
+        const subscriptionFrontendService = new FakeSubscriptionFrontendService();
+        const windowService = new FakeWindowService();
+        const syncService = new FakeSyncService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).subscriptionFrontendService = subscriptionFrontendService;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).windowService = windowService;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).syncService = syncService;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (widget as any).handleUpgrade();
+
+        expect(subscriptionFrontendService.refreshCalls).to.equal(1);
+        expect(syncService.enableSyncCalls).to.equal(0);
+    });
+
+    it('the "Retry sync" button in the needs-plan view restarts sync directly, for a payment made outside the in-app flow', async () => {
+        const widget = createWidget({ status: 'payment_required', lastSyncedAt: undefined, error: undefined });
+        const syncService = new FakeSyncService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).syncService = syncService;
+
+        const tree = renderSyncSection(widget, makeSubscription(['sync']));
+        const buttons = collect(tree, el => el.type === 'button');
+        expect(buttons).to.have.length(2);
+        const retryButton = buttons[1];
+
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (retryButton.props as any).onClick();
+
+            expect(syncService.enableSyncCalls).to.equal(1);
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (widget as any).stopSyncPolling();
+        }
+    });
+});

--- a/packages/cooklang-account/src/browser/account-widget.tsx
+++ b/packages/cooklang-account/src/browser/account-widget.tsx
@@ -181,7 +181,7 @@ export class AccountWidget extends ReactWidget {
                     ? this.renderSubscriptionLoading()
                     : subscription.hasAccess
                         ? this.renderSubscriptionActive(subscription)
-                        : this.renderSubscriptionUpgrade()
+                        : this.renderSubscriptionUpgrade(subscription)
                 }
             </div>
         );
@@ -211,7 +211,7 @@ export class AccountWidget extends ReactWidget {
                     <span className='theia-account-row-label'>{nls.localize('theia/cooklang-account/manageSubscription', 'Manage Subscription')}</span>
                 </div>
                 {subscription.features.includes('ai') && this.renderAiCreditsSection(subscription)}
-                {this.renderSyncSection(statusLabel)}
+                {this.renderSyncSection(subscription, statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
                     <i className='codicon codicon-sign-out' />
@@ -221,7 +221,13 @@ export class AccountWidget extends ReactWidget {
         );
     }
 
-    protected renderSyncSection(statusLabel: string): React.ReactNode {
+    protected renderSyncSection(subscription: SubscriptionState, statusLabel: string): React.ReactNode {
+        if (!subscription.features.includes('sync')) {
+            return this.renderSyncLocked();
+        }
+        if (this.syncStatus.status === 'payment_required') {
+            return this.renderSyncNeedsPlan();
+        }
         return (
             <React.Fragment>
                 <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/syncHeader', 'CookCloud Sync')}</div>
@@ -256,6 +262,67 @@ export class AccountWidget extends ReactWidget {
         );
     }
 
+    /**
+     * Rendered instead of the toggle when the current plan doesn't include
+     * the `sync` feature (mirrors the AI block's `features.includes('ai')`
+     * gate in {@link renderSubscriptionActive}). No price is named here —
+     * that lives on the pricing page the Upgrade button opens.
+     */
+    protected renderSyncLocked(): React.ReactNode {
+        return (
+            <React.Fragment>
+                <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/syncHeader', 'CookCloud Sync')}</div>
+                <div className='theia-account-upgrade-section'>
+                    <div className='theia-account-upgrade-message'>
+                        {nls.localize('theia/cooklang-account/syncLockedMessage', 'Sync runs on our servers — part of Cook Basic')}
+                    </div>
+                    <button
+                        className='theia-button main theia-account-upgrade-button'
+                        onClick={this.handleUpgrade}
+                    >
+                        {nls.localizeByDefault('Upgrade')}
+                    </button>
+                </div>
+            </React.Fragment>
+        );
+    }
+
+    /**
+     * Rendered instead of the toggle/status rows when the native sync client
+     * reports `payment_required` — the entitlement lapsed while sync was
+     * already on (an HTTP 402 from the sync server). Deliberately not the
+     * generic error row: this is a known, actionable state, not a failure.
+     *
+     * Two ways out, both wired to {@link restartSync}: Upgrade drives the
+     * in-app checkout flow (which restarts sync itself once the callback
+     * resolves — see {@link handleUpgrade}); "Retry sync" is for a user who
+     * paid in a plain browser tab with no callback round-trip to notice.
+     */
+    protected renderSyncNeedsPlan(): React.ReactNode {
+        return (
+            <React.Fragment>
+                <div className='theia-account-section-header'>{nls.localize('theia/cooklang-account/syncHeader', 'CookCloud Sync')}</div>
+                <div className='theia-account-upgrade-section'>
+                    <div className='theia-account-upgrade-message theia-account-sync-error'>
+                        {nls.localize('theia/cooklang-account/syncNeedsPlanMessage', 'Sync needs a plan')}
+                    </div>
+                    <button
+                        className='theia-button main theia-account-upgrade-button'
+                        onClick={this.handleUpgrade}
+                    >
+                        {nls.localizeByDefault('Upgrade')}
+                    </button>
+                    <button
+                        className='theia-button secondary theia-account-sync-retry-button'
+                        onClick={this.restartSync}
+                    >
+                        {nls.localize('theia/cooklang-account/syncRetryButton', 'Retry sync')}
+                    </button>
+                </div>
+            </React.Fragment>
+        );
+    }
+
     protected renderAiCreditsSection(subscription: SubscriptionState): React.ReactNode {
         const credits = subscription.aiCreditsRemaining;
         const creditsClass = credits <= 0
@@ -285,7 +352,7 @@ export class AccountWidget extends ReactWidget {
         );
     }
 
-    protected renderSubscriptionUpgrade(): React.ReactNode {
+    protected renderSubscriptionUpgrade(subscription: SubscriptionState): React.ReactNode {
         const statusLabel = this.syncStatus.status.charAt(0).toUpperCase() + this.syncStatus.status.slice(1);
         return (
             <React.Fragment>
@@ -301,7 +368,7 @@ export class AccountWidget extends ReactWidget {
                         {nls.localize('theia/cooklang-account/upgradeButton', 'Upgrade to Pro')}
                     </button>
                 </div>
-                {this.renderSyncSection(statusLabel)}
+                {this.renderSyncSection(subscription, statusLabel)}
                 <div className='theia-account-divider' />
                 <div className='theia-account-row theia-account-row-interactive' onClick={this.handleLogout}>
                     <i className='codicon codicon-sign-out' />
@@ -377,12 +444,37 @@ export class AccountWidget extends ReactWidget {
         try {
             const result = await this.subscriptionFrontendService.awaitUpgradeCallback();
             if (result.status === 'ok') {
+                // Capture before refresh(): refreshing subscription features
+                // (which will now include 'sync') doesn't touch the native
+                // sync task — it already stopped itself on the 402 — so
+                // resolving payment_required needs an explicit restart.
+                const needsSyncRestart = this.syncEnabled && this.syncStatus.status === 'payment_required';
                 await this.subscriptionFrontendService.refresh();
+                if (needsSyncRestart) {
+                    await this.restartSync();
+                }
             }
         } catch (err) {
             // Timeout, state mismatch, or superseded flow — user can retry.
             console.warn('Upgrade flow did not complete:', err);
         }
+    };
+
+    /**
+     * Restarts the native sync task via the same `enableSync()` path the
+     * toggle uses (see {@link handleSyncToggle}). Used after an upgrade
+     * resolves a `payment_required` state, and by the "Retry sync" button in
+     * {@link renderSyncNeedsPlan}.
+     */
+    private restartSync = async (): Promise<void> => {
+        try {
+            await this.syncService.enableSync();
+            await this.refreshSyncStatus();
+            this.startSyncPolling();
+        } catch (err) {
+            console.error('Failed to restart sync:', err);
+        }
+        this.update();
     };
 
 }

--- a/packages/cooklang-account/src/common/sync-protocol.ts
+++ b/packages/cooklang-account/src/common/sync-protocol.ts
@@ -15,7 +15,7 @@ export const SyncServicePath = '/services/cooked-sync';
 export const SyncService = Symbol('SyncService');
 
 export interface SyncStatus {
-    status: 'idle' | 'syncing' | 'indexing' | 'downloading' | 'uploading' | 'error' | 'stopped';
+    status: 'idle' | 'syncing' | 'indexing' | 'downloading' | 'uploading' | 'error' | 'stopped' | 'payment_required';
     lastSyncedAt: string | undefined;
     error: string | undefined;
 }

--- a/packages/cooklang-account/src/node/sync-service.spec.ts
+++ b/packages/cooklang-account/src/node/sync-service.spec.ts
@@ -1,0 +1,77 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { SyncServiceImpl } from './sync-service';
+import { SyncStatus } from '../common/sync-protocol';
+
+/** Stands in for the `@theia/cooklang-native` addon without requiring a build. */
+class FakeNativeModule {
+    callback: ((json: string) => void) | undefined;
+    onSyncStatusChanged(cb: (json: string) => void): void {
+        this.callback = cb;
+    }
+}
+
+class FakeAuthService {
+    logoutCalls = 0;
+    async logout(): Promise<void> {
+        this.logoutCalls++;
+    }
+    async getToken(): Promise<string | undefined> {
+        return undefined;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onDidChangeAuth(): any {
+        return { dispose: () => { /* no-op */ } };
+    }
+}
+
+function createService(): { service: SyncServiceImpl; native: FakeNativeModule; auth: FakeAuthService } {
+    const service = new SyncServiceImpl();
+    const native = new FakeNativeModule();
+    const auth = new FakeAuthService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).nativeModule = native;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).authService = auth;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).syncEnabled = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).registerNativeCallback();
+    return { service, native, auth };
+}
+
+describe('SyncServiceImpl native status passthrough', () => {
+
+    it('passes a payment_required status straight through to onDidChangeSyncStatus', () => {
+        const { service, native } = createService();
+        const events: SyncStatus[] = [];
+        service.onDidChangeSyncStatus(status => events.push(status));
+
+        // eslint-disable-next-line no-null/no-null
+        native.callback!(JSON.stringify({ status: 'payment_required', lastError: null, lastSynced: null }));
+
+        expect(events).to.have.length(1);
+        expect(events[0]).to.deep.equal({ status: 'payment_required', lastSyncedAt: undefined, error: undefined });
+    });
+
+    it('never logs out in response to any sync status, including payment_required and error', async () => {
+        const { native, auth } = createService();
+        for (const status of ['error', 'payment_required', 'idle', 'syncing']) {
+            // eslint-disable-next-line no-null/no-null
+            native.callback!(JSON.stringify({ status, lastError: 'boom', lastSynced: null }));
+        }
+        expect(auth.logoutCalls).to.equal(0);
+    });
+});

--- a/packages/cooklang-native/Cargo.lock
+++ b/packages/cooklang-native/Cargo.lock
@@ -506,9 +506,8 @@ dependencies = [
 
 [[package]]
 name = "cooklang-sync-client"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091a9790342274289a9a9db9a6441488a364323a31312ef040e925a80095e9cc"
+version = "0.5.1"
+source = "git+https://github.com/cooklang/cooklang-sync?rev=3464309f8799732f765fc1d99a01a310cbba3df7#3464309f8799732f765fc1d99a01a310cbba3df7"
 dependencies = [
  "async-stream",
  "base64",

--- a/packages/cooklang-native/Cargo.toml
+++ b/packages/cooklang-native/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 cooklang-language-server = { path = "../../../cooklang-language-server" }
-cooklang-sync-client = "0.5"
+cooklang-sync-client = { git = "https://github.com/cooklang/cooklang-sync", rev = "3464309f8799732f765fc1d99a01a310cbba3df7" }
 chrono = "0.4"
 cookmd-nutrition-client = { version = "0.1", optional = true }
 cooklang-reports-nutrition = { version = "0.1", optional = true }

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -64,6 +64,90 @@ fn notify_js_callback(state: &SyncStatusState) {
     }
 }
 
+/// True when `message` is the stringified form of a sync failure caused by a
+/// lapsed/missing sync entitlement (the server's HTTP 402 response), as
+/// surfaced by `cooklang_sync_client::SyncError::PaymentRequired`.
+///
+/// This has to match on text because `SyncStatusListener::on_complete` only
+/// gives us a `String` (built with `format!("{:?}", err)` — see `start_sync`
+/// below and `cooklang_sync_client::run_async`). Every call site propagates
+/// `SyncError::PaymentRequired` unchanged (pinned rev
+/// 3464309f8799732f765fc1d99a01a310cbba3df7 fixed `syncer::download_loop`,
+/// which used to re-wrap it into `SyncError::Unknown(format!("Check download
+/// failed: {e}"))`, losing the variant on the very call that usually hits the
+/// server first), so `message` today is just the Debug'd variant name
+/// "PaymentRequired".
+///
+/// The direct forms are matched by *exact* (trimmed) equality, not
+/// substring — an unrelated error whose message merely contains
+/// "PaymentRequired" (e.g. an `IoError` on a file or folder path literally
+/// named that) must not paywall the sync UI. The wrapped-prefix check is
+/// kept as a narrow, `.contains`-based fallback for the one known shape a
+/// future regression could reintroduce: `Unknown(format!("Check download
+/// failed: {e}"))`, which embeds `PaymentRequired`'s `Display` text
+/// ("Sync requires a paid plan") after that fixed prefix.
+fn is_payment_required_error(message: &str) -> bool {
+    const WRAPPED_PREFIX: &str = "Check download failed: Sync requires a paid plan";
+    let trimmed = message.trim();
+    trimmed == "PaymentRequired" || trimmed == "Sync requires a paid plan" || message.contains(WRAPPED_PREFIX)
+}
+
+impl SyncStatusState {
+    /// Applies a `SyncStatusListener::on_status_changed` event, mirroring the
+    /// mapping `NapiSyncStatusListener` sends to JS. Split out from the trait
+    /// impl so it can be unit-tested without going through
+    /// `notify_js_callback` (whose `ThreadsafeFunction::call` needs the real
+    /// napi runtime and can't link in a plain `cargo test` binary).
+    fn apply_status_changed(&mut self, status: cooklang_sync_client::SyncStatus) {
+        match status {
+            cooklang_sync_client::SyncStatus::Idle => {
+                self.status = "idle".to_string();
+            }
+            cooklang_sync_client::SyncStatus::Syncing => {
+                self.status = "syncing".to_string();
+            }
+            cooklang_sync_client::SyncStatus::Indexing => {
+                self.status = "indexing".to_string();
+            }
+            cooklang_sync_client::SyncStatus::Downloading => {
+                self.status = "downloading".to_string();
+            }
+            cooklang_sync_client::SyncStatus::Uploading => {
+                self.status = "uploading".to_string();
+            }
+            cooklang_sync_client::SyncStatus::Error { message } => {
+                if is_payment_required_error(&message) {
+                    self.status = "payment_required".to_string();
+                    self.last_error = None;
+                } else {
+                    self.status = "error".to_string();
+                    self.last_error = Some(message);
+                }
+            }
+        }
+    }
+
+    /// Applies a `SyncStatusListener::on_complete` event. See
+    /// `apply_status_changed` for why this is a plain method rather than
+    /// living directly in the trait impl.
+    fn apply_complete(&mut self, success: bool, message: Option<String>) {
+        if success {
+            self.status = "idle".to_string();
+            self.last_error = None;
+            self.last_synced = Some(chrono::Utc::now().to_rfc3339());
+        } else {
+            let message = message.unwrap_or_else(|| "Sync failed".to_string());
+            if is_payment_required_error(&message) {
+                self.status = "payment_required".to_string();
+                self.last_error = None;
+            } else {
+                self.status = "error".to_string();
+                self.last_error = Some(message);
+            }
+        }
+    }
+}
+
 /// Listener that receives callbacks from `cooklang-sync-client` and updates
 /// the shared `SyncStatusState`, then notifies the JS callback.
 struct NapiSyncStatusListener {
@@ -73,40 +157,13 @@ struct NapiSyncStatusListener {
 impl cooklang_sync_client::SyncStatusListener for NapiSyncStatusListener {
     fn on_status_changed(&self, status: cooklang_sync_client::SyncStatus) {
         let mut state = self.state.lock().unwrap();
-        match status {
-            cooklang_sync_client::SyncStatus::Idle => {
-                state.status = "idle".to_string();
-            }
-            cooklang_sync_client::SyncStatus::Syncing => {
-                state.status = "syncing".to_string();
-            }
-            cooklang_sync_client::SyncStatus::Indexing => {
-                state.status = "indexing".to_string();
-            }
-            cooklang_sync_client::SyncStatus::Downloading => {
-                state.status = "downloading".to_string();
-            }
-            cooklang_sync_client::SyncStatus::Uploading => {
-                state.status = "uploading".to_string();
-            }
-            cooklang_sync_client::SyncStatus::Error { message } => {
-                state.status = "error".to_string();
-                state.last_error = Some(message);
-            }
-        }
+        state.apply_status_changed(status);
         notify_js_callback(&state);
     }
 
     fn on_complete(&self, success: bool, message: Option<String>) {
         let mut state = self.state.lock().unwrap();
-        if success {
-            state.status = "idle".to_string();
-            state.last_error = None;
-            state.last_synced = Some(chrono::Utc::now().to_rfc3339());
-        } else {
-            state.status = "error".to_string();
-            state.last_error = Some(message.unwrap_or_else(|| "Sync failed".to_string()));
-        }
+        state.apply_complete(success, message);
         notify_js_callback(&state);
     }
 }
@@ -762,10 +819,15 @@ pub fn start_sync(
         .await;
 
         if let Err(e) = result {
+            // `run_async` already reported this failure via the listener's
+            // `on_complete` (and pushed it to the JS callback) before
+            // returning it here. Re-apply the same classification (rather
+            // than defaulting to "error") so a payment_required push above
+            // isn't immediately clobbered — with no matching JS notification
+            // — the next time `getSyncStatus` is polled.
             let shared_state = get_sync_status_state();
             let mut state = shared_state.lock().unwrap();
-            state.status = "error".to_string();
-            state.last_error = Some(format!("{:?}", e));
+            state.apply_complete(false, Some(format!("{:?}", e)));
         }
 
         // Clear the global context when the task finishes.
@@ -1459,5 +1521,138 @@ salt = {}
         );
         assert_eq!(v[2]["inStock"], true);
         assert_eq!(v[2]["isLow"], true);
+    }
+}
+
+#[cfg(test)]
+mod sync_status_tests {
+    use super::*;
+
+    #[test]
+    fn detects_direct_payment_required_debug_text() {
+        // What most call sites produce: SyncError::PaymentRequired propagated
+        // unchanged, `format!("{:?}", e)`'d by run_async/start_sync.
+        assert!(is_payment_required_error("PaymentRequired"));
+    }
+
+    #[test]
+    fn detects_payment_required_wrapped_by_download_loop() {
+        // `syncer::download_loop` re-wraps any non-Unauthorized error into
+        // SyncError::Unknown(format!("Check download failed: {e}")), which
+        // loses the variant but keeps PaymentRequired's Display text.
+        let wrapped = "Unknown(\"Check download failed: Sync requires a paid plan\")";
+        assert!(is_payment_required_error(wrapped));
+    }
+
+    #[test]
+    fn does_not_flag_unrelated_errors() {
+        assert!(!is_payment_required_error("Unauthorized"));
+        assert!(!is_payment_required_error(
+            "IoErrorGeneric(Os { code: 2, kind: NotFound, message: \"No such file or directory\" })"
+        ));
+        assert!(!is_payment_required_error("Sync failed"));
+    }
+
+    #[test]
+    fn does_not_flag_an_io_error_whose_path_merely_contains_the_variant_name() {
+        // A recipe folder or file literally named "PaymentRequired" must not
+        // paywall an unrelated IO error — only an exact (trimmed) match on
+        // the direct forms counts, never a substring match.
+        let message = "IoError { path: \"/Users/alex/PaymentRequired/notes.cook\", \
+            source: Os { code: 2, kind: NotFound, message: \"No such file or directory\" } }";
+        assert!(!is_payment_required_error(message));
+    }
+
+    #[test]
+    fn detects_exact_display_text() {
+        assert!(is_payment_required_error("Sync requires a paid plan"));
+    }
+
+    #[test]
+    fn does_not_flag_display_text_as_a_mere_substring() {
+        // Same tightening as the Debug case: the Display text must match
+        // exactly, not just appear somewhere in a longer message.
+        assert!(!is_payment_required_error(
+            "context: Sync requires a paid plan (retry later)"
+        ));
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace_before_exact_matching() {
+        assert!(is_payment_required_error("  PaymentRequired  "));
+        assert!(is_payment_required_error("\nSync requires a paid plan\n"));
+    }
+
+    // These exercise `SyncStatusState::apply_status_changed`/`apply_complete`
+    // directly rather than the `NapiSyncStatusListener` trait methods: the
+    // trait methods also call `notify_js_callback`, whose `ThreadsafeFunction`
+    // needs real napi runtime symbols that a plain `cargo test` binary (no
+    // Node host) can't link. The `apply_*` methods hold 100% of the mapping
+    // logic the trait methods delegate to, so this covers the same behavior.
+
+    #[test]
+    fn on_complete_maps_payment_required_debug_text_without_generic_error() {
+        let mut state = SyncStatusState::default();
+        state.apply_complete(false, Some("PaymentRequired".to_string()));
+        assert_eq!(state.status, "payment_required");
+        assert!(
+            state.last_error.is_none(),
+            "payment_required must not carry the generic error text"
+        );
+    }
+
+    #[test]
+    fn on_complete_maps_wrapped_payment_required_from_download_loop() {
+        let mut state = SyncStatusState::default();
+        state.apply_complete(
+            false,
+            Some("Unknown(\"Check download failed: Sync requires a paid plan\")".to_string()),
+        );
+        assert_eq!(state.status, "payment_required");
+        assert!(state.last_error.is_none());
+    }
+
+    #[test]
+    fn on_complete_keeps_generic_error_for_other_failures() {
+        let mut state = SyncStatusState::default();
+        state.apply_complete(false, Some("Unauthorized".to_string()));
+        assert_eq!(state.status, "error");
+        assert_eq!(state.last_error.as_deref(), Some("Unauthorized"));
+    }
+
+    #[test]
+    fn on_complete_success_still_marks_idle_and_clears_error() {
+        let mut state = SyncStatusState::default();
+        state.apply_complete(true, None);
+        assert_eq!(state.status, "idle");
+        assert!(state.last_error.is_none());
+        assert!(state.last_synced.is_some());
+    }
+
+    #[test]
+    fn on_status_changed_error_variant_also_detects_payment_required() {
+        let mut state = SyncStatusState::default();
+        state.apply_status_changed(cooklang_sync_client::SyncStatus::Error {
+            message: "PaymentRequired".to_string(),
+        });
+        assert_eq!(state.status, "payment_required");
+        assert!(state.last_error.is_none());
+    }
+
+    #[test]
+    fn on_status_changed_error_variant_keeps_generic_error_message() {
+        let mut state = SyncStatusState::default();
+        state.apply_status_changed(cooklang_sync_client::SyncStatus::Error {
+            message: "boom".to_string(),
+        });
+        assert_eq!(state.status, "error");
+        assert_eq!(state.last_error.as_deref(), Some("boom"));
+    }
+
+    #[test]
+    fn on_status_changed_non_error_variants_are_unaffected() {
+        let mut state = SyncStatusState::default();
+        state.apply_status_changed(cooklang_sync_client::SyncStatus::Downloading);
+        assert_eq!(state.status, "downloading");
     }
 }


### PR DESCRIPTION
D2 of the sync-enforcement rollout (growth repo docs/superpowers/plans/2026-08-26-ws3-sync-entitlement-enforcement.md). Sync toggle now gates on the 'sync' feature (mirrors the AI block): locked state shows 'Sync runs on our servers — part of Cook Basic' + Upgrade via the existing startUpgradeFlow round-trip. A runtime 402 (SYNC_ENFORCEMENT=enforce) surfaces as a distinct 'payment_required' status → 'Sync needs a plan' with the same Upgrade affordance — never the generic error, never the logout path. Native pinned to cooklang-sync@3464309f (includes the upstream download_loop 402-passthrough fix); also fixes start_sync's error path clobbering the classified status after on_complete. New Rust unit tests (34/34 local) + mocha specs for the three render paths — mocha needs Node ≥22, verified by this PR's CI rather than locally.