### PR TITLE
feat: recipe images in the recipe preview

### DIFF
--- a/docs/superpowers/plans/2026-08-29-recipe-images.md
+++ b/docs/superpowers/plans/2026-08-29-recipe-images.md
@@ -1,0 +1,1445 @@
+# Recipe Images Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a hero image and per-step images in the editor's `.cook` recipe preview, discovered with exactly the same rules CookCLI's web server uses.
+
+**Architecture:** A new napi function in `packages/cooklang-native` wraps `cooklang-find`'s `title_image()` / `step_images()` and returns them as JSON. The frontend keeps the section/step lookup and the URI resolution in a pure, monaco-free module so both are unit-testable. Because the Theia renderer is served from `http://localhost:<port>`, Chromium blocks `file://` image sources, so local files are read via `FileService` and turned into blob URLs by a per-widget service.
+
+**Tech Stack:** Rust + NAPI-RS (`napi` 2, `cooklang-find` 0.6.1, `serde_json`), TypeScript 5.4, React 18, InversifyJS, Theia 1.70 (`FileService`, `ReactWidget`), mocha + chai.
+
+**Spec:** `docs/superpowers/specs/2026-08-29-recipe-images-design.md`
+
+---
+
+## Background you need before starting
+
+**The naming convention** (defined by `cooklang-find`, see
+`/Users/alexeydubovskoy/Cooklang/cooklang-find/src/model/recipe_entry.rs`):
+
+- Title image: metadata `image` / `images` / `picture` / `pictures` wins; otherwise
+  a sibling file `Pancakes.jpg`, `.jpeg`, `.png`, `.webp` next to `Pancakes.cook`.
+- Step images: `Recipe.N.ext` is step N counted continuously across all sections
+  and is stored at map key `[0][N-1]`. `Recipe.S.N.ext` is step N inside section S
+  and is stored at `[S-1][N-1]`. Filenames are one-indexed, map keys are
+  zero-indexed, and section 0 is reserved for the linear form.
+
+**The lookup order** CookCLI uses per step
+(`/Users/alexeydubovskoy/Cooklang/cookcli/src/web/builders.rs:502-506`) — the
+section-specific image wins, the linear one is the fallback:
+
+```rust
+entry.step_images()
+    .get(section_index + 1, step_count + 1)
+    .or_else(|| entry.step_images().get(0, total_steps + step_count + 1))
+```
+
+`StepImageCollection::get(section, step)` normalises its arguments as
+`section_idx = if section == 0 { 0 } else { section - 1 }` and `step_idx = step - 1`,
+returning `None` when `step == 0`. Note the consequence: `get(0, N)` and
+`get(1, N)` address the *same* map entry. That collision exists upstream and we
+reproduce it deliberately — do not "fix" it.
+
+**File conventions in this repo:** 4-space indent, single quotes, `undefined`
+never `null`, explicit return types, property injection with `@inject`, kebab-case
+filenames. Every new `.ts`/`.tsx` file starts with the same 12-line AGPL header
+block used by its siblings — copy it verbatim from
+`packages/cooklang/src/common/cooklang-uri.ts`.
+
+**Running tests:** specs are compiled to `lib/` first, then run from there.
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+npx mocha --config configs/mocharc.yml "packages/cooklang/lib/common/recipe-images.spec.js"
+```
+
+---
+
+### Task 1: `recipeImages` napi function
+
+**Files:**
+- Modify: `packages/cooklang-native/src/lib.rs` (append near the other
+  `cooklang_find` helper, `napi_find_recipe`, around line 939)
+
+- [ ] **Step 1: Write the failing Rust tests**
+
+Append to the bottom of `packages/cooklang-native/src/lib.rs`:
+
+```rust
+#[cfg(test)]
+mod recipe_images_tests {
+    use super::*;
+    use std::fs;
+
+    /// Creates a temp dir with `Recipe.cook` plus the given sibling image files.
+    fn fixture(name: &str, images: &[&str]) -> (std::path::PathBuf, String) {
+        let dir = std::env::temp_dir().join(format!(
+            "cooklang-images-{}-{}",
+            name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let recipe = dir.join("Pancakes.cook");
+        fs::write(&recipe, "Crack the @eggs{2}.\nFry it.\n").unwrap();
+        for image in images {
+            fs::write(dir.join(image), b"fake").unwrap();
+        }
+        (dir.clone(), recipe.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn reports_no_images_when_folder_has_none() {
+        let (_dir, path) = fixture("none", &[]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["title"].is_null());
+        assert_eq!(value["steps"].as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn finds_the_sibling_title_image() {
+        let (_dir, path) = fixture("title", &["Pancakes.jpg"]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["title"].as_str().unwrap().ends_with("Pancakes.jpg"));
+    }
+
+    #[test]
+    fn finds_a_title_image_for_every_supported_extension() {
+        for ext in ["jpg", "jpeg", "png", "webp"] {
+            let (_dir, path) = fixture(ext, &[&format!("Pancakes.{ext}")]);
+            let json = napi_recipe_images(path).unwrap();
+            let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert!(
+                value["title"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .ends_with(&format!("Pancakes.{ext}")),
+                "extension {ext} was not discovered"
+            );
+        }
+    }
+
+    // `Recipe.N.ext` is the linear form: step N across all sections, stored at [0][N-1].
+    #[test]
+    fn stores_linear_step_images_under_section_zero() {
+        let (_dir, path) = fixture("linear", &["Pancakes.1.jpg", "Pancakes.3.png"]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["steps"]["0"]["0"].as_str().unwrap().ends_with("Pancakes.1.jpg"));
+        assert!(value["steps"]["0"]["2"].as_str().unwrap().ends_with("Pancakes.3.png"));
+    }
+
+    // `Recipe.S.N.ext` is the sectioned form: section S step N, stored at [S-1][N-1].
+    #[test]
+    fn stores_section_step_images_under_the_section_index() {
+        let (_dir, path) = fixture("sectioned", &["Pancakes.2.4.jpg"]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["steps"]["1"]["3"].as_str().unwrap().ends_with("Pancakes.2.4.jpg"));
+    }
+
+    #[test]
+    fn errors_when_the_recipe_does_not_exist() {
+        assert!(napi_recipe_images("/definitely/not/here/Nope.cook".to_string()).is_err());
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd packages/cooklang-native && cargo test recipe_images
+```
+
+Expected: FAIL to compile — `cannot find function 'napi_recipe_images' in this scope`.
+
+- [ ] **Step 3: Write the implementation**
+
+Insert into `packages/cooklang-native/src/lib.rs`, directly after the closing
+brace of `napi_find_recipe`:
+
+```rust
+/// Title and step images for the recipe at `recipe_path`, discovered with
+/// `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
+///
+/// Returns JSON `{ "title": string | null, "steps": { section: { step: path } } }`.
+/// `title` is the raw value from metadata (which may be a URL or a relative path)
+/// or an absolute path to a sibling file. `steps` keys are zero-indexed, with
+/// section 0 holding the linear `Recipe.N.ext` form.
+#[napi(js_name = "recipeImages")]
+pub fn napi_recipe_images(recipe_path: String) -> napi::Result<String> {
+    let path = Utf8PathBuf::from(recipe_path);
+    let entry = cooklang_find::RecipeEntry::from_path(path)
+        .map_err(|e| napi::Error::from_reason(format!("recipeImages: {e}")))?;
+    let payload = serde_json::json!({
+        "title": entry.title_image(),
+        "steps": entry.step_images().images,
+    });
+    serde_json::to_string(&payload)
+        .map_err(|e| napi::Error::from_reason(format!("recipeImages serialize: {e}")))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd packages/cooklang-native && cargo test recipe_images
+```
+
+Expected: PASS, 6 tests.
+
+If `RecipeEntry` is not in scope, add `use cooklang_find::RecipeEntry;` — but
+prefer the fully-qualified `cooklang_find::RecipeEntry` shown above, which
+matches how `napi_find_recipe` refers to the crate.
+
+- [ ] **Step 5: Build the addon so the new export exists in `index.d.ts`**
+
+```bash
+cd packages/cooklang-native && npm run build
+grep -n "recipeImages" index.d.ts
+```
+
+Expected: a `export declare function recipeImages(recipePath: string): string` line.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cooklang-native/src/lib.rs packages/cooklang-native/index.d.ts packages/cooklang-native/index.js
+git commit -m "feat(native): add recipeImages for cooklang-find image discovery"
+```
+
+---
+
+### Task 2: Expose `recipeImages` on the language service
+
+**Files:**
+- Modify: `packages/cooklang/src/common/cooklang-language-service.ts` (add to the
+  `CooklangLanguageService` interface, next to `findRecipe`)
+- Modify: `packages/cooklang/src/node/cooklang-language-service-impl.ts` (add
+  next to `findRecipe`, around line 272)
+
+- [ ] **Step 1: Add the interface method**
+
+In `packages/cooklang/src/common/cooklang-language-service.ts`, directly after
+the `findRecipe` declaration:
+
+```ts
+    /**
+     * Title and step images for the recipe at `recipePath`, discovered with
+     * `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
+     *
+     * Returns JSON `{ title: string | null, steps: { [section]: { [step]: path } } }`.
+     * `title` is raw: an absolute path, a URL, or a relative path from metadata.
+     * `steps` keys are zero-indexed; section 0 holds the linear `Recipe.N.ext` form.
+     *
+     * `recipePath` must be an OS filesystem path (not a URI) — this RPC reads
+     * from disk directly via `cooklang-find` and bypasses Theia's `FileService`.
+     * Electron-only by design; remote/virtual workspaces are not supported.
+     */
+    recipeImages(recipePath: string): Promise<string>;
+```
+
+- [ ] **Step 2: Add the backend delegation**
+
+In `packages/cooklang/src/node/cooklang-language-service-impl.ts`, directly
+after the `findRecipe` method:
+
+```ts
+    async recipeImages(recipePath: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.recipeImages(recipePath);
+    }
+```
+
+- [ ] **Step 3: Compile to verify the interface is satisfied**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: exits 0. A missing method would fail with
+`Class 'CooklangLanguageServiceImpl' incorrectly implements interface`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cooklang/src/common/cooklang-language-service.ts packages/cooklang/src/node/cooklang-language-service-impl.ts
+git commit -m "feat(cooklang): expose recipeImages over the language service RPC"
+```
+
+---
+
+### Task 3: Step-image lookup (pure logic)
+
+This module must not import anything that transitively pulls in `@theia/monaco`,
+or its spec will abort the whole mocha run with a `.css` extension error. `URI`
+from `@theia/core/lib/common/uri` is safe; anything from
+`@theia/monaco` or `@theia/filesystem/lib/browser` is not.
+
+**Files:**
+- Create: `packages/cooklang/src/common/recipe-images.ts`
+- Test: `packages/cooklang/src/common/recipe-images.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/common/recipe-images.spec.ts` (with the standard
+12-line AGPL header at the top, copied from `cooklang-uri.ts`):
+
+```ts
+import { expect } from 'chai';
+import { RecipeImages, lookupStepImage } from './recipe-images';
+
+describe('lookupStepImage', () => {
+
+    const linear: RecipeImages = {
+        steps: { '0': { '0': '/r/Pancakes.1.jpg', '2': '/r/Pancakes.3.jpg' } }
+    };
+
+    it('finds a linear image by its global step index', () => {
+        expect(lookupStepImage(linear, 0, 0, 0)).to.equal('/r/Pancakes.1.jpg');
+        expect(lookupStepImage(linear, 0, 2, 2)).to.equal('/r/Pancakes.3.jpg');
+    });
+
+    it('returns undefined for a step with no image', () => {
+        expect(lookupStepImage(linear, 0, 1, 1)).to.be.undefined;
+    });
+
+    it('finds a section image at [section][step]', () => {
+        // Pancakes.2.4.jpg -> section 2, step 4 -> stored at [1][3].
+        const sectioned: RecipeImages = { steps: { '1': { '3': '/r/Pancakes.2.4.jpg' } } };
+        expect(lookupStepImage(sectioned, 1, 3, 7)).to.equal('/r/Pancakes.2.4.jpg');
+    });
+
+    // Mirrors cookcli builders.rs: the section-specific image wins over the linear one.
+    it('prefers the section image over the linear fallback', () => {
+        const both: RecipeImages = {
+            steps: {
+                '1': { '0': '/r/Pancakes.2.1.jpg' },
+                '0': { '3': '/r/Pancakes.4.jpg' }
+            }
+        };
+        expect(lookupStepImage(both, 1, 0, 3)).to.equal('/r/Pancakes.2.1.jpg');
+    });
+
+    it('falls back to the linear image when the section has none', () => {
+        const both: RecipeImages = { steps: { '0': { '3': '/r/Pancakes.4.jpg' } } };
+        expect(lookupStepImage(both, 1, 0, 3)).to.equal('/r/Pancakes.4.jpg');
+    });
+
+    // StepImageCollection::get normalises section 0 and section 1 to the same
+    // index, so the first section of a sectioned recipe shares keys with the
+    // linear form. This collision exists upstream; it is reproduced, not fixed.
+    it('treats section index 0 as section index 0, like the upstream collection', () => {
+        const images: RecipeImages = { steps: { '0': { '1': '/r/Pancakes.2.jpg' } } };
+        expect(lookupStepImage(images, 0, 1, 1)).to.equal('/r/Pancakes.2.jpg');
+    });
+
+    it('returns undefined when there are no images at all', () => {
+        expect(lookupStepImage({ steps: {} }, 0, 0, 0)).to.be.undefined;
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: FAIL — `Cannot find module './recipe-images'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/common/recipe-images.ts` (standard AGPL header,
+then):
+
+```ts
+/**
+ * Image paths for one recipe, as returned by the `recipeImages` RPC.
+ *
+ * `steps` mirrors `cooklang-find`'s `StepImageCollection`: section index ->
+ * step index -> path, both zero-indexed, with section 0 holding the linear
+ * `Recipe.N.ext` form.
+ */
+export interface RecipeImages {
+    title?: string;
+    steps: Record<string, Record<string, string>>;
+}
+
+/** The same shape after every entry has been turned into an `<img>` src. */
+export interface ResolvedRecipeImages {
+    title?: string;
+    steps: Record<string, Record<string, string>>;
+}
+
+/**
+ * The image for one step, following the two naming conventions cookcli
+ * supports (see `builders.rs`): the section-specific `Recipe.S.N.ext` wins,
+ * and the continuous `Recipe.N.ext` is the fallback.
+ *
+ * @param sectionIndex zero-based index of the section the step is in
+ * @param stepInSection zero-based index of the step within that section
+ * @param globalStepIndex zero-based index of the step counted across all sections
+ */
+export function lookupStepImage(
+    images: RecipeImages | ResolvedRecipeImages,
+    sectionIndex: number,
+    stepInSection: number,
+    globalStepIndex: number
+): string | undefined {
+    return images.steps[String(sectionIndex)]?.[String(stepInSection)]
+        ?? images.steps['0']?.[String(globalStepIndex)];
+}
+```
+
+Note there is no `section - 1` arithmetic here: `builders.rs` calls
+`get(section_index + 1, ...)` and `get` immediately undoes that with
+`section - 1`, so the two cancel and the section key is just the zero-based
+index. The `?? images.steps['0']` fallback is what makes section 0 and section 1
+collide, matching upstream.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+npx mocha --config configs/mocharc.yml "packages/cooklang/lib/common/recipe-images.spec.js"
+```
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang/src/common/recipe-images.ts packages/cooklang/src/common/recipe-images.spec.ts
+git commit -m "feat(cooklang): add step-image lookup matching cookcli conventions"
+```
+
+---
+
+### Task 4: Image URI resolution (pure logic)
+
+**Files:**
+- Modify: `packages/cooklang/src/common/recipe-images.ts`
+- Modify: `packages/cooklang/src/common/recipe-images.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/cooklang/src/common/recipe-images.spec.ts`, and add
+`URI` plus `resolveImageUri` to the imports at the top of the file:
+
+```ts
+import URI from '@theia/core/lib/common/uri';
+import { RecipeImages, lookupStepImage, resolveImageUri } from './recipe-images';
+```
+
+```ts
+describe('resolveImageUri', () => {
+
+    const recipe = new URI('file:///work/recipes/Pancakes.cook');
+    const root = new URI('file:///work');
+
+    it('passes http and https URLs through untouched', () => {
+        expect(resolveImageUri('https://cdn.example/p.jpg', recipe, root))
+            .to.deep.equal({ kind: 'remote', url: 'https://cdn.example/p.jpg' });
+        expect(resolveImageUri('http://cdn.example/p.jpg', recipe, root))
+            .to.deep.equal({ kind: 'remote', url: 'http://cdn.example/p.jpg' });
+    });
+
+    // Discovery is sibling-based, so an absolute path always names a file next
+    // to the recipe. Rebuilding it from the recipe URI avoids converting a raw
+    // OS path into a URI in browser code.
+    it('resolves an absolute path against the recipe folder by basename', () => {
+        const result = resolveImageUri('/work/recipes/Pancakes.jpg', recipe, root);
+        expect(result?.kind).to.equal('file');
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/Pancakes.jpg');
+    });
+
+    it('resolves a Windows-style absolute path by basename too', () => {
+        const result = resolveImageUri('C:\\work\\recipes\\Pancakes.jpg', recipe, root);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/Pancakes.jpg');
+    });
+
+    it('resolves a relative metadata path against the recipe folder', () => {
+        const result = resolveImageUri('photo.jpg', recipe, root);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/photo.jpg');
+    });
+
+    it('resolves a root-relative metadata path against the workspace root', () => {
+        const result = resolveImageUri('images/photo.jpg', recipe, root);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/images/photo.jpg');
+    });
+
+    it('falls back to the recipe folder when there is no workspace root', () => {
+        const result = resolveImageUri('images/photo.jpg', recipe, undefined);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/images/photo.jpg');
+    });
+
+    it('returns undefined for blank input', () => {
+        expect(resolveImageUri('', recipe, root)).to.be.undefined;
+        expect(resolveImageUri('   ', recipe, root)).to.be.undefined;
+    });
+});
+```
+
+The two multi-segment cases encode the rule: a relative path with no separator
+is a sibling of the recipe, and one with a separator is resolved from the
+workspace root (matching cookcli's `ServeDir` at the root), falling back to the
+recipe folder when no root is open.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: FAIL — `Module './recipe-images' has no exported member 'resolveImageUri'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `packages/cooklang/src/common/recipe-images.ts`, and add the import
+`import URI from '@theia/core/lib/common/uri';` at the top:
+
+```ts
+/** Where an image should be loaded from. */
+export type ImageLocation =
+    | { kind: 'remote'; url: string }
+    | { kind: 'file'; uri: URI };
+
+/** Image file extensions `cooklang-find` discovers, lower-case, in its own order. */
+export const RECIPE_IMAGE_EXTENSIONS: ReadonlyArray<string> = ['jpg', 'jpeg', 'png', 'webp'];
+
+/**
+ * Turn a raw image value from the `recipeImages` RPC into something loadable.
+ *
+ * - `http(s)` URLs are passed through.
+ * - An absolute path names a sibling of the recipe, so only its basename is
+ *   used and it is resolved against the recipe's folder. This keeps browser
+ *   code free of raw OS paths and works for both POSIX and Windows separators.
+ * - A relative path from metadata with no separator resolves against the
+ *   recipe's folder; one with a separator resolves against the workspace root
+ *   (matching cookcli, which serves relative metadata paths from the root),
+ *   falling back to the recipe's folder when no workspace is open.
+ */
+export function resolveImageUri(
+    raw: string,
+    recipeUri: URI,
+    workspaceRootUri: URI | undefined
+): ImageLocation | undefined {
+    const value = raw.trim();
+    if (value.length === 0) {
+        return undefined;
+    }
+    if (/^https?:\/\//i.test(value)) {
+        return { kind: 'remote', url: value };
+    }
+    const folder = recipeUri.parent;
+    const normalized = value.replace(/\\/g, '/');
+    const isAbsolute = normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized);
+    if (isAbsolute) {
+        const base = normalized.substring(normalized.lastIndexOf('/') + 1);
+        return base.length === 0 ? undefined : { kind: 'file', uri: folder.resolve(base) };
+    }
+    if (normalized.includes('/') && workspaceRootUri) {
+        return { kind: 'file', uri: workspaceRootUri.resolve(normalized) };
+    }
+    return { kind: 'file', uri: folder.resolve(normalized) };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+npx mocha --config configs/mocharc.yml "packages/cooklang/lib/common/recipe-images.spec.js"
+```
+
+Expected: PASS, 14 tests.
+
+- [ ] **Step 5: Export the module from the package barrel**
+
+In `packages/cooklang/src/common/index.ts`, after the
+`export * from './recipe-types';` line:
+
+```ts
+export * from './recipe-images';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cooklang/src/common/recipe-images.ts packages/cooklang/src/common/recipe-images.spec.ts packages/cooklang/src/common/index.ts
+git commit -m "feat(cooklang): resolve recipe image paths to URIs"
+```
+
+---
+
+### Task 5: `RecipeImageService` — blob URLs for local images
+
+`<img src="file://…">` is blocked because the renderer is served from
+`http://localhost:<port>`, so local files are read through `FileService` and
+handed to the DOM as blob URLs.
+
+**Files:**
+- Create: `packages/cooklang/src/browser/recipe-image-service.ts`
+- Test: `packages/cooklang/src/browser/recipe-image-service.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/browser/recipe-image-service.spec.ts` (standard
+AGPL header, then):
+
+```ts
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { RecipeImageService } from './recipe-image-service';
+
+after(() => disableJSDOM());
+
+class FakeFileService {
+    size = 1024;
+    reads: string[] = [];
+    missing = false;
+    async resolve(uri: URI): Promise<{ size: number }> {
+        if (this.missing) { throw new Error(`not found: ${uri.toString()}`); }
+        return { size: this.size };
+    }
+    async readFile(uri: URI): Promise<{ value: BinaryBuffer }> {
+        if (this.missing) { throw new Error(`not found: ${uri.toString()}`); }
+        this.reads.push(uri.toString());
+        return { value: BinaryBuffer.wrap(new Uint8Array([1, 2, 3])) };
+    }
+}
+
+function createService(): { service: RecipeImageService; files: FakeFileService; created: string[]; revoked: string[] } {
+    const created: string[] = [];
+    const revoked: string[] = [];
+    let counter = 0;
+    // jsdom has no URL.createObjectURL; stub it so the service is observable.
+    (URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL = () => {
+        const url = `blob:fake/${counter++}`;
+        created.push(url);
+        return url;
+    };
+    (URL as unknown as { revokeObjectURL: (u: string) => void }).revokeObjectURL = url => {
+        revoked.push(url);
+    };
+    const service = new RecipeImageService();
+    const files = new FakeFileService();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (service as any).fileService = files;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return { service, files, created, revoked };
+}
+
+describe('RecipeImageService', () => {
+
+    it('reads a local file and returns a blob URL', async () => {
+        const { service, created } = createService();
+        const url = await service.resolve(new URI('file:///r/Pancakes.jpg'));
+        expect(url).to.equal(created[0]);
+    });
+
+    it('reads each file once and reuses the cached URL', async () => {
+        const { service, files } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        const first = await service.resolve(uri);
+        const second = await service.resolve(uri);
+        expect(second).to.equal(first);
+        expect(files.reads).to.have.length(1);
+    });
+
+    // FileService reads travel over RPC to the backend; a huge file would stall
+    // the preview, so it is skipped rather than loaded.
+    it('skips files over the size cap', async () => {
+        const { service, files } = createService();
+        files.size = 40 * 1024 * 1024;
+        expect(await service.resolve(new URI('file:///r/Huge.png'))).to.be.undefined;
+        expect(files.reads).to.be.empty;
+    });
+
+    it('resolves to undefined for a missing or unreadable file', async () => {
+        const { service, files } = createService();
+        files.missing = true;
+        expect(await service.resolve(new URI('file:///r/Gone.jpg'))).to.be.undefined;
+    });
+
+    it('resolves to undefined for an unsupported extension', async () => {
+        const { service, files } = createService();
+        expect(await service.resolve(new URI('file:///r/notes.txt'))).to.be.undefined;
+        expect(files.reads).to.be.empty;
+    });
+
+    // A file replaced in place keeps its URI, so the cache must be invalidated
+    // for it or the preview keeps showing the old bytes forever.
+    it('re-reads a single file after release', async () => {
+        const { service, files, revoked } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        const first = await service.resolve(uri);
+        service.release(uri);
+        expect(revoked).to.deep.equal([first!]);
+        const second = await service.resolve(uri);
+        expect(second).to.not.equal(first);
+        expect(files.reads).to.have.length(2);
+    });
+
+    it('ignores release for a URI it never loaded', () => {
+        const { service, revoked } = createService();
+        service.release(new URI('file:///r/never.jpg'));
+        expect(revoked).to.be.empty;
+    });
+
+    it('revokes every object URL on releaseAll', async () => {
+        const { service, revoked } = createService();
+        const a = await service.resolve(new URI('file:///r/a.jpg'));
+        const b = await service.resolve(new URI('file:///r/b.png'));
+        service.releaseAll();
+        expect(revoked).to.have.members([a!, b!]);
+    });
+
+    it('re-reads a file after releaseAll', async () => {
+        const { service, files } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        await service.resolve(uri);
+        service.releaseAll();
+        await service.resolve(uri);
+        expect(files.reads).to.have.length(2);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: FAIL — `Cannot find module './recipe-image-service'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/browser/recipe-image-service.ts` (standard AGPL
+header, then):
+
+```ts
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import URI from '@theia/core/lib/common/uri';
+
+const MIME_TYPES: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    webp: 'image/webp',
+};
+
+/**
+ * Turns local image files into `blob:` URLs an `<img>` can load.
+ *
+ * The Theia renderer is served from `http://localhost:<port>`, so Chromium
+ * blocks `file://` sources: the bytes have to come through `FileService`.
+ * One instance is bound per preview widget, and `releaseAll` runs on dispose.
+ */
+@injectable()
+export class RecipeImageService {
+
+    /**
+     * `FileService` reads travel over the RPC channel to the backend, so a very
+     * large file would stall the preview. Recipe photos are far below this.
+     */
+    static readonly MAX_BYTES = 20 * 1024 * 1024;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    protected readonly urls = new Map<string, string>();
+
+    /**
+     * A `blob:` URL for `uri`, or `undefined` when the file is missing,
+     * unreadable, too large, or not a supported image type. Repeated calls for
+     * the same URI reuse one object URL.
+     */
+    async resolve(uri: URI): Promise<string | undefined> {
+        const key = uri.toString();
+        const cached = this.urls.get(key);
+        if (cached) {
+            return cached;
+        }
+        const type = MIME_TYPES[uri.path.ext.replace(/^\./, '').toLowerCase()];
+        if (!type) {
+            return undefined;
+        }
+        try {
+            const stat = await this.fileService.resolve(uri);
+            if ((stat.size ?? 0) > RecipeImageService.MAX_BYTES) {
+                return undefined;
+            }
+            const content = await this.fileService.readFile(uri);
+            const url = URL.createObjectURL(new Blob([content.value.buffer], { type }));
+            // Another call may have populated the cache while we awaited.
+            const raced = this.urls.get(key);
+            if (raced) {
+                URL.revokeObjectURL(url);
+                return raced;
+            }
+            this.urls.set(key, url);
+            return url;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * Drop the cached URL for one file, so the next `resolve` re-reads it.
+     * Needed when an image is replaced in place: the URI is unchanged, so
+     * without this the preview would keep showing the old bytes.
+     */
+    release(uri: URI): void {
+        const key = uri.toString();
+        const url = this.urls.get(key);
+        if (url) {
+            URL.revokeObjectURL(url);
+            this.urls.delete(key);
+        }
+    }
+
+    /** Revoke every object URL handed out so far and empty the cache. */
+    releaseAll(): void {
+        for (const url of this.urls.values()) {
+            URL.revokeObjectURL(url);
+        }
+        this.urls.clear();
+    }
+}
+```
+
+`fileService.resolve(uri)` without options returns a `FileStat` whose `size` is
+optional, hence the `?? 0`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+npx mocha --config configs/mocharc.yml "packages/cooklang/lib/browser/recipe-image-service.spec.js"
+```
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cooklang/src/browser/recipe-image-service.ts packages/cooklang/src/browser/recipe-image-service.spec.ts
+git commit -m "feat(cooklang): load local recipe images as blob URLs"
+```
+
+---
+
+### Task 6: Render the hero and step images
+
+Rendering comes before the widget wiring so the components can be reviewed with
+plain props before any async plumbing exists.
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/recipe-preview-components.tsx`
+- Modify: `packages/cooklang/src/browser/style/recipe-preview.css`
+
+- [ ] **Step 1: Add `picture`/`pictures` to the skipped metadata keys**
+
+In `packages/cooklang/src/browser/recipe-preview-components.tsx`, replace the
+`SKIP_META_KEYS` constant (around line 42):
+
+```tsx
+const SKIP_META_KEYS = new Set([
+    'name', 'tags', 'tag', 'description', 'images', 'image', 'locale',
+    'picture', 'pictures',
+]);
+```
+
+`cooklang-find` reads the title image from any of `image`, `images`, `picture`
+or `pictures`, so all four must stay out of the metadata pills.
+
+- [ ] **Step 2: Add the import and a shared image element**
+
+Add a new import line directly below the existing multi-line import from
+`'../common/recipe-types'` (which ends around line 35):
+
+```tsx
+import { ResolvedRecipeImages, lookupStepImage } from '../common/recipe-images';
+```
+
+Then add this component just above the `StepItemView` section header:
+
+```tsx
+// ---------------------------------------------------------------------------
+// RecipeImage
+// ---------------------------------------------------------------------------
+
+interface RecipeImageProps {
+    src: string;
+    alt: string;
+    className: string;
+}
+
+/**
+ * An image that removes itself when the source fails to load, so a corrupt or
+ * vanished file degrades to no image rather than a broken-image icon.
+ */
+const RecipeImage = ({ src, alt, className }: RecipeImageProps): React.ReactElement => {
+    const [failed, setFailed] = React.useState(false);
+    const onError = React.useCallback(() => setFailed(true), []);
+    // A new src is a new attempt: clear the previous failure.
+    React.useEffect(() => setFailed(false), [src]);
+    if (failed) {
+        return <></>;
+    }
+    return <img className={className} src={src} alt={alt} onError={onError} />;
+};
+```
+
+- [ ] **Step 3: Thread an image through `SectionContentView`**
+
+In `packages/cooklang/src/browser/recipe-preview-components.tsx`, add
+`imageSrc` to `SectionContentViewProps` and render it. Replace the whole
+`SectionContentViewProps` interface and `SectionContentView` component
+(currently lines 192-229) with:
+
+```tsx
+interface SectionContentViewProps {
+    content: SectionContent;
+    ingredients: Ingredient[];
+    cookware: Cookware[];
+    timers: Timer[];
+    inlineQuantities: InlineQuantity[];
+    imageSrc?: string;
+}
+
+const SectionContentView = ({
+    content,
+    ingredients,
+    cookware,
+    timers,
+    inlineQuantities,
+    imageSrc,
+}: SectionContentViewProps): React.ReactElement => {
+    if (content.type === 'text') {
+        return <div className='note-item'>{content.value}</div>;
+    }
+
+    const { items, number } = content.value;
+    return (
+        <div className='step-item'>
+            <div className='step-number'>{number}</div>
+            <div className='step-content'>
+                {items.map((item, idx) => (
+                    <StepItemView
+                        key={idx}
+                        item={item}
+                        ingredients={ingredients}
+                        cookware={cookware}
+                        timers={timers}
+                        inlineQuantities={inlineQuantities}
+                    />
+                ))}
+                <StepIngredientsSummary items={items} ingredients={ingredients} />
+                {imageSrc && (
+                    <RecipeImage className='step-image' src={imageSrc} alt={`Step ${number}`} />
+                )}
+            </div>
+        </div>
+    );
+};
+```
+
+- [ ] **Step 4: Count steps and look up images in `InstructionsPanel`**
+
+Replace the whole `InstructionsPanelProps` interface and `InstructionsPanel`
+component (currently lines 236-269) with:
+
+```tsx
+interface InstructionsPanelProps {
+    sections: Section[];
+    ingredients: Ingredient[];
+    cookware: Cookware[];
+    timers: Timer[];
+    inlineQuantities: InlineQuantity[];
+    images?: ResolvedRecipeImages;
+}
+
+export const InstructionsPanel = ({
+    sections,
+    ingredients,
+    cookware,
+    timers,
+    inlineQuantities,
+    images,
+}: InstructionsPanelProps): React.ReactElement => {
+    // Steps are counted here rather than read from `content.value.number` so the
+    // per-section and global counters match cookcli's `builders.rs` exactly,
+    // whichever convention the parser uses for `number`.
+    let globalStepIndex = 0;
+    return (
+        <div className='recipe-instructions'>
+            <h2 className='instructions-title'>Instructions</h2>
+            {sections.map((section, sIdx) => {
+                let stepInSection = 0;
+                return (
+                    <React.Fragment key={sIdx}>
+                        {section.name && (
+                            <h3 className='section-header'>{section.name}</h3>
+                        )}
+                        {section.content.map((content, cIdx) => {
+                            let imageSrc: string | undefined;
+                            if (content.type === 'step') {
+                                if (images) {
+                                    imageSrc = lookupStepImage(images, sIdx, stepInSection, globalStepIndex);
+                                }
+                                stepInSection++;
+                                globalStepIndex++;
+                            }
+                            return (
+                                <SectionContentView
+                                    key={cIdx}
+                                    content={content}
+                                    ingredients={ingredients}
+                                    cookware={cookware}
+                                    timers={timers}
+                                    inlineQuantities={inlineQuantities}
+                                    imageSrc={imageSrc}
+                                />
+                            );
+                        })}
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+};
+```
+
+- [ ] **Step 5: Add the hero image to `RecipeView`**
+
+In `RecipeViewProps` (around line 437) add:
+
+```tsx
+    images?: ResolvedRecipeImages;
+```
+
+Change the destructuring on the `RecipeView` line to include `images`:
+
+```tsx
+export const RecipeView = ({ recipe, fileName, images, onShowSource, onAddToShoppingList, onNavigateToRecipe }: RecipeViewProps): React.ReactElement => {
+```
+
+Insert the hero image as the first child of the outer `<div>`, immediately
+before `<div className='recipe-header'>`:
+
+```tsx
+            {images?.title && (
+                <RecipeImage className='recipe-hero-image' src={images.title} alt={title} />
+            )}
+```
+
+And pass `images` down to the instructions panel — replace the
+`<InstructionsPanel .../>` call at the bottom with:
+
+```tsx
+                <InstructionsPanel
+                    sections={scaled.sections}
+                    ingredients={scaled.ingredients}
+                    cookware={scaled.cookware}
+                    timers={scaled.timers}
+                    inlineQuantities={scaled.inline_quantities}
+                    images={images}
+                />
+```
+
+- [ ] **Step 6: Add the styles**
+
+Append to `packages/cooklang/src/browser/style/recipe-preview.css`:
+
+```css
+/* Recipe images -------------------------------------------------------- */
+
+.recipe-hero-image {
+    display: block;
+    margin: 0 auto 16px;
+    max-width: 100%;
+    max-height: 400px;
+    object-fit: contain;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px var(--theia-widget-shadow);
+}
+
+.step-image {
+    display: block;
+    margin-top: 10px;
+    max-width: 320px;
+    width: 100%;
+    height: auto;
+    border-radius: 6px;
+    box-shadow: 0 1px 4px var(--theia-widget-shadow);
+}
+```
+
+- [ ] **Step 7: Compile and lint**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cooklang/src/browser/recipe-preview-components.tsx packages/cooklang/src/browser/style/recipe-preview.css
+git commit -m "feat(cooklang): render hero and step images in the recipe preview"
+```
+
+---
+
+### Task 7: Wire discovery, resolution and watching into the widget
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/recipe-preview-widget.tsx`
+
+- [ ] **Step 1: Add the imports and state**
+
+At the top of `packages/cooklang/src/browser/recipe-preview-widget.tsx`, add
+after the existing `Recipe` import:
+
+```tsx
+import {
+    RecipeImages,
+    ResolvedRecipeImages,
+    resolveImageUri,
+    RECIPE_IMAGE_EXTENSIONS,
+} from '../common/recipe-images';
+import { RecipeImageService } from './recipe-image-service';
+```
+
+Add the injection next to the other `@inject` properties:
+
+```tsx
+    @inject(RecipeImageService)
+    protected readonly imageService: RecipeImageService;
+```
+
+Add the state next to `parseSequence`:
+
+```tsx
+    protected images: ResolvedRecipeImages = { steps: {} };
+    protected imageSequence = 0;
+    protected imageDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+```
+
+- [ ] **Step 2: Trigger discovery from `setUri` and start watching**
+
+Replace the body of `setUri` (currently lines 96-106) with:
+
+```tsx
+    setUri(uri: URI): void {
+        this.uri = uri;
+        this.id = createRecipePreviewWidgetId(uri);
+        this.title.label = `Preview: ${uri.path.base}`;
+        this.title.caption = `Recipe preview for ${uri.toString()}`;
+        this.title.closable = true;
+        this.title.iconClass = 'codicon codicon-open-preview';
+        this.watchImageFolder();
+        this.refreshImages();
+        this.parseCurrentContent();
+    }
+```
+
+- [ ] **Step 3: Add the discovery, resolution and watching methods**
+
+Add these methods after `parseContent`:
+
+```tsx
+    // --- Image helpers ---
+
+    /**
+     * Watch the recipe's folder so an image dropped in from Finder shows up in
+     * an already-open preview, and a deleted one disappears.
+     */
+    protected watchImageFolder(): void {
+        const folder = this.uri.parent;
+        this.toDispose.push(this.fileService.watch(folder));
+        this.toDispose.push(this.fileService.onDidFilesChange(event => {
+            const touched = event.changes
+                .map(change => change.resource)
+                .filter(resource => this.isImageOfThisRecipe(resource));
+            if (touched.length === 0) {
+                return;
+            }
+            // An image replaced in place keeps its URI, so the cached blob for
+            // it has to go or the preview would keep showing the old bytes.
+            for (const resource of touched) {
+                this.imageService.release(resource);
+            }
+            this.debouncedRefreshImages();
+        }));
+    }
+
+    /** True when `resource` is a `<stem>.….<ext>` image belonging to this recipe. */
+    protected isImageOfThisRecipe(resource: URI): boolean {
+        if (resource.parent.toString() !== this.uri.parent.toString()) {
+            return false;
+        }
+        const name = resource.path.base;
+        const stem = this.uri.path.name;
+        if (!name.toLowerCase().startsWith(stem.toLowerCase() + '.')) {
+            return false;
+        }
+        const ext = resource.path.ext.replace(/^\./, '').toLowerCase();
+        return RECIPE_IMAGE_EXTENSIONS.includes(ext);
+    }
+
+    /** Coalesce the burst of events a multi-file copy produces into one refresh. */
+    protected debouncedRefreshImages(): void {
+        if (this.imageDebounceTimer !== undefined) {
+            clearTimeout(this.imageDebounceTimer);
+        }
+        this.imageDebounceTimer = setTimeout(() => {
+            this.imageDebounceTimer = undefined;
+            this.refreshImages();
+        }, 150);
+    }
+
+    /**
+     * Ask the backend which images exist for this recipe and turn each one into
+     * an `<img>` src. Guarded by `imageSequence` so a slow refresh cannot
+     * overwrite a newer one.
+     */
+    protected async refreshImages(): Promise<void> {
+        if (!this.uri) {
+            return;
+        }
+        const sequence = ++this.imageSequence;
+        const resolved: ResolvedRecipeImages = { steps: {} };
+        try {
+            const json = await this.service.recipeImages(this.uri.path.fsPath());
+            const discovered = JSON.parse(json) as RecipeImages;
+            resolved.title = await this.toImageSrc(discovered.title);
+            for (const [section, steps] of Object.entries(discovered.steps ?? {})) {
+                for (const [step, raw] of Object.entries(steps)) {
+                    const src = await this.toImageSrc(raw);
+                    if (src) {
+                        (resolved.steps[section] ??= {})[step] = src;
+                    }
+                }
+            }
+        } catch {
+            // No images, an unsaved file, or an unreadable folder: render none.
+        }
+        if (this.isDisposed || sequence !== this.imageSequence) {
+            return;
+        }
+        this.images = resolved;
+        this.update();
+    }
+
+    /** Resolve one raw image value to a URL an `<img>` can load. */
+    protected async toImageSrc(raw: string | undefined): Promise<string | undefined> {
+        if (!raw) {
+            return undefined;
+        }
+        const root = this.workspaceService.tryGetRoots()[0];
+        const location = resolveImageUri(
+            raw,
+            this.uri,
+            root ? new URI(root.resource.toString()) : undefined
+        );
+        if (!location) {
+            return undefined;
+        }
+        return location.kind === 'remote'
+            ? location.url
+            : this.imageService.resolve(location.uri);
+    }
+```
+
+`this.uri.path.fsPath()` gives the OS path the RPC expects. Note the widget
+already injects `FileService` and `WorkspaceService`, so no new injections are
+needed beyond `RecipeImageService`.
+
+- [ ] **Step 4: Re-run discovery whenever the recipe is reparsed**
+
+Metadata can name the title image, so an edit can change it. In
+`parseContent`, add a `refreshImages()` call in the success path — insert it
+immediately before the `this.update();` at the end of the `.then(...)` callback:
+
+```tsx
+            this.refreshImages();
+            this.update();
+```
+
+- [ ] **Step 5: Pass the images to `RecipeView`**
+
+In `render()`, add the prop:
+
+```tsx
+                <RecipeView
+                    recipe={this.recipe}
+                    fileName={this.uri?.path.base ?? ''}
+                    images={this.images}
+                    onShowSource={this.handleShowSource}
+                    onAddToShoppingList={this.handleAddToShoppingList}
+                    onNavigateToRecipe={this.handleNavigateToRecipe}
+                />
+```
+
+- [ ] **Step 6: Release the object URLs on dispose**
+
+Replace the `dispose` override at the bottom of the class with:
+
+```tsx
+    override dispose(): void {
+        if (this.debounceTimer !== undefined) {
+            clearTimeout(this.debounceTimer);
+            this.debounceTimer = undefined;
+        }
+        if (this.imageDebounceTimer !== undefined) {
+            clearTimeout(this.imageDebounceTimer);
+            this.imageDebounceTimer = undefined;
+        }
+        this.imageService.releaseAll();
+        super.dispose();
+    }
+```
+
+- [ ] **Step 7: Bind the service per widget**
+
+In the same file, in `createRecipePreviewWidget`, bind `RecipeImageService` into
+the child container so its lifetime matches the preview panel:
+
+```tsx
+export function createRecipePreviewWidget(
+    container: interfaces.Container,
+    uri: URI
+): RecipePreviewWidget {
+    const child = container.createChild();
+    child.bind(RecipeImageService).toSelf().inSingletonScope();
+    child.bind(RecipePreviewWidget).toSelf().inTransientScope();
+    const widget = child.get(RecipePreviewWidget);
+    widget.setUri(uri);
+    return widget;
+}
+```
+
+`inSingletonScope` here means one instance *per child container*, i.e. one per
+preview widget — which is exactly the caching and release scope we want.
+
+- [ ] **Step 8: Compile, lint and run the package tests**
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+npx lerna run test --scope @theia/cooklang
+```
+
+Expected: all three exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/cooklang/src/browser/recipe-preview-widget.tsx
+git commit -m "feat(cooklang): discover, resolve and watch recipe images in the preview"
+```
+
+---
+
+### Task 8: Verify in the running app
+
+**Files:** none — this is a manual check.
+
+- [ ] **Step 1: Build the app**
+
+```bash
+cd app && npm run bundle
+```
+
+Expected: exits 0.
+
+- [ ] **Step 2: Create a fixture recipe**
+
+```bash
+mkdir -p /tmp/recipe-images-check
+cat > /tmp/recipe-images-check/Pancakes.cook <<'EOF'
+---
+title: Pancakes
+---
+Crack the @eggs{2} into a bowl.
+
+Whisk in the @flour{200%g}.
+
+= Serving
+
+Stack and pour over the @syrup{}.
+EOF
+```
+
+Copy any four JPEGs in as `Pancakes.jpg` (hero), `Pancakes.1.jpg` (linear step
+1), `Pancakes.3.jpg` (linear step 3) and `Pancakes.2.1.jpg` (section 2, step 1).
+
+- [ ] **Step 3: Start the app and open the fixture**
+
+```bash
+npm run start:electron
+```
+
+Open `/tmp/recipe-images-check` as the workspace, open `Pancakes.cook`, and open
+the recipe preview.
+
+- [ ] **Step 4: Check each behaviour**
+
+- The hero image appears above the title, capped at 400px tall and centred.
+- Step 1 shows `Pancakes.1.jpg`; step 2 shows no image.
+- The step under `= Serving` shows `Pancakes.2.1.jpg`, not `Pancakes.3.jpg` —
+  the section-specific image wins over the linear one.
+- `title`, and no `image`/`picture` key, appears in the metadata pills.
+- With the preview still open, copy another image in as `Pancakes.2.jpg`; step 2
+  gains an image within a second without touching the `.cook` file.
+- Overwrite `Pancakes.1.jpg` with a visibly different photo; step 1 updates to
+  the new image rather than keeping the old one.
+- Delete `Pancakes.jpg`; the hero image disappears.
+- Add `image: https://cooklang.org/images/logo.png` to the frontmatter; the
+  hero switches to the remote image.
+- Close the preview tab and confirm no errors appear in the devtools console.
+
+- [ ] **Step 5: Commit nothing, but record the result**
+
+If any check fails, fix it and amend the relevant task's commit. If all pass,
+the feature is done.
+
+---
+
+## Definition of done
+
+- `cd packages/cooklang-native && cargo test recipe_images` passes.
+- `npx lerna run test --scope @theia/cooklang` passes.
+- `npx lerna run lint --scope @theia/cooklang` passes.
+- Every manual check in Task 8 passes.
+- No changes were made to menu previews, editor hovers, the report/PDF export
+  path, or any drag-and-drop attach flow — all four are out of scope.

--- a/docs/superpowers/specs/2026-08-29-recipe-images-design.md
+++ b/docs/superpowers/specs/2026-08-29-recipe-images-design.md
@@ -151,22 +151,32 @@ Path resolution also lives here:
 ```ts
 export function resolveImageUri(
     raw: string,
-    recipeUri: URI,
-    workspaceRootUri: URI | undefined
+    recipeUri: URI
 ): { kind: 'remote'; url: string } | { kind: 'file'; uri: URI } | undefined;
 ```
 
-- `http://` / `https://` → passed through unchanged.
-- An absolute path → take its basename and resolve it against the recipe's
-  parent URI. Discovery is sibling-based, so this is always correct and avoids
-  converting a raw OS path into a URI in browser code.
-- A relative path from metadata → resolve against the recipe's folder first,
-  then the workspace root.
+Exactly three rules, with no heuristics:
 
-That last fallback is a deliberate, small superset of CookCLI, which resolves
-relative metadata paths against the workspace root only. `image: photo.jpg`
-next to the recipe is the obvious intent and currently 404s in CookCLI; trying
-the recipe folder first fixes that without breaking the root-relative case.
+- `http://` / `https://` (case-insensitive) → passed through unchanged.
+- An absolute path — POSIX `/…` or Windows `C:\…` / `C:/…` → used as given,
+  via `URI.fromFilePath`. Windows separators are normalised to `/` first,
+  because `URI.fromFilePath` does not translate them.
+- Anything else is relative → resolved against the recipe file's own folder.
+
+The rationale is that `cooklang-find` has already answered almost everything.
+`find_title_image` and `find_step_images` both return **absolute** paths, so
+those need no interpretation at all — rebuilding them from the recipe URI, or
+reducing them to a basename, would only discard information the crate gave us.
+The single genuinely ambiguous value is a metadata string (`image:`, `images:`,
+`picture:`, `pictures:`), which `Metadata::image_url()` hands back verbatim
+with zero resolution. For that one case we apply one conventional reading —
+relative to the recipe file — and stop guessing. In particular there is no
+workspace-root fallback: a metadata path containing a separator is treated the
+same as one without.
+
+`RECIPE_IMAGE_MIME_TYPES` also lives here and is the single source of truth for
+supported extensions; `RECIPE_IMAGE_EXTENSIONS` is derived from its keys and
+`RecipeImageService` reads its MIME types from it, so the two cannot drift.
 
 ### 3. Image loading — `packages/cooklang/src/browser/recipe-image-service.ts`
 
@@ -186,6 +196,12 @@ export class RecipeImageService {
   (`jpg`/`jpeg` → `image/jpeg`, `png` → `image/png`, `webp` → `image/webp`).
 - An internal `Map<string, string>` keyed by URI string means repeated renders
   of the same image reuse one object URL. `releaseAll()` revokes every URL.
+- A parallel map holds the *in-flight* read promise for each URI, so concurrent
+  `resolve` calls share one read, and an invalidation counter is captured before
+  the awaits. A read that settles after `release(uri)` or `releaseAll()` has
+  already run is stale: its object URL is revoked and discarded rather than
+  cached. Without that, disposing mid-read leaked a URL nothing could revoke,
+  and a file overwritten mid-read cached the old bytes permanently.
 - Files larger than 20 MB are skipped: `FileService` reads travel over the RPC
   channel to the backend, so a huge file would stall the preview.
 - A missing or unreadable file resolves to `undefined` rather than throwing.
@@ -207,16 +223,29 @@ protected images: ResolvedRecipeImages = { steps: {} };
 where the values are `src` strings ready for an `<img>`.
 
 - `setUri()` and the existing parse path both trigger `refreshImages()`.
-- `refreshImages()` calls `service.recipeImages(path)`, resolves every entry
-  through `RecipeImageService`, and guards on an `imageSequence` counter — the
-  same pattern `parseContent` uses — so a stale async resolve cannot overwrite
-  a newer result. Then `update()`.
+- `refreshImages()` calls `service.recipeImages(path)`, flattens the title and
+  every step entry into one list and resolves them with `Promise.all` — each is
+  a `FileService` read over RPC, so resolving them in sequence would make a
+  20-image recipe wait for ~40 round-trips before anything rendered. It guards
+  on an `imageSequence` counter — the same pattern `parseContent` uses — so a
+  stale async resolve cannot overwrite a newer result. Then `update()`.
+- A failed refresh is logged with `console.debug`. It is usually harmless (no
+  images, an unsaved file, an unreadable folder), but it is also where
+  `native.recipeImages is not a function` surfaces when the addon has not been
+  rebuilt, and that should not vanish silently.
 - Watching: `fileService.watch(this.uri.parent)` plus an `onDidFilesChange`
-  listener filtered to files whose name matches the recipe stem followed by a
-  dot and a supported image extension. Dropping `Pancakes.jpg` into the folder
-  refreshes an open preview; deleting it removes the image. The watcher
-  disposable goes on `this.toDispose`, and the handler is debounced by 150 ms
-  so a multi-file copy triggers one refresh.
+  listener. The listener does **not** re-derive the `<stem>.N.<ext>` naming
+  convention — that is `cooklang-find`'s job, and duplicating it meant a
+  metadata-referenced image such as `image: photo.jpg` never matched and so was
+  never invalidated. Instead `refreshImages()` records the set of file URIs it
+  actually resolved (remote ones excluded), and the handler refreshes when a
+  change either hits a URI in that set — calling `imageService.release(uri)` for
+  each, so an image replaced in place is re-read — or is a file in the watched
+  folder with an extension in `RECIPE_IMAGE_EXTENSIONS`. The second case is what
+  makes a *newly added* sibling image appear: a file that did not exist at the
+  last refresh cannot be in the resolved set. The watcher disposable goes on
+  `this.toDispose`, and the handler is debounced by 150 ms so a multi-file copy
+  triggers one refresh.
 
 ### 5. Rendering — `recipe-preview-components.tsx`
 
@@ -246,8 +275,14 @@ left-aligned. No hard-coded colours.
 - `recipe-images.spec.ts` — lookup precedence (section-specific beats linear),
   linear-only, section-only, missing, and every `resolveImageUri` branch.
   Monaco-free, no DOM.
-- `recipe-image-service.spec.ts` — MIME mapping, cache reuse, the size cap, and
-  missing-file → `undefined`, against a stubbed `FileService`.
+- `recipe-image-service.spec.ts` — MIME mapping (asserted on the captured
+  `Blob.type`, not merely that a URL came back), cache reuse, the size cap,
+  missing-file → `undefined`, and the in-flight cases above, against a stubbed
+  `FileService` whose reads can be deferred and settled by the test.
+- `recipe-preview-components.spec.ts` — `InstructionsPanel` rendered with
+  `renderToStaticMarkup` over a two-section recipe, checking that the panel
+  feeds `lookupStepImage` the right per-section and global indices and that a
+  text note does not advance either counter. Monaco-free, no jsdom needed.
 - Manual: open a recipe with `Pancakes.jpg`, `Pancakes.1.jpg` and
   `Pancakes.2.3.jpg`; confirm hero and step placement; then drop a new image
   into the folder and confirm the preview refreshes live.

--- a/docs/superpowers/specs/2026-08-29-recipe-images-design.md
+++ b/docs/superpowers/specs/2026-08-29-recipe-images-design.md
@@ -1,0 +1,261 @@
+# Recipe Images in the Recipe Preview
+
+Date: 2026-08-29
+
+## Goal
+
+Show recipe images in the editor's `.cook` preview panel, using the same
+discovery rules as the CookCLI web server so a recipe folder renders
+identically in both tools.
+
+## Background: how CookCLI does it
+
+Discovery lives in the `cooklang-find` crate (`src/model/recipe_entry.rs`);
+CookCLI consumes it in `src/web/builders.rs`.
+
+**Title image** — `RecipeEntry::title_image()`, in priority order:
+
+1. Metadata field `image`, `images`, `picture`, or `pictures` (a string, or the
+   first element of an array). May be a URL or a path.
+2. A sibling file with the recipe's stem: `Pancakes.jpg`, `.jpeg`, `.png`,
+   `.webp` next to `Pancakes.cook` (extensions tried in that order).
+
+**Step images** — `RecipeEntry::step_images()` globs the recipe's directory for
+`<stem>.*.<ext>` and parses the numeric components:
+
+- `Recipe.N.ext` — step N counted continuously across all sections, stored at
+  `[0][N-1]`.
+- `Recipe.S.N.ext` — step N within section S, stored at `[S-1][N-1]`.
+
+Filenames are one-indexed; the map keys are zero-indexed. Section 0 is reserved
+for the linear form.
+
+When rendering a step, `builders.rs` prefers the section-specific image and
+falls back to the linear one:
+
+```rust
+entry.step_images()
+    .get(section_index + 1, step_count + 1)
+    .or_else(|| entry.step_images().get(0, total_steps + step_count + 1))
+```
+
+`step_count` is the zero-based step index within the current section;
+`total_steps` is the number of steps in all preceding sections. Both arguments
+to `get()` are one-indexed. This two-convention lookup is CookCLI issue #374:
+the iOS app writes `Recipe.S.N.ext`, other tools write `Recipe.N.ext`.
+
+CookCLI serves the resolved files over an `/api/static` `ServeDir` mounted at
+the workspace root, and passes `http(s)` metadata values through untouched.
+
+## Current state of the editor
+
+`packages/cooklang/src/browser/recipe-preview-{widget,components}.tsx` render
+the parsed recipe. There is no image support at all — `image` and `images` are
+in `SKIP_META_KEYS` so they are not even shown as metadata pills.
+
+The editor has no static-file endpoint (no `@theia/mini-browser`), and the
+Theia renderer is loaded from `http://localhost:<port>`, so Chromium blocks
+`<img src="file://…">`. Local images must be read through `FileService` and
+converted to blob URLs.
+
+## Scope
+
+In scope:
+
+- Title (hero) image and per-step images in the `.cook` recipe preview.
+- Read-only display. Users add image files through Finder / their file manager.
+- `http(s)` URLs from metadata are loaded directly.
+
+Out of scope:
+
+- Menu (`.menu`) previews.
+- Monaco hover cards or editor decorations.
+- The report / PDF / PNG export path.
+- Drag-and-drop or paste to attach an image.
+
+## Design
+
+### 1. Native layer — `packages/cooklang-native`
+
+`cooklang-find` 0.6.1 is already a dependency. Add one napi function:
+
+```rust
+#[napi(js_name = "recipeImages")]
+pub fn napi_recipe_images(recipe_path: String) -> napi::Result<String>
+```
+
+It builds a `RecipeEntry::from_path(...)` and serialises:
+
+```json
+{
+  "title": "/abs/path/Pancakes.jpg",
+  "steps": { "0": { "2": "/abs/path/Pancakes.3.jpg" }, "1": { "0": "…" } }
+}
+```
+
+- `title` is `entry.title_image()` verbatim — an absolute path, a URL, a
+  relative path from metadata, or `null`.
+- `steps` is `entry.step_images().images` serialised as-is: section index →
+  step index, both zero-indexed, section 0 meaning the linear form.
+
+Returning the raw collection rather than a flattened list keeps the editor's
+lookup identical to `builders.rs` and inherits upstream's behaviour — including
+the known key collision where `get(0, N)` and `get(1, N)` both address section
+index 0 — instead of reinventing it.
+
+A `#[cfg(test)]` block with a tempdir covers: no images, title image only, each
+supported extension, linear step images, section-step images, and a recipe path
+that does not exist.
+
+Plumbing follows the existing `findRecipe` pattern exactly:
+
+- `recipeImages(recipePath: string): Promise<string>` on the
+  `CooklangLanguageService` interface in `src/common/cooklang-language-service.ts`,
+  documented with the same "OS filesystem path, not a URI; Electron-only"
+  caveat as its neighbours.
+- One `require('@theia/cooklang-native')` delegation in
+  `src/node/cooklang-language-service-impl.ts`.
+
+### 2. Pure logic — `packages/cooklang/src/common/recipe-images.ts`
+
+This module must not import anything that transitively pulls in
+`@theia/monaco`, so its spec can run under the mocha harness.
+
+```ts
+export interface RecipeImages {
+    title?: string;
+    steps: Record<string, Record<string, string>>;
+}
+
+/** The same shape after every entry has been turned into an <img> src. */
+export interface ResolvedRecipeImages {
+    title?: string;
+    steps: Record<string, Record<string, string>>;
+}
+
+export function lookupStepImage(
+    images: RecipeImages | ResolvedRecipeImages,
+    sectionIndex: number,     // zero-based section
+    stepInSection: number,    // zero-based step within that section
+    globalStepIndex: number   // zero-based step counted across all sections
+): string | undefined;
+```
+
+`lookupStepImage` mirrors `builders.rs`: try the section-specific entry first,
+applying the same section normalisation `StepImageCollection::get` uses, then
+fall back to the linear entry at `steps[0][globalStepIndex]`. The
+section-specific image wins.
+
+Path resolution also lives here:
+
+```ts
+export function resolveImageUri(
+    raw: string,
+    recipeUri: URI,
+    workspaceRootUri: URI | undefined
+): { kind: 'remote'; url: string } | { kind: 'file'; uri: URI } | undefined;
+```
+
+- `http://` / `https://` → passed through unchanged.
+- An absolute path → take its basename and resolve it against the recipe's
+  parent URI. Discovery is sibling-based, so this is always correct and avoids
+  converting a raw OS path into a URI in browser code.
+- A relative path from metadata → resolve against the recipe's folder first,
+  then the workspace root.
+
+That last fallback is a deliberate, small superset of CookCLI, which resolves
+relative metadata paths against the workspace root only. `image: photo.jpg`
+next to the recipe is the obvious intent and currently 404s in CookCLI; trying
+the recipe folder first fixes that without breaking the root-relative case.
+
+### 3. Image loading — `packages/cooklang/src/browser/recipe-image-service.ts`
+
+`file://` is blocked from the renderer's `http://localhost` origin, so local
+images are read and turned into blob URLs.
+
+```ts
+@injectable()
+export class RecipeImageService {
+    resolve(uri: URI): Promise<string | undefined>;
+    releaseAll(): void;
+}
+```
+
+- `FileService.readFile(uri)` → `Blob([buffer], { type })` →
+  `URL.createObjectURL`. The MIME type is derived from the extension
+  (`jpg`/`jpeg` → `image/jpeg`, `png` → `image/png`, `webp` → `image/webp`).
+- An internal `Map<string, string>` keyed by URI string means repeated renders
+  of the same image reuse one object URL. `releaseAll()` revokes every URL.
+- Files larger than 20 MB are skipped: `FileService` reads travel over the RPC
+  channel to the backend, so a huge file would stall the preview.
+- A missing or unreadable file resolves to `undefined` rather than throwing.
+
+`http(s)` URLs never reach this service; they go straight into `src`.
+
+The service is bound in the child container that
+`createRecipePreviewWidget` already creates, so its lifetime matches the
+preview panel and `releaseAll()` runs on widget dispose.
+
+### 4. Widget wiring — `recipe-preview-widget.tsx`
+
+New state beside `recipe` and `parseErrors`:
+
+```ts
+protected images: ResolvedRecipeImages = { steps: {} };
+```
+
+where the values are `src` strings ready for an `<img>`.
+
+- `setUri()` and the existing parse path both trigger `refreshImages()`.
+- `refreshImages()` calls `service.recipeImages(path)`, resolves every entry
+  through `RecipeImageService`, and guards on an `imageSequence` counter — the
+  same pattern `parseContent` uses — so a stale async resolve cannot overwrite
+  a newer result. Then `update()`.
+- Watching: `fileService.watch(this.uri.parent)` plus an `onDidFilesChange`
+  listener filtered to files whose name matches the recipe stem followed by a
+  dot and a supported image extension. Dropping `Pancakes.jpg` into the folder
+  refreshes an open preview; deleting it removes the image. The watcher
+  disposable goes on `this.toDispose`, and the handler is debounced by 150 ms
+  so a multi-file copy triggers one refresh.
+
+### 5. Rendering — `recipe-preview-components.tsx`
+
+- `RecipeView` gains an optional `images` prop. When `images.title` is set it
+  renders a hero `<img className='recipe-hero-image'>` above `.recipe-header`,
+  with `alt` set to the recipe title.
+- `SectionContentView` gains an optional `imageSrc`. When present it renders
+  `<img className='step-image'>` inside `.step-content`, below the step text
+  and the ingredients summary.
+- `InstructionsPanel` does the step counting — per-section and global — and
+  calls `lookupStepImage` for each step. It counts steps itself rather than
+  trusting the parser's `number` field, so the counters match `builders.rs`
+  regardless of whether `number` is per-section or global.
+- Both images get an `onError` handler that hides the element, so a corrupt
+  file degrades to no image rather than a broken-image icon.
+- `SKIP_META_KEYS` gains `picture` and `pictures` so those do not leak into the
+  metadata pills.
+
+CSS in `style/recipe-preview.css`: the hero image gets `max-width: 100%`,
+`max-height: 400px`, `object-fit: contain`, centred, rounded, with
+`var(--theia-widget-shadow)`. Step images are capped narrower (~320px) and
+left-aligned. No hard-coded colours.
+
+## Testing
+
+- Rust `#[cfg(test)]` tempdir cases for `recipeImages` (see section 1).
+- `recipe-images.spec.ts` — lookup precedence (section-specific beats linear),
+  linear-only, section-only, missing, and every `resolveImageUri` branch.
+  Monaco-free, no DOM.
+- `recipe-image-service.spec.ts` — MIME mapping, cache reuse, the size cap, and
+  missing-file → `undefined`, against a stubbed `FileService`.
+- Manual: open a recipe with `Pancakes.jpg`, `Pancakes.1.jpg` and
+  `Pancakes.2.3.jpg`; confirm hero and step placement; then drop a new image
+  into the folder and confirm the preview refreshes live.
+
+## Notes
+
+- The native addon must be rebuilt (`cd packages/cooklang-native && npm run
+  build`) for the new function to be callable, and the change ships to users
+  only with a new platform build.
+- Image discovery keys off the recipe's path on disk, not the editor buffer, so
+  images appear for unsaved edits as long as the file itself exists.

--- a/packages/cooklang-native/index.d.ts
+++ b/packages/cooklang-native/index.d.ts
@@ -61,6 +61,16 @@ export declare function checkedSet(entriesJson: string): Array<string>
  * Returns the file content, or `null` if no matching file is found.
  */
 export declare function findRecipe(baseDir: string, name: string): string | null
+/**
+ * Title and step images for the recipe at `recipe_path`, discovered with
+ * `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
+ *
+ * Returns JSON `{ "title": string | null, "steps": { section: { step: path } } }`.
+ * `title` is the raw value from metadata (which may be a URL or a relative path)
+ * or an absolute path to a sibling file. `steps` keys are zero-indexed, with
+ * section 0 holding the linear `Recipe.N.ext` form.
+ */
+export declare function recipeImages(recipePath: string): string
 export declare function compactChecked(entriesJson: string, currentIngredients: Array<string>): string
 /**
  * Search recipes under `base_dir` the way `cook search` does

--- a/packages/cooklang-native/index.js
+++ b/packages/cooklang-native/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, compactChecked, searchRecipes, parsePantry, checkPantry, renderReport } = nativeBinding
+const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, recipeImages, compactChecked, searchRecipes, parsePantry, checkPantry, renderReport } = nativeBinding
 
 module.exports.parse = parse
 module.exports.generateShoppingList = generateShoppingList
@@ -326,6 +326,7 @@ module.exports.parseChecked = parseChecked
 module.exports.writeCheckEntry = writeCheckEntry
 module.exports.checkedSet = checkedSet
 module.exports.findRecipe = findRecipe
+module.exports.recipeImages = recipeImages
 module.exports.compactChecked = compactChecked
 module.exports.searchRecipes = searchRecipes
 module.exports.parsePantry = parsePantry

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -949,6 +949,26 @@ pub fn napi_find_recipe(base_dir: String, name: String) -> napi::Result<Option<S
     }
 }
 
+/// Title and step images for the recipe at `recipe_path`, discovered with
+/// `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
+///
+/// Returns JSON `{ "title": string | null, "steps": { section: { step: path } } }`.
+/// `title` is the raw value from metadata (which may be a URL or a relative path)
+/// or an absolute path to a sibling file. `steps` keys are zero-indexed, with
+/// section 0 holding the linear `Recipe.N.ext` form.
+#[napi(js_name = "recipeImages")]
+pub fn napi_recipe_images(recipe_path: String) -> napi::Result<String> {
+    let path = Utf8PathBuf::from(recipe_path);
+    let entry = cooklang_find::RecipeEntry::from_path(path)
+        .map_err(|e| napi::Error::from_reason(format!("recipeImages: {e}")))?;
+    let payload = serde_json::json!({
+        "title": entry.title_image(),
+        "steps": entry.step_images().images,
+    });
+    serde_json::to_string(&payload)
+        .map_err(|e| napi::Error::from_reason(format!("recipeImages serialize: {e}")))
+}
+
 #[napi(js_name = "compactChecked")]
 pub fn napi_compact_checked(
     entries_json: String,
@@ -1654,5 +1674,87 @@ mod sync_status_tests {
         let mut state = SyncStatusState::default();
         state.apply_status_changed(cooklang_sync_client::SyncStatus::Downloading);
         assert_eq!(state.status, "downloading");
+    }
+}
+
+#[cfg(test)]
+mod recipe_images_tests {
+    use super::*;
+    use std::fs;
+
+    /// Creates a temp dir with `Recipe.cook` plus the given sibling image files.
+    fn fixture(name: &str, images: &[&str]) -> (std::path::PathBuf, String) {
+        let dir = std::env::temp_dir().join(format!(
+            "cooklang-images-{}-{}",
+            name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let recipe = dir.join("Pancakes.cook");
+        fs::write(&recipe, "Crack the @eggs{2}.\nFry it.\n").unwrap();
+        for image in images {
+            fs::write(dir.join(image), b"fake").unwrap();
+        }
+        (dir.clone(), recipe.to_string_lossy().to_string())
+    }
+
+    #[test]
+    fn reports_no_images_when_folder_has_none() {
+        let (_dir, path) = fixture("none", &[]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["title"].is_null());
+        assert_eq!(value["steps"].as_object().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn finds_the_sibling_title_image() {
+        let (_dir, path) = fixture("title", &["Pancakes.jpg"]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["title"].as_str().unwrap().ends_with("Pancakes.jpg"));
+    }
+
+    #[test]
+    fn finds_a_title_image_for_every_supported_extension() {
+        for ext in ["jpg", "jpeg", "png", "webp"] {
+            let (_dir, path) = fixture(ext, &[&format!("Pancakes.{ext}")]);
+            let json = napi_recipe_images(path).unwrap();
+            let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert!(
+                value["title"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .ends_with(&format!("Pancakes.{ext}")),
+                "extension {ext} was not discovered"
+            );
+        }
+    }
+
+    // `Recipe.N.ext` is the linear form: step N across all sections, stored at [0][N-1].
+    #[test]
+    fn stores_linear_step_images_under_section_zero() {
+        let (_dir, path) = fixture("linear", &["Pancakes.1.jpg", "Pancakes.3.png"]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["steps"]["0"]["0"].as_str().unwrap().ends_with("Pancakes.1.jpg"));
+        assert!(value["steps"]["0"]["2"].as_str().unwrap().ends_with("Pancakes.3.png"));
+    }
+
+    // `Recipe.S.N.ext` is the sectioned form: section S step N, stored at [S-1][N-1].
+    #[test]
+    fn stores_section_step_images_under_the_section_index() {
+        let (_dir, path) = fixture("sectioned", &["Pancakes.2.4.jpg"]);
+        let json = napi_recipe_images(path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(value["steps"]["1"]["3"].as_str().unwrap().ends_with("Pancakes.2.4.jpg"));
+    }
+
+    #[test]
+    fn errors_when_the_recipe_does_not_exist() {
+        assert!(napi_recipe_images("/definitely/not/here/Nope.cook".to_string()).is_err());
     }
 }

--- a/packages/cooklang/src/browser/recipe-image-service.spec.ts
+++ b/packages/cooklang/src/browser/recipe-image-service.spec.ts
@@ -33,23 +33,57 @@ class FakeFileService {
     size = 1024;
     reads: string[] = [];
     missing = false;
+    /** When true, `readFile` blocks until `settleReads` is called. */
+    deferReads = false;
+    protected waiting: Array<() => void> = [];
+
     async resolve(uri: URI): Promise<{ size: number }> {
         if (this.missing) { throw new Error(`not found: ${uri.toString()}`); }
         return { size: this.size };
     }
-    async readFile(uri: URI): Promise<{ value: BinaryBuffer }> {
-        if (this.missing) { throw new Error(`not found: ${uri.toString()}`); }
+
+    readFile(uri: URI): Promise<{ value: BinaryBuffer }> {
+        if (this.missing) { return Promise.reject(new Error(`not found: ${uri.toString()}`)); }
         this.reads.push(uri.toString());
-        return { value: BinaryBuffer.wrap(new Uint8Array([1, 2, 3])) };
+        const content = { value: BinaryBuffer.wrap(new Uint8Array([1, 2, 3])) };
+        if (!this.deferReads) {
+            return Promise.resolve(content);
+        }
+        return new Promise(resolve => this.waiting.push(() => resolve(content)));
+    }
+
+    /** Let every deferred read complete. */
+    settleReads(): void {
+        const waiting = this.waiting;
+        this.waiting = [];
+        for (const resume of waiting) {
+            resume();
+        }
     }
 }
 
-function createService(): { service: RecipeImageService; files: FakeFileService; created: string[]; revoked: string[] } {
+/** Let pending microtasks and timers run, so an in-flight read reaches `readFile`. */
+function flush(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+interface Harness {
+    service: RecipeImageService;
+    files: FakeFileService;
+    created: string[];
+    revoked: string[];
+    blobs: Blob[];
+}
+
+function createService(): Harness {
     const created: string[] = [];
     const revoked: string[] = [];
+    const blobs: Blob[] = [];
     let counter = 0;
     // jsdom has no URL.createObjectURL; stub it so the service is observable.
-    (URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL = () => {
+    // The blob is captured so the MIME type the service chose can be asserted.
+    (URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL = blob => {
+        blobs.push(blob);
         const url = `blob:fake/${counter++}`;
         created.push(url);
         return url;
@@ -62,7 +96,7 @@ function createService(): { service: RecipeImageService; files: FakeFileService;
     /* eslint-disable @typescript-eslint/no-explicit-any */
     (service as any).fileService = files;
     /* eslint-enable @typescript-eslint/no-explicit-any */
-    return { service, files, created, revoked };
+    return { service, files, created, revoked, blobs };
 }
 
 describe('RecipeImageService', () => {
@@ -137,5 +171,72 @@ describe('RecipeImageService', () => {
         service.releaseAll();
         await service.resolve(uri);
         expect(files.reads).to.have.length(2);
+    });
+
+    // The blob type is the only place the extension-to-MIME mapping is visible,
+    // so assert it directly rather than trusting that a URL came back at all.
+    it('gives each supported extension its MIME type', async () => {
+        const { service, blobs } = createService();
+        await service.resolve(new URI('file:///r/a.jpg'));
+        await service.resolve(new URI('file:///r/b.jpeg'));
+        await service.resolve(new URI('file:///r/c.png'));
+        await service.resolve(new URI('file:///r/d.webp'));
+        expect(blobs.map(blob => blob.type)).to.deep.equal([
+            'image/jpeg', 'image/jpeg', 'image/png', 'image/webp',
+        ]);
+    });
+
+    it('matches the extension case-insensitively', async () => {
+        const { service, blobs } = createService();
+        await service.resolve(new URI('file:///r/Hero.PNG'));
+        expect(blobs.map(blob => blob.type)).to.deep.equal(['image/png']);
+    });
+
+    // The widget disposes while a read is still in flight. Without tracking the
+    // in-flight read, that read would create an object URL after the cache had
+    // been emptied, so nothing would ever revoke it.
+    it('revokes the URL of a read that finishes after releaseAll', async () => {
+        const { service, files, created, revoked } = createService();
+        files.deferReads = true;
+        const pending = service.resolve(new URI('file:///r/Pancakes.jpg'));
+        await flush();
+        service.releaseAll();
+        files.settleReads();
+        expect(await pending).to.be.undefined;
+        expect(created).to.have.length(1);
+        expect(revoked).to.deep.equal(created);
+    });
+
+    // A file overwritten while its first read is in flight: the read settles
+    // after the invalidation, so its bytes are already stale and must not be
+    // cached, or every later resolve is a cache hit on the old image.
+    it('does not cache bytes read before a release of the same file', async () => {
+        const { service, files, created, revoked } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        files.deferReads = true;
+        const stale = service.resolve(uri);
+        await flush();
+        service.release(uri);
+        files.settleReads();
+        expect(await stale).to.be.undefined;
+        expect(revoked).to.deep.equal(created);
+
+        files.deferReads = false;
+        expect(await service.resolve(uri)).to.not.be.undefined;
+        expect(files.reads).to.have.length(2);
+    });
+
+    it('shares one read between concurrent resolves of the same file', async () => {
+        const { service, files } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        files.deferReads = true;
+        const first = service.resolve(uri);
+        const second = service.resolve(uri);
+        await flush();
+        files.settleReads();
+        const [a, b] = await Promise.all([first, second]);
+        expect(a).to.not.be.undefined;
+        expect(b).to.equal(a);
+        expect(files.reads).to.have.length(1);
     });
 });

--- a/packages/cooklang/src/browser/recipe-image-service.spec.ts
+++ b/packages/cooklang/src/browser/recipe-image-service.spec.ts
@@ -1,0 +1,141 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { RecipeImageService } from './recipe-image-service';
+
+after(() => disableJSDOM());
+
+class FakeFileService {
+    size = 1024;
+    reads: string[] = [];
+    missing = false;
+    async resolve(uri: URI): Promise<{ size: number }> {
+        if (this.missing) { throw new Error(`not found: ${uri.toString()}`); }
+        return { size: this.size };
+    }
+    async readFile(uri: URI): Promise<{ value: BinaryBuffer }> {
+        if (this.missing) { throw new Error(`not found: ${uri.toString()}`); }
+        this.reads.push(uri.toString());
+        return { value: BinaryBuffer.wrap(new Uint8Array([1, 2, 3])) };
+    }
+}
+
+function createService(): { service: RecipeImageService; files: FakeFileService; created: string[]; revoked: string[] } {
+    const created: string[] = [];
+    const revoked: string[] = [];
+    let counter = 0;
+    // jsdom has no URL.createObjectURL; stub it so the service is observable.
+    (URL as unknown as { createObjectURL: (b: Blob) => string }).createObjectURL = () => {
+        const url = `blob:fake/${counter++}`;
+        created.push(url);
+        return url;
+    };
+    (URL as unknown as { revokeObjectURL: (u: string) => void }).revokeObjectURL = url => {
+        revoked.push(url);
+    };
+    const service = new RecipeImageService();
+    const files = new FakeFileService();
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    (service as any).fileService = files;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    return { service, files, created, revoked };
+}
+
+describe('RecipeImageService', () => {
+
+    it('reads a local file and returns a blob URL', async () => {
+        const { service, created } = createService();
+        const url = await service.resolve(new URI('file:///r/Pancakes.jpg'));
+        expect(url).to.equal(created[0]);
+    });
+
+    it('reads each file once and reuses the cached URL', async () => {
+        const { service, files } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        const first = await service.resolve(uri);
+        const second = await service.resolve(uri);
+        expect(second).to.equal(first);
+        expect(files.reads).to.have.length(1);
+    });
+
+    // FileService reads travel over RPC to the backend; a huge file would stall
+    // the preview, so it is skipped rather than loaded.
+    it('skips files over the size cap', async () => {
+        const { service, files } = createService();
+        files.size = 40 * 1024 * 1024;
+        expect(await service.resolve(new URI('file:///r/Huge.png'))).to.be.undefined;
+        expect(files.reads).to.be.empty;
+    });
+
+    it('resolves to undefined for a missing or unreadable file', async () => {
+        const { service, files } = createService();
+        files.missing = true;
+        expect(await service.resolve(new URI('file:///r/Gone.jpg'))).to.be.undefined;
+    });
+
+    it('resolves to undefined for an unsupported extension', async () => {
+        const { service, files } = createService();
+        expect(await service.resolve(new URI('file:///r/notes.txt'))).to.be.undefined;
+        expect(files.reads).to.be.empty;
+    });
+
+    // A file replaced in place keeps its URI, so the cache must be invalidated
+    // for it or the preview keeps showing the old bytes forever.
+    it('re-reads a single file after release', async () => {
+        const { service, files, revoked } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        const first = await service.resolve(uri);
+        service.release(uri);
+        expect(revoked).to.deep.equal([first!]);
+        const second = await service.resolve(uri);
+        expect(second).to.not.equal(first);
+        expect(files.reads).to.have.length(2);
+    });
+
+    it('ignores release for a URI it never loaded', () => {
+        const { service, revoked } = createService();
+        service.release(new URI('file:///r/never.jpg'));
+        expect(revoked).to.be.empty;
+    });
+
+    it('revokes every object URL on releaseAll', async () => {
+        const { service, revoked } = createService();
+        const a = await service.resolve(new URI('file:///r/a.jpg'));
+        const b = await service.resolve(new URI('file:///r/b.png'));
+        service.releaseAll();
+        expect(revoked).to.have.members([a!, b!]);
+    });
+
+    it('re-reads a file after releaseAll', async () => {
+        const { service, files } = createService();
+        const uri = new URI('file:///r/Pancakes.jpg');
+        await service.resolve(uri);
+        service.releaseAll();
+        await service.resolve(uri);
+        expect(files.reads).to.have.length(2);
+    });
+});

--- a/packages/cooklang/src/browser/recipe-image-service.ts
+++ b/packages/cooklang/src/browser/recipe-image-service.ts
@@ -14,13 +14,7 @@
 import { injectable, inject } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import URI from '@theia/core/lib/common/uri';
-
-const MIME_TYPES: Record<string, string> = {
-    jpg: 'image/jpeg',
-    jpeg: 'image/jpeg',
-    png: 'image/png',
-    webp: 'image/webp',
-};
+import { RECIPE_IMAGE_MIME_TYPES } from '../common/recipe-images';
 
 /**
  * Turns local image files into `blob:` URLs an `<img>` can load.
@@ -41,42 +35,70 @@ export class RecipeImageService {
     @inject(FileService)
     protected readonly fileService: FileService;
 
+    /** Object URLs for reads that have settled, so they can be revoked. */
     protected readonly urls = new Map<string, string>();
+
+    /** In-flight or settled reads, so concurrent callers share one read. */
+    protected readonly pending = new Map<string, Promise<string | undefined>>();
+
+    /**
+     * Bumped by every `release`/`releaseAll`. A read that started before the
+     * bump is stale by the time it settles and must not populate the cache.
+     */
+    protected epoch = 0;
 
     /**
      * A `blob:` URL for `uri`, or `undefined` when the file is missing,
      * unreadable, too large, or not a supported image type. Repeated calls for
-     * the same URI reuse one object URL.
+     * the same URI reuse one object URL, and concurrent calls share one read.
      */
-    async resolve(uri: URI): Promise<string | undefined> {
+    resolve(uri: URI): Promise<string | undefined> {
         const key = uri.toString();
-        const cached = this.urls.get(key);
-        if (cached) {
-            return cached;
+        const inFlight = this.pending.get(key);
+        if (inFlight) {
+            return inFlight;
         }
-        const type = MIME_TYPES[uri.path.ext.replace(/^\./, '').toLowerCase()];
+        const type = RECIPE_IMAGE_MIME_TYPES[uri.path.ext.replace(/^\./, '').toLowerCase()];
         if (!type) {
-            return undefined;
+            return Promise.resolve(undefined);
         }
+        const read = this.read(uri, key, type);
+        this.pending.set(key, read);
+        return read;
+    }
+
+    /** Read one file and cache its object URL, unless invalidated meanwhile. */
+    protected async read(uri: URI, key: string, type: string): Promise<string | undefined> {
+        const epoch = this.epoch;
         try {
             const stat = await this.fileService.resolve(uri);
             if ((stat.size ?? 0) > RecipeImageService.MAX_BYTES) {
+                this.forget(key, epoch);
                 return undefined;
             }
             const content = await this.fileService.readFile(uri);
             // `BinaryBuffer#buffer` is typed as `Uint8Array<ArrayBufferLike>`, but
             // `BlobPart` wants `ArrayBufferView<ArrayBuffer>`; the bytes are fine as-is.
             const url = URL.createObjectURL(new Blob([content.value.buffer as BlobPart], { type }));
-            // Another call may have populated the cache while we awaited.
-            const raced = this.urls.get(key);
-            if (raced) {
+            if (epoch !== this.epoch) {
+                // The file was invalidated, or the widget disposed, while this read
+                // was in flight. These bytes are stale and nothing would ever revoke
+                // the URL, so drop it instead of caching it.
                 URL.revokeObjectURL(url);
-                return raced;
+                return undefined;
             }
             this.urls.set(key, url);
             return url;
         } catch {
+            this.forget(key, epoch);
             return undefined;
+        }
+    }
+
+    /** Drop a read that produced nothing, so a later call retries it. */
+    protected forget(key: string, epoch: number): void {
+        if (epoch === this.epoch) {
+            this.pending.delete(key);
         }
     }
 
@@ -92,6 +114,8 @@ export class RecipeImageService {
             URL.revokeObjectURL(url);
             this.urls.delete(key);
         }
+        this.pending.delete(key);
+        this.epoch++;
     }
 
     /** Revoke every object URL handed out so far and empty the cache. */
@@ -100,5 +124,7 @@ export class RecipeImageService {
             URL.revokeObjectURL(url);
         }
         this.urls.clear();
+        this.pending.clear();
+        this.epoch++;
     }
 }

--- a/packages/cooklang/src/browser/recipe-image-service.ts
+++ b/packages/cooklang/src/browser/recipe-image-service.ts
@@ -1,0 +1,104 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import URI from '@theia/core/lib/common/uri';
+
+const MIME_TYPES: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    webp: 'image/webp',
+};
+
+/**
+ * Turns local image files into `blob:` URLs an `<img>` can load.
+ *
+ * The Theia renderer is served from `http://localhost:<port>`, so Chromium
+ * blocks `file://` sources: the bytes have to come through `FileService`.
+ * One instance is bound per preview widget, and `releaseAll` runs on dispose.
+ */
+@injectable()
+export class RecipeImageService {
+
+    /**
+     * `FileService` reads travel over the RPC channel to the backend, so a very
+     * large file would stall the preview. Recipe photos are far below this.
+     */
+    static readonly MAX_BYTES = 20 * 1024 * 1024;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    protected readonly urls = new Map<string, string>();
+
+    /**
+     * A `blob:` URL for `uri`, or `undefined` when the file is missing,
+     * unreadable, too large, or not a supported image type. Repeated calls for
+     * the same URI reuse one object URL.
+     */
+    async resolve(uri: URI): Promise<string | undefined> {
+        const key = uri.toString();
+        const cached = this.urls.get(key);
+        if (cached) {
+            return cached;
+        }
+        const type = MIME_TYPES[uri.path.ext.replace(/^\./, '').toLowerCase()];
+        if (!type) {
+            return undefined;
+        }
+        try {
+            const stat = await this.fileService.resolve(uri);
+            if ((stat.size ?? 0) > RecipeImageService.MAX_BYTES) {
+                return undefined;
+            }
+            const content = await this.fileService.readFile(uri);
+            // `BinaryBuffer#buffer` is typed as `Uint8Array<ArrayBufferLike>`, but
+            // `BlobPart` wants `ArrayBufferView<ArrayBuffer>`; the bytes are fine as-is.
+            const url = URL.createObjectURL(new Blob([content.value.buffer as BlobPart], { type }));
+            // Another call may have populated the cache while we awaited.
+            const raced = this.urls.get(key);
+            if (raced) {
+                URL.revokeObjectURL(url);
+                return raced;
+            }
+            this.urls.set(key, url);
+            return url;
+        } catch {
+            return undefined;
+        }
+    }
+
+    /**
+     * Drop the cached URL for one file, so the next `resolve` re-reads it.
+     * Needed when an image is replaced in place: the URI is unchanged, so
+     * without this the preview would keep showing the old bytes.
+     */
+    release(uri: URI): void {
+        const key = uri.toString();
+        const url = this.urls.get(key);
+        if (url) {
+            URL.revokeObjectURL(url);
+            this.urls.delete(key);
+        }
+    }
+
+    /** Revoke every object URL handed out so far and empty the cache. */
+    releaseAll(): void {
+        for (const url of this.urls.values()) {
+            URL.revokeObjectURL(url);
+        }
+        this.urls.clear();
+    }
+}

--- a/packages/cooklang/src/browser/recipe-preview-components.spec.ts
+++ b/packages/cooklang/src/browser/recipe-preview-components.spec.ts
@@ -1,0 +1,93 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Section } from '../common/recipe-types';
+import { ResolvedRecipeImages } from '../common/recipe-images';
+import { InstructionsPanel } from './recipe-preview-components';
+
+/** A step whose only content is `text`, so it is identifiable in the markup. */
+function step(text: string, number: number): Section['content'][number] {
+    return { type: 'step', value: { items: [{ type: 'text', value: text }], number } };
+}
+
+function render(sections: Section[], images: ResolvedRecipeImages): string {
+    return renderToStaticMarkup(
+        React.createElement(InstructionsPanel, {
+            sections,
+            ingredients: [],
+            cookware: [],
+            timers: [],
+            inlineQuantities: [],
+            images,
+        })
+    );
+}
+
+/** The `src` of the image rendered inside the step whose text is `text`, if any. */
+function imageForStep(markup: string, text: string): string | undefined {
+    const start = markup.indexOf(text);
+    expect(start, `step "${text}" is not in the markup`).to.be.greaterThan(-1);
+    const next = markup.indexOf('class="step-item"', start);
+    const slice = next === -1 ? markup.substring(start) : markup.substring(start, next);
+    return /class="step-image" src="([^"]*)"/.exec(slice)?.[1];
+}
+
+describe('InstructionsPanel step image indices', () => {
+
+    // Two sections, 2 + 1 steps. The third step overall is both global index 2
+    // (the linear entry `linear.jpg`) and section 1 / step 0 (`sec.jpg`), so it
+    // pins the section-beats-linear precedence end to end.
+    const sections: Section[] = [
+        { name: 'Prep', content: [step('one', 1), step('two', 2)] },
+        { name: 'Cook', content: [step('three', 1)] },
+    ];
+
+    const images: ResolvedRecipeImages = {
+        steps: {
+            '0': { '2': 'linear.jpg' },
+            '1': { '0': 'sec.jpg' },
+        },
+    };
+
+    it('gives the third step the section image, not the linear one', () => {
+        expect(imageForStep(render(sections, images), 'three')).to.equal('sec.jpg');
+    });
+
+    it('gives the first two steps no image', () => {
+        const markup = render(sections, images);
+        expect(imageForStep(markup, 'one')).to.be.undefined;
+        expect(imageForStep(markup, 'two')).to.be.undefined;
+    });
+
+    // Same recipe with the section entry removed: the third step now falls back
+    // to the linear entry, which proves the global index really is 2 there.
+    it('falls back to the linear image at the global step index', () => {
+        const markup = render(sections, { steps: { '0': { '2': 'linear.jpg' } } });
+        expect(imageForStep(markup, 'three')).to.equal('linear.jpg');
+        expect(imageForStep(markup, 'one')).to.be.undefined;
+        expect(imageForStep(markup, 'two')).to.be.undefined;
+    });
+
+    // Text content between steps must not advance either counter.
+    it('does not count text notes as steps', () => {
+        const withNote: Section[] = [
+            { name: 'Only', content: [step('one', 1), { type: 'text', value: 'a note' }, step('two', 2)] },
+        ];
+        const markup = render(withNote, { steps: { '0': { '1': 'second.jpg' } } });
+        expect(imageForStep(markup, 'two')).to.equal('second.jpg');
+        expect(imageForStep(markup, 'one')).to.be.undefined;
+    });
+});

--- a/packages/cooklang/src/browser/recipe-preview-components.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-components.tsx
@@ -34,6 +34,7 @@ import {
     formatQuantity,
     scaleRecipe,
 } from '../common/recipe-types';
+import { ResolvedRecipeImages, lookupStepImage } from '../common/recipe-images';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -41,6 +42,7 @@ import {
 
 const SKIP_META_KEYS = new Set([
     'name', 'tags', 'tag', 'description', 'images', 'image', 'locale',
+    'picture', 'pictures',
 ]);
 
 const KNOWN_META_KEYS: ReadonlyArray<string> = [
@@ -186,6 +188,31 @@ const StepIngredientsSummary = ({ items, ingredients }: StepIngredientsSummaryPr
 };
 
 // ---------------------------------------------------------------------------
+// RecipeImage
+// ---------------------------------------------------------------------------
+
+interface RecipeImageProps {
+    src: string;
+    alt: string;
+    className: string;
+}
+
+/**
+ * An image that removes itself when the source fails to load, so a corrupt or
+ * vanished file degrades to no image rather than a broken-image icon.
+ */
+const RecipeImage = ({ src, alt, className }: RecipeImageProps): React.ReactElement => {
+    const [failed, setFailed] = React.useState(false);
+    const onError = React.useCallback(() => setFailed(true), []);
+    // A new src is a new attempt: clear the previous failure.
+    React.useEffect(() => setFailed(false), [src]);
+    if (failed) {
+        return <></>;
+    }
+    return <img className={className} src={src} alt={alt} onError={onError} />;
+};
+
+// ---------------------------------------------------------------------------
 // SectionContentView  (single step or text note)
 // ---------------------------------------------------------------------------
 
@@ -195,6 +222,7 @@ interface SectionContentViewProps {
     cookware: Cookware[];
     timers: Timer[];
     inlineQuantities: InlineQuantity[];
+    imageSrc?: string;
 }
 
 const SectionContentView = ({
@@ -203,6 +231,7 @@ const SectionContentView = ({
     cookware,
     timers,
     inlineQuantities,
+    imageSrc,
 }: SectionContentViewProps): React.ReactElement => {
     if (content.type === 'text') {
         return <div className='note-item'>{content.value}</div>;
@@ -224,6 +253,9 @@ const SectionContentView = ({
                     />
                 ))}
                 <StepIngredientsSummary items={items} ingredients={ingredients} />
+                {imageSrc && (
+                    <RecipeImage className='step-image' src={imageSrc} alt={`Step ${number}`} />
+                )}
             </div>
         </div>
     );
@@ -239,6 +271,7 @@ interface InstructionsPanelProps {
     cookware: Cookware[];
     timers: Timer[];
     inlineQuantities: InlineQuantity[];
+    images?: ResolvedRecipeImages;
 }
 
 export const InstructionsPanel = ({
@@ -247,28 +280,49 @@ export const InstructionsPanel = ({
     cookware,
     timers,
     inlineQuantities,
-}: InstructionsPanelProps): React.ReactElement => (
-    <div className='recipe-instructions'>
-        <h2 className='instructions-title'>Instructions</h2>
-        {sections.map((section, sIdx) => (
-            <React.Fragment key={sIdx}>
-                {section.name && (
-                    <h3 className='section-header'>{section.name}</h3>
-                )}
-                {section.content.map((content, cIdx) => (
-                    <SectionContentView
-                        key={cIdx}
-                        content={content}
-                        ingredients={ingredients}
-                        cookware={cookware}
-                        timers={timers}
-                        inlineQuantities={inlineQuantities}
-                    />
-                ))}
-            </React.Fragment>
-        ))}
-    </div>
-);
+    images,
+}: InstructionsPanelProps): React.ReactElement => {
+    // Steps are counted here rather than read from `content.value.number` so the
+    // per-section and global counters match cookcli's `builders.rs` exactly,
+    // whichever convention the parser uses for `number`.
+    let globalStepIndex = 0;
+    return (
+        <div className='recipe-instructions'>
+            <h2 className='instructions-title'>Instructions</h2>
+            {sections.map((section, sIdx) => {
+                let stepInSection = 0;
+                return (
+                    <React.Fragment key={sIdx}>
+                        {section.name && (
+                            <h3 className='section-header'>{section.name}</h3>
+                        )}
+                        {section.content.map((content, cIdx) => {
+                            let imageSrc: string | undefined;
+                            if (content.type === 'step') {
+                                if (images) {
+                                    imageSrc = lookupStepImage(images, sIdx, stepInSection, globalStepIndex);
+                                }
+                                stepInSection++;
+                                globalStepIndex++;
+                            }
+                            return (
+                                <SectionContentView
+                                    key={cIdx}
+                                    content={content}
+                                    ingredients={ingredients}
+                                    cookware={cookware}
+                                    timers={timers}
+                                    inlineQuantities={inlineQuantities}
+                                    imageSrc={imageSrc}
+                                />
+                            );
+                        })}
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+};
 
 // ---------------------------------------------------------------------------
 // IngredientRow
@@ -437,12 +491,13 @@ export const MetadataPills = ({ meta }: MetadataPillsProps): React.ReactElement 
 export interface RecipeViewProps {
     recipe: Recipe;
     fileName: string;
+    images?: ResolvedRecipeImages;
     onShowSource?: () => void;
     onAddToShoppingList?: (scale: number) => void;
     onNavigateToRecipe?: (referencePath: string) => void;
 }
 
-export const RecipeView = ({ recipe, fileName, onShowSource, onAddToShoppingList, onNavigateToRecipe }: RecipeViewProps): React.ReactElement => {
+export const RecipeView = ({ recipe, fileName, images, onShowSource, onAddToShoppingList, onNavigateToRecipe }: RecipeViewProps): React.ReactElement => {
     const [scale, setScale] = React.useState(1);
     const meta = recipe.metadata.map;
 
@@ -465,6 +520,9 @@ export const RecipeView = ({ recipe, fileName, onShowSource, onAddToShoppingList
 
     return (
         <div>
+            {images?.title && (
+                <RecipeImage className='recipe-hero-image' src={images.title} alt={title} />
+            )}
             <div className='recipe-header'>
                 <h1 className='recipe-title'>{title}</h1>
                 <div className='recipe-header-actions'>
@@ -528,6 +586,7 @@ export const RecipeView = ({ recipe, fileName, onShowSource, onAddToShoppingList
                     cookware={scaled.cookware}
                     timers={scaled.timers}
                     inlineQuantities={scaled.inline_quantities}
+                    images={images}
                 />
             </div>
         </div>

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -305,12 +305,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         if (!raw) {
             return undefined;
         }
-        const root = this.workspaceService.tryGetRoots()[0];
-        const location = resolveImageUri(
-            raw,
-            this.uri,
-            root ? new URI(root.resource.toString()) : undefined
-        );
+        const location = resolveImageUri(raw, this.uri);
         if (!location) {
             return undefined;
         }

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -25,6 +25,13 @@ import URI from '@theia/core/lib/common/uri';
 import * as React from '@theia/core/shared/react';
 import { CooklangLanguageService, COOKLANG_LANGUAGE_ID } from '../common';
 import { Recipe } from '../common/recipe-types';
+import {
+    RecipeImages,
+    ResolvedRecipeImages,
+    resolveImageUri,
+    RECIPE_IMAGE_EXTENSIONS,
+} from '../common/recipe-images';
+import { RecipeImageService } from './recipe-image-service';
 import { RecipeView } from './recipe-preview-components';
 
 import '../../src/browser/style/recipe-preview.css';
@@ -70,11 +77,17 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
+    @inject(RecipeImageService)
+    protected readonly imageService: RecipeImageService;
+
     protected uri: URI;
     protected recipe: Recipe | undefined;
     protected parseErrors: string[] = [];
     protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
     protected parseSequence = 0;
+    protected images: ResolvedRecipeImages = { steps: {} };
+    protected imageSequence = 0;
+    protected imageDebounceTimer: ReturnType<typeof setTimeout> | undefined;
 
     @postConstruct()
     protected init(): void {
@@ -102,6 +115,8 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         this.title.caption = `Recipe preview for ${uri.toString()}`;
         this.title.closable = true;
         this.title.iconClass = 'codicon codicon-open-preview';
+        this.watchImageFolder();
+        this.refreshImages();
         this.parseCurrentContent();
     }
 
@@ -190,6 +205,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
                 this.recipe = undefined;
                 this.parseErrors = [`Failed to parse response: ${e}`];
             }
+            this.refreshImages();
             this.update();
         }).catch(e => {
             if (this.isDisposed || sequence !== this.parseSequence) {
@@ -199,6 +215,108 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
             this.parseErrors = [`Parse request failed: ${e}`];
             this.update();
         });
+    }
+
+    // --- Image helpers ---
+
+    /**
+     * Watch the recipe's folder so an image dropped in from Finder shows up in
+     * an already-open preview, and a deleted one disappears.
+     */
+    protected watchImageFolder(): void {
+        const folder = this.uri.parent;
+        this.toDispose.push(this.fileService.watch(folder));
+        this.toDispose.push(this.fileService.onDidFilesChange(event => {
+            const touched = event.changes
+                .map(change => change.resource)
+                .filter(resource => this.isImageOfThisRecipe(resource));
+            if (touched.length === 0) {
+                return;
+            }
+            // An image replaced in place keeps its URI, so the cached blob for
+            // it has to go or the preview would keep showing the old bytes.
+            for (const resource of touched) {
+                this.imageService.release(resource);
+            }
+            this.debouncedRefreshImages();
+        }));
+    }
+
+    /** True when `resource` is a `<stem>.….<ext>` image belonging to this recipe. */
+    protected isImageOfThisRecipe(resource: URI): boolean {
+        if (resource.parent.toString() !== this.uri.parent.toString()) {
+            return false;
+        }
+        const name = resource.path.base;
+        const stem = this.uri.path.name;
+        if (!name.toLowerCase().startsWith(stem.toLowerCase() + '.')) {
+            return false;
+        }
+        const ext = resource.path.ext.replace(/^\./, '').toLowerCase();
+        return RECIPE_IMAGE_EXTENSIONS.includes(ext);
+    }
+
+    /** Coalesce the burst of events a multi-file copy produces into one refresh. */
+    protected debouncedRefreshImages(): void {
+        if (this.imageDebounceTimer !== undefined) {
+            clearTimeout(this.imageDebounceTimer);
+        }
+        this.imageDebounceTimer = setTimeout(() => {
+            this.imageDebounceTimer = undefined;
+            this.refreshImages();
+        }, 150);
+    }
+
+    /**
+     * Ask the backend which images exist for this recipe and turn each one into
+     * an `<img>` src. Guarded by `imageSequence` so a slow refresh cannot
+     * overwrite a newer one.
+     */
+    protected async refreshImages(): Promise<void> {
+        if (!this.uri) {
+            return;
+        }
+        const sequence = ++this.imageSequence;
+        const resolved: ResolvedRecipeImages = { steps: {} };
+        try {
+            const json = await this.service.recipeImages(this.uri.path.fsPath());
+            const discovered = JSON.parse(json) as RecipeImages;
+            resolved.title = await this.toImageSrc(discovered.title);
+            for (const [section, steps] of Object.entries(discovered.steps ?? {})) {
+                for (const [step, raw] of Object.entries(steps)) {
+                    const src = await this.toImageSrc(raw);
+                    if (src) {
+                        (resolved.steps[section] ??= {})[step] = src;
+                    }
+                }
+            }
+        } catch {
+            // No images, an unsaved file, or an unreadable folder: render none.
+        }
+        if (this.isDisposed || sequence !== this.imageSequence) {
+            return;
+        }
+        this.images = resolved;
+        this.update();
+    }
+
+    /** Resolve one raw image value to a URL an `<img>` can load. */
+    protected async toImageSrc(raw: string | undefined): Promise<string | undefined> {
+        if (!raw) {
+            return undefined;
+        }
+        const root = this.workspaceService.tryGetRoots()[0];
+        const location = resolveImageUri(
+            raw,
+            this.uri,
+            root ? new URI(root.resource.toString()) : undefined
+        );
+        if (!location) {
+            return undefined;
+        }
+        return location.kind === 'remote'
+            ? location.url
+            : this.imageService.resolve(location.uri);
     }
 
     // --- Rendering ---
@@ -229,6 +347,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
                 <RecipeView
                     recipe={this.recipe}
                     fileName={this.uri?.path.base ?? ''}
+                    images={this.images}
                     onShowSource={this.handleShowSource}
                     onAddToShoppingList={this.handleAddToShoppingList}
                     onNavigateToRecipe={this.handleNavigateToRecipe}
@@ -263,6 +382,11 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
             clearTimeout(this.debounceTimer);
             this.debounceTimer = undefined;
         }
+        if (this.imageDebounceTimer !== undefined) {
+            clearTimeout(this.imageDebounceTimer);
+            this.imageDebounceTimer = undefined;
+        }
+        this.imageService.releaseAll();
         super.dispose();
     }
 }
@@ -283,6 +407,7 @@ export function createRecipePreviewWidget(
     uri: URI
 ): RecipePreviewWidget {
     const child = container.createChild();
+    child.bind(RecipeImageService).toSelf().inSingletonScope();
     child.bind(RecipePreviewWidget).toSelf().inTransientScope();
     const widget = child.get(RecipePreviewWidget);
     widget.setUri(uri);

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -88,6 +88,8 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     protected images: ResolvedRecipeImages = { steps: {} };
     protected imageSequence = 0;
     protected imageDebounceTimer: ReturnType<typeof setTimeout> | undefined;
+    /** File URIs the last successful refresh actually resolved (remote ones excluded). */
+    protected resolvedImageUris: ReadonlySet<string> = new Set<string>();
 
     @postConstruct()
     protected init(): void {
@@ -227,10 +229,19 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         const folder = this.uri.parent;
         this.toDispose.push(this.fileService.watch(folder));
         this.toDispose.push(this.fileService.onDidFilesChange(event => {
+            // Which files this recipe uses is `cooklang-find`'s answer, not
+            // something to re-derive here: consult the set the last refresh
+            // resolved rather than pattern-matching filenames.
             const touched = event.changes
                 .map(change => change.resource)
-                .filter(resource => this.isImageOfThisRecipe(resource));
-            if (touched.length === 0) {
+                .filter(resource => this.resolvedImageUris.has(resource.toString()));
+            // A file that did not exist at the last refresh cannot be in that
+            // set, so also react to any image appearing in the watched folder.
+            const folderKey = folder.toString();
+            const nearbyImage = event.changes.some(change =>
+                change.resource.parent.toString() === folderKey
+                && RECIPE_IMAGE_EXTENSIONS.includes(change.resource.path.ext.replace(/^\./, '').toLowerCase()));
+            if (touched.length === 0 && !nearbyImage) {
                 return;
             }
             // An image replaced in place keeps its URI, so the cached blob for
@@ -240,20 +251,6 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
             }
             this.debouncedRefreshImages();
         }));
-    }
-
-    /** True when `resource` is a `<stem>.….<ext>` image belonging to this recipe. */
-    protected isImageOfThisRecipe(resource: URI): boolean {
-        if (resource.parent.toString() !== this.uri.parent.toString()) {
-            return false;
-        }
-        const name = resource.path.base;
-        const stem = this.uri.path.name;
-        if (!name.toLowerCase().startsWith(stem.toLowerCase() + '.')) {
-            return false;
-        }
-        const ext = resource.path.ext.replace(/^\./, '').toLowerCase();
-        return RECIPE_IMAGE_EXTENSIONS.includes(ext);
     }
 
     /** Coalesce the burst of events a multi-file copy produces into one refresh. */
@@ -278,30 +275,52 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         }
         const sequence = ++this.imageSequence;
         const resolved: ResolvedRecipeImages = { steps: {} };
+        const fileUris = new Set<string>();
         try {
             const json = await this.service.recipeImages(this.uri.path.fsPath());
             const discovered = JSON.parse(json) as RecipeImages;
-            resolved.title = await this.toImageSrc(discovered.title);
+            // Every entry is a `FileService` read over RPC, so they are flattened
+            // and awaited together: a 20-image recipe should not pay for forty
+            // sequential round-trips before anything renders.
+            const entries: Array<{ section?: string; step?: string; raw: string }> = [];
+            if (discovered.title) {
+                entries.push({ raw: discovered.title });
+            }
             for (const [section, steps] of Object.entries(discovered.steps ?? {})) {
                 for (const [step, raw] of Object.entries(steps)) {
-                    const src = await this.toImageSrc(raw);
-                    if (src) {
-                        (resolved.steps[section] ??= {})[step] = src;
-                    }
+                    entries.push({ section, step, raw });
                 }
             }
-        } catch {
-            // No images, an unsaved file, or an unreadable folder: render none.
+            await Promise.all(entries.map(async entry => {
+                const src = await this.toImageSrc(entry.raw, fileUris);
+                if (!src) {
+                    return;
+                }
+                if (entry.section === undefined || entry.step === undefined) {
+                    resolved.title = src;
+                } else {
+                    (resolved.steps[entry.section] ??= {})[entry.step] = src;
+                }
+            }));
+        } catch (e) {
+            // Usually harmless: no images, an unsaved file, or an unreadable
+            // folder. But it also catches a native addon that predates
+            // `recipeImages` and needs rebuilding, so say what happened.
+            console.debug('Recipe image refresh failed', e);
         }
         if (this.isDisposed || sequence !== this.imageSequence) {
             return;
         }
         this.images = resolved;
+        this.resolvedImageUris = fileUris;
         this.update();
     }
 
-    /** Resolve one raw image value to a URL an `<img>` can load. */
-    protected async toImageSrc(raw: string | undefined): Promise<string | undefined> {
+    /**
+     * Resolve one raw image value to a URL an `<img>` can load, recording every
+     * local file URI in `fileUris` so the watcher knows what this recipe reads.
+     */
+    protected async toImageSrc(raw: string | undefined, fileUris: Set<string>): Promise<string | undefined> {
         if (!raw) {
             return undefined;
         }
@@ -309,9 +328,13 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         if (!location) {
             return undefined;
         }
-        return location.kind === 'remote'
-            ? location.url
-            : this.imageService.resolve(location.uri);
+        if (location.kind === 'remote') {
+            return location.url;
+        }
+        // Recorded even when the read fails: a file that is missing now may be
+        // created later, and the watcher should notice when it is.
+        fileUris.add(location.uri.toString());
+        return this.imageService.resolve(location.uri);
     }
 
     // --- Rendering ---

--- a/packages/cooklang/src/browser/style/recipe-preview.css
+++ b/packages/cooklang/src/browser/style/recipe-preview.css
@@ -388,3 +388,25 @@
     color: var(--theia-descriptionForeground);
     font-style: italic;
 }
+
+/* Recipe images -------------------------------------------------------- */
+
+.theia-recipe-preview .recipe-hero-image {
+    display: block;
+    margin: 0 auto 16px;
+    max-width: 100%;
+    max-height: 400px;
+    object-fit: contain;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px var(--theia-widget-shadow);
+}
+
+.theia-recipe-preview .step-image {
+    display: block;
+    margin-top: 10px;
+    max-width: 320px;
+    width: 100%;
+    height: auto;
+    border-radius: 6px;
+    box-shadow: 0 1px 4px var(--theia-widget-shadow);
+}

--- a/packages/cooklang/src/common/cooklang-language-service.ts
+++ b/packages/cooklang/src/common/cooklang-language-service.ts
@@ -67,6 +67,20 @@ export interface CooklangLanguageService {
     findRecipe(baseDir: string, name: string): Promise<string | undefined>;
 
     /**
+     * Title and step images for the recipe at `recipePath`, discovered with
+     * `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
+     *
+     * Returns JSON `{ title: string | null, steps: { [section]: { [step]: path } } }`.
+     * `title` is raw: an absolute path, a URL, or a relative path from metadata.
+     * `steps` keys are zero-indexed; section 0 holds the linear `Recipe.N.ext` form.
+     *
+     * `recipePath` must be an OS filesystem path (not a URI) — this RPC reads
+     * from disk directly via `cooklang-find` and bypasses Theia's `FileService`.
+     * Electron-only by design; remote/virtual workspaces are not supported.
+     */
+    recipeImages(recipePath: string): Promise<string>;
+
+    /**
      * Search recipes under `baseDir` like `cook search` (cooklang-find: filename
      * + content term scoring over `.cook` and `.menu`). A blank query lists every
      * recipe. Same disk-access caveat as `findRecipe` (OS path, Electron-only).

--- a/packages/cooklang/src/common/index.ts
+++ b/packages/cooklang/src/common/index.ts
@@ -18,6 +18,7 @@ export const AISLE_CONF_TEXTMATE_SCOPE = 'source.aisle-conf';
 export { CooklangLanguageService, CooklangLanguageServicePath } from './cooklang-language-service';
 export { CooklangUri } from './cooklang-uri';
 export * from './recipe-types';
+export * from './recipe-images';
 export { CooklangPreferences, bindCooklangPreferences } from './cooklang-preferences';
 export * from './shopping-list-types';
 export * from './menu-types';

--- a/packages/cooklang/src/common/recipe-images.spec.ts
+++ b/packages/cooklang/src/common/recipe-images.spec.ts
@@ -12,7 +12,8 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { RecipeImages, lookupStepImage } from './recipe-images';
+import URI from '@theia/core/lib/common/uri';
+import { RecipeImages, lookupStepImage, resolveImageUri } from './recipe-images';
 
 describe('lookupStepImage', () => {
 
@@ -61,5 +62,57 @@ describe('lookupStepImage', () => {
 
     it('returns undefined when there are no images at all', () => {
         expect(lookupStepImage({ steps: {} }, 0, 0, 0)).to.be.undefined;
+    });
+});
+
+describe('resolveImageUri', () => {
+
+    const recipe = new URI('file:///work/recipes/Pancakes.cook');
+    const root = new URI('file:///work');
+
+    it('passes http and https URLs through untouched', () => {
+        expect(resolveImageUri('https://cdn.example/p.jpg', recipe, root))
+            .to.deep.equal({ kind: 'remote', url: 'https://cdn.example/p.jpg' });
+        expect(resolveImageUri('http://cdn.example/p.jpg', recipe, root))
+            .to.deep.equal({ kind: 'remote', url: 'http://cdn.example/p.jpg' });
+    });
+
+    // Discovery is sibling-based, so an absolute path always names a file next
+    // to the recipe. Rebuilding it from the recipe URI avoids converting a raw
+    // OS path into a URI in browser code.
+    it('resolves an absolute path against the recipe folder by basename', () => {
+        const result = resolveImageUri('/work/recipes/Pancakes.jpg', recipe, root);
+        expect(result?.kind).to.equal('file');
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/Pancakes.jpg');
+    });
+
+    it('resolves a Windows-style absolute path by basename too', () => {
+        const result = resolveImageUri('C:\\work\\recipes\\Pancakes.jpg', recipe, root);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/Pancakes.jpg');
+    });
+
+    it('resolves a relative metadata path against the recipe folder', () => {
+        const result = resolveImageUri('photo.jpg', recipe, root);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/photo.jpg');
+    });
+
+    it('resolves a root-relative metadata path against the workspace root', () => {
+        const result = resolveImageUri('images/photo.jpg', recipe, root);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/images/photo.jpg');
+    });
+
+    it('falls back to the recipe folder when there is no workspace root', () => {
+        const result = resolveImageUri('images/photo.jpg', recipe, undefined);
+        expect((result as { uri: URI }).uri.toString())
+            .to.equal('file:///work/recipes/images/photo.jpg');
+    });
+
+    it('returns undefined for blank input', () => {
+        expect(resolveImageUri('', recipe, root)).to.be.undefined;
+        expect(resolveImageUri('   ', recipe, root)).to.be.undefined;
     });
 });

--- a/packages/cooklang/src/common/recipe-images.spec.ts
+++ b/packages/cooklang/src/common/recipe-images.spec.ts
@@ -68,51 +68,52 @@ describe('lookupStepImage', () => {
 describe('resolveImageUri', () => {
 
     const recipe = new URI('file:///work/recipes/Pancakes.cook');
-    const root = new URI('file:///work');
 
     it('passes http and https URLs through untouched', () => {
-        expect(resolveImageUri('https://cdn.example/p.jpg', recipe, root))
+        expect(resolveImageUri('https://cdn.example/p.jpg', recipe))
             .to.deep.equal({ kind: 'remote', url: 'https://cdn.example/p.jpg' });
-        expect(resolveImageUri('http://cdn.example/p.jpg', recipe, root))
+        expect(resolveImageUri('http://cdn.example/p.jpg', recipe))
             .to.deep.equal({ kind: 'remote', url: 'http://cdn.example/p.jpg' });
     });
 
-    // Discovery is sibling-based, so an absolute path always names a file next
-    // to the recipe. Rebuilding it from the recipe URI avoids converting a raw
-    // OS path into a URI in browser code.
-    it('resolves an absolute path against the recipe folder by basename', () => {
-        const result = resolveImageUri('/work/recipes/Pancakes.jpg', recipe, root);
+    // `cooklang-find` returns absolute paths for everything it discovers, so
+    // they are used exactly as given rather than rebuilt from the recipe URI.
+    it('keeps a POSIX absolute path in full', () => {
+        const result = resolveImageUri('/work/images/hero.jpg', recipe);
         expect(result?.kind).to.equal('file');
+        expect((result as { uri: URI }).uri.path.toString())
+            .to.equal('/work/images/hero.jpg');
+    });
+
+    it('keeps an absolute path that is a sibling of the recipe', () => {
+        const result = resolveImageUri('/work/recipes/Pancakes.jpg', recipe);
         expect((result as { uri: URI }).uri.toString())
             .to.equal('file:///work/recipes/Pancakes.jpg');
     });
 
-    it('resolves a Windows-style absolute path by basename too', () => {
-        const result = resolveImageUri('C:\\work\\recipes\\Pancakes.jpg', recipe, root);
-        expect((result as { uri: URI }).uri.toString())
-            .to.equal('file:///work/recipes/Pancakes.jpg');
+    it('accepts a Windows-style absolute path', () => {
+        const result = resolveImageUri('C:\\work\\images\\hero.jpg', recipe);
+        expect(result?.kind).to.equal('file');
+        expect((result as { uri: URI }).uri.path.toString().toLowerCase())
+            .to.equal('/c:/work/images/hero.jpg');
     });
 
-    it('resolves a relative metadata path against the recipe folder', () => {
-        const result = resolveImageUri('photo.jpg', recipe, root);
+    it('resolves a relative sibling against the recipe folder', () => {
+        const result = resolveImageUri('photo.jpg', recipe);
         expect((result as { uri: URI }).uri.toString())
             .to.equal('file:///work/recipes/photo.jpg');
     });
 
-    it('resolves a root-relative metadata path against the workspace root', () => {
-        const result = resolveImageUri('images/photo.jpg', recipe, root);
+    // A metadata path with a separator is still relative to the recipe file,
+    // not to the workspace root.
+    it('resolves a relative path with a separator under the recipe folder', () => {
+        const result = resolveImageUri('photos/hero.jpg', recipe);
         expect((result as { uri: URI }).uri.toString())
-            .to.equal('file:///work/images/photo.jpg');
-    });
-
-    it('falls back to the recipe folder when there is no workspace root', () => {
-        const result = resolveImageUri('images/photo.jpg', recipe, undefined);
-        expect((result as { uri: URI }).uri.toString())
-            .to.equal('file:///work/recipes/images/photo.jpg');
+            .to.equal('file:///work/recipes/photos/hero.jpg');
     });
 
     it('returns undefined for blank input', () => {
-        expect(resolveImageUri('', recipe, root)).to.be.undefined;
-        expect(resolveImageUri('   ', recipe, root)).to.be.undefined;
+        expect(resolveImageUri('', recipe)).to.be.undefined;
+        expect(resolveImageUri('   ', recipe)).to.be.undefined;
     });
 });

--- a/packages/cooklang/src/common/recipe-images.spec.ts
+++ b/packages/cooklang/src/common/recipe-images.spec.ts
@@ -1,0 +1,65 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { RecipeImages, lookupStepImage } from './recipe-images';
+
+describe('lookupStepImage', () => {
+
+    const linear: RecipeImages = {
+        steps: { '0': { '0': '/r/Pancakes.1.jpg', '2': '/r/Pancakes.3.jpg' } }
+    };
+
+    it('finds a linear image by its global step index', () => {
+        expect(lookupStepImage(linear, 0, 0, 0)).to.equal('/r/Pancakes.1.jpg');
+        expect(lookupStepImage(linear, 0, 2, 2)).to.equal('/r/Pancakes.3.jpg');
+    });
+
+    it('returns undefined for a step with no image', () => {
+        expect(lookupStepImage(linear, 0, 1, 1)).to.be.undefined;
+    });
+
+    it('finds a section image at [section][step]', () => {
+        // Pancakes.2.4.jpg -> section 2, step 4 -> stored at [1][3].
+        const sectioned: RecipeImages = { steps: { '1': { '3': '/r/Pancakes.2.4.jpg' } } };
+        expect(lookupStepImage(sectioned, 1, 3, 7)).to.equal('/r/Pancakes.2.4.jpg');
+    });
+
+    // Mirrors cookcli builders.rs: the section-specific image wins over the linear one.
+    it('prefers the section image over the linear fallback', () => {
+        const both: RecipeImages = {
+            steps: {
+                '1': { '0': '/r/Pancakes.2.1.jpg' },
+                '0': { '3': '/r/Pancakes.4.jpg' }
+            }
+        };
+        expect(lookupStepImage(both, 1, 0, 3)).to.equal('/r/Pancakes.2.1.jpg');
+    });
+
+    it('falls back to the linear image when the section has none', () => {
+        const both: RecipeImages = { steps: { '0': { '3': '/r/Pancakes.4.jpg' } } };
+        expect(lookupStepImage(both, 1, 0, 3)).to.equal('/r/Pancakes.4.jpg');
+    });
+
+    // StepImageCollection::get normalises section 0 and section 1 to the same
+    // index, so the first section of a sectioned recipe shares keys with the
+    // linear form. This collision exists upstream; it is reproduced, not fixed.
+    it('treats section index 0 as section index 0, like the upstream collection', () => {
+        const images: RecipeImages = { steps: { '0': { '1': '/r/Pancakes.2.jpg' } } };
+        expect(lookupStepImage(images, 0, 1, 1)).to.equal('/r/Pancakes.2.jpg');
+    });
+
+    it('returns undefined when there are no images at all', () => {
+        expect(lookupStepImage({ steps: {} }, 0, 0, 0)).to.be.undefined;
+    });
+});

--- a/packages/cooklang/src/common/recipe-images.ts
+++ b/packages/cooklang/src/common/recipe-images.ts
@@ -11,6 +11,8 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+import URI from '@theia/core/lib/common/uri';
+
 /**
  * Image paths for one recipe, as returned by the `recipeImages` RPC.
  *
@@ -46,4 +48,49 @@ export function lookupStepImage(
 ): string | undefined {
     return images.steps[String(sectionIndex)]?.[String(stepInSection)]
         ?? images.steps['0']?.[String(globalStepIndex)];
+}
+
+/** Where an image should be loaded from. */
+export type ImageLocation =
+    | { kind: 'remote'; url: string }
+    | { kind: 'file'; uri: URI };
+
+/** Image file extensions `cooklang-find` discovers, lower-case, in its own order. */
+export const RECIPE_IMAGE_EXTENSIONS: ReadonlyArray<string> = ['jpg', 'jpeg', 'png', 'webp'];
+
+/**
+ * Turn a raw image value from the `recipeImages` RPC into something loadable.
+ *
+ * - `http(s)` URLs are passed through.
+ * - An absolute path names a sibling of the recipe, so only its basename is
+ *   used and it is resolved against the recipe's folder. This keeps browser
+ *   code free of raw OS paths and works for both POSIX and Windows separators.
+ * - A relative path from metadata with no separator resolves against the
+ *   recipe's folder; one with a separator resolves against the workspace root
+ *   (matching cookcli, which serves relative metadata paths from the root),
+ *   falling back to the recipe's folder when no workspace is open.
+ */
+export function resolveImageUri(
+    raw: string,
+    recipeUri: URI,
+    workspaceRootUri: URI | undefined
+): ImageLocation | undefined {
+    const value = raw.trim();
+    if (value.length === 0) {
+        return undefined;
+    }
+    if (/^https?:\/\//i.test(value)) {
+        return { kind: 'remote', url: value };
+    }
+    const folder = recipeUri.parent;
+    const normalized = value.replace(/\\/g, '/');
+    const isAbsolute = normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized);
+    if (isAbsolute) {
+        const base = normalized.substring(normalized.lastIndexOf('/') + 1);
+        return base.length === 0 ? undefined : { kind: 'file', uri: folder.resolve(base) };
+    }
+    if (normalized.includes('/') && workspaceRootUri) {
+        return { kind: 'file', uri: workspaceRootUri.resolve(normalized) };
+    }
+    return { kind: 'file', uri: folder.resolve(normalized) };
 }

--- a/packages/cooklang/src/common/recipe-images.ts
+++ b/packages/cooklang/src/common/recipe-images.ts
@@ -1,0 +1,49 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * Image paths for one recipe, as returned by the `recipeImages` RPC.
+ *
+ * `steps` mirrors `cooklang-find`'s `StepImageCollection`: section index ->
+ * step index -> path, both zero-indexed, with section 0 holding the linear
+ * `Recipe.N.ext` form.
+ */
+export interface RecipeImages {
+    title?: string;
+    steps: Record<string, Record<string, string>>;
+}
+
+/** The same shape after every entry has been turned into an `<img>` src. */
+export interface ResolvedRecipeImages {
+    title?: string;
+    steps: Record<string, Record<string, string>>;
+}
+
+/**
+ * The image for one step, following the two naming conventions cookcli
+ * supports (see `builders.rs`): the section-specific `Recipe.S.N.ext` wins,
+ * and the continuous `Recipe.N.ext` is the fallback.
+ *
+ * @param sectionIndex zero-based index of the section the step is in
+ * @param stepInSection zero-based index of the step within that section
+ * @param globalStepIndex zero-based index of the step counted across all sections
+ */
+export function lookupStepImage(
+    images: RecipeImages | ResolvedRecipeImages,
+    sectionIndex: number,
+    stepInSection: number,
+    globalStepIndex: number
+): string | undefined {
+    return images.steps[String(sectionIndex)]?.[String(stepInSection)]
+        ?? images.steps['0']?.[String(globalStepIndex)];
+}

--- a/packages/cooklang/src/common/recipe-images.ts
+++ b/packages/cooklang/src/common/recipe-images.ts
@@ -55,26 +55,35 @@ export type ImageLocation =
     | { kind: 'remote'; url: string }
     | { kind: 'file'; uri: URI };
 
+/**
+ * MIME type per supported image file extension, lower-case and without the
+ * leading dot. This is the single source of truth for which extensions the
+ * preview understands; {@link RECIPE_IMAGE_EXTENSIONS} is derived from it.
+ */
+export const RECIPE_IMAGE_MIME_TYPES: Readonly<Record<string, string>> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    webp: 'image/webp',
+};
+
 /** Image file extensions `cooklang-find` discovers, lower-case, in its own order. */
-export const RECIPE_IMAGE_EXTENSIONS: ReadonlyArray<string> = ['jpg', 'jpeg', 'png', 'webp'];
+export const RECIPE_IMAGE_EXTENSIONS: ReadonlyArray<string> = Object.keys(RECIPE_IMAGE_MIME_TYPES);
 
 /**
  * Turn a raw image value from the `recipeImages` RPC into something loadable.
  *
- * - `http(s)` URLs are passed through.
- * - An absolute path names a sibling of the recipe, so only its basename is
- *   used and it is resolved against the recipe's folder. This keeps browser
- *   code free of raw OS paths and works for both POSIX and Windows separators.
- * - A relative path from metadata with no separator resolves against the
- *   recipe's folder; one with a separator resolves against the workspace root
- *   (matching cookcli, which serves relative metadata paths from the root),
- *   falling back to the recipe's folder when no workspace is open.
+ * `cooklang-find` returns absolute paths for everything it discovers on disk
+ * and hands metadata values (`image:`, `images:`, `picture:`, `pictures:`)
+ * back verbatim, so exactly three rules are needed:
+ *
+ * 1. `http://` or `https://` (case-insensitive) is passed through as a remote URL.
+ * 2. An absolute path — POSIX `/…` or Windows `C:\…` / `C:/…` — is used as given.
+ * 3. Anything else is relative and resolves against the recipe file's own folder.
+ *
+ * Blank or whitespace-only input yields `undefined`.
  */
-export function resolveImageUri(
-    raw: string,
-    recipeUri: URI,
-    workspaceRootUri: URI | undefined
-): ImageLocation | undefined {
+export function resolveImageUri(raw: string, recipeUri: URI): ImageLocation | undefined {
     const value = raw.trim();
     if (value.length === 0) {
         return undefined;
@@ -82,15 +91,11 @@ export function resolveImageUri(
     if (/^https?:\/\//i.test(value)) {
         return { kind: 'remote', url: value };
     }
-    const folder = recipeUri.parent;
+    // `URI.fromFilePath` does not translate Windows separators, so normalise them.
     const normalized = value.replace(/\\/g, '/');
     const isAbsolute = normalized.startsWith('/') || /^[a-zA-Z]:\//.test(normalized);
     if (isAbsolute) {
-        const base = normalized.substring(normalized.lastIndexOf('/') + 1);
-        return base.length === 0 ? undefined : { kind: 'file', uri: folder.resolve(base) };
+        return { kind: 'file', uri: URI.fromFilePath(normalized) };
     }
-    if (normalized.includes('/') && workspaceRootUri) {
-        return { kind: 'file', uri: workspaceRootUri.resolve(normalized) };
-    }
-    return { kind: 'file', uri: folder.resolve(normalized) };
+    return { kind: 'file', uri: recipeUri.parent.resolve(normalized) };
 }

--- a/packages/cooklang/src/node/cooklang-language-service-impl.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.ts
@@ -275,6 +275,11 @@ export class CooklangLanguageServiceImpl implements CooklangLanguageService {
         return result ?? undefined;
     }
 
+    async recipeImages(recipePath: string): Promise<string> {
+        const native = require('@theia/cooklang-native');
+        return native.recipeImages(recipePath);
+    }
+
     async searchRecipes(baseDir: string, query: string): Promise<string> {
         const native = require('@theia/cooklang-native');
         return native.searchRecipes(baseDir, query);


### PR DESCRIPTION
## Summary

Shows a hero image and per-step images in the `.cook` preview panel, using the
same discovery rules as the CookCLI web server so a recipe folder renders
identically in both tools.

Discovery is delegated entirely to the `cooklang-find` crate (already a
dependency) via a new NAPI function — the editor does not re-derive the
`<stem>.N.<ext>` naming convention anywhere:

- **Title image** — metadata `image`/`images`/`picture`/`pictures`, else a
  sibling `Recipe.{jpg,jpeg,png,webp}`.
- **Step images** — `Recipe.S.N.ext` (section S, step N) preferred over
  `Recipe.N.ext` (step N counted continuously across sections), matching
  cookcli issue #374.

Local files are read through `FileService` and handed to the DOM as blob URLs,
because the renderer is served from `http://localhost:<port>` and Chromium
blocks `file://`. Remote `http(s)` metadata URLs are passed straight through.

Path handling is three rules with no heuristics: `http(s)` passes through,
absolute paths (everything `cooklang-find` discovers) are used verbatim, and
the one genuinely ambiguous case — a relative metadata string, which
`Metadata::image_url()` returns uninterpreted — resolves against the recipe
file's own folder.

The preview watches the recipe's folder, so dropping an image in from Finder
updates an open preview, and replacing one in place re-reads it.

## Scope

Recipe preview only, read-only display. Menu previews, editor hovers, the
report/PDF export path, and drag-and-drop attach are all deliberately out of
scope.

## Test plan

- [x] Rust: 6 discovery tests (title, every extension, linear, section-step, absent)
- [x] TypeScript: 183 passing (+9), incl. lookup precedence, path resolution,
      blob-URL lifecycle, and `InstructionsPanel`'s step-index arithmetic
- [x] Mutation-checked: reverting the in-flight-read fix fails exactly the 3 new
      service tests; moving the step counters fails all 4 component tests
- [x] End-to-end against a fixture: section-specific image correctly wins over
      the linear image at the same global step index
- [x] Manually verified in the running app

## Notes

- Design: `docs/superpowers/specs/2026-08-29-recipe-images-design.md`
- Plan: `docs/superpowers/plans/2026-08-29-recipe-images.md`
- The native addon must be rebuilt for `recipeImages` to be callable; CI builds
  it per-platform.

https://claude.ai/code/session_01ARkeTZR76wXcsfvCjtSYr7