### PR TITLE
feat(sync): restart sync task on session-token renewal

### DIFF
--- a/packages/cooklang-account/src/node/auth-service.ts
+++ b/packages/cooklang-account/src/node/auth-service.ts
@@ -34,6 +34,14 @@ const RENEWAL_INTERVAL_MS = 24 * 60 * 60 * 1000;
 export const AuthServiceBackend = Symbol('AuthServiceBackend');
 export interface AuthServiceBackend extends AuthService {
     readonly onDidChangeAuth: Event<AuthState>;
+    /**
+     * Fires with the fresh token whenever a session-token renewal succeeds
+     * (app-start renewal and the periodic 24h renewal). Does NOT fire for
+     * login/logout — use `onDidChangeAuth` for those. Backend services that
+     * hold onto a token for a long-running task (e.g. sync) should listen to
+     * this to pick up the renewed token instead of going stale.
+     */
+    readonly onDidRenewToken: Event<string>;
 }
 
 @injectable()
@@ -46,6 +54,9 @@ export class AuthServiceImpl implements AuthServiceBackend {
 
     private readonly onDidChangeAuthEmitter = new Emitter<AuthState>();
     readonly onDidChangeAuth: Event<AuthState> = this.onDidChangeAuthEmitter.event;
+
+    private readonly onDidRenewTokenEmitter = new Emitter<string>();
+    readonly onDidRenewToken: Event<string> = this.onDidRenewTokenEmitter.event;
 
     @postConstruct()
     protected init(): void {
@@ -239,6 +250,7 @@ p { color: #666; }
                 };
                 await this.saveToDisk(renewed);
                 this.authData = renewed;
+                this.onDidRenewTokenEmitter.fire(renewed.token);
             }
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);

--- a/packages/cooklang-account/src/node/sync-service.spec.ts
+++ b/packages/cooklang-account/src/node/sync-service.spec.ts
@@ -12,29 +12,82 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
+import { Emitter } from '@theia/core/lib/common';
 import { SyncServiceImpl } from './sync-service';
 import { SyncStatus } from '../common/sync-protocol';
+import { AuthState } from '../common/auth-protocol';
 
 /** Stands in for the `@theia/cooklang-native` addon without requiring a build. */
 class FakeNativeModule {
     callback: ((json: string) => void) | undefined;
+    startCalls: Array<{ recipesDir: string; dbPath: string; endpoint: string; token: string; namespaceId: number }> = [];
+    stopCalls = 0;
+    failNextStart = false;
     onSyncStatusChanged(cb: (json: string) => void): void {
         this.callback = cb;
+    }
+    startSync(recipesDir: string, dbPath: string, endpoint: string, token: string, namespaceId: number): void {
+        if (this.failNextStart) {
+            this.failNextStart = false;
+            throw new Error('native boom');
+        }
+        this.startCalls.push({ recipesDir, dbPath, endpoint, token, namespaceId });
+    }
+    stopSync(): void {
+        this.stopCalls++;
     }
 }
 
 class FakeAuthService {
     logoutCalls = 0;
+    token: string | undefined = undefined;
+
+    private readonly onDidChangeAuthEmitter = new Emitter<AuthState>();
+    readonly onDidChangeAuth = this.onDidChangeAuthEmitter.event;
+
+    private readonly onDidRenewTokenEmitter = new Emitter<string>();
+    readonly onDidRenewToken = this.onDidRenewTokenEmitter.event;
+
     async logout(): Promise<void> {
         this.logoutCalls++;
     }
     async getToken(): Promise<string | undefined> {
-        return undefined;
+        return this.token;
     }
+    fireRenewal(token: string): void {
+        this.token = token;
+        this.onDidRenewTokenEmitter.fire(token);
+    }
+}
+
+class FakeWorkspaceServer {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    onDidChangeAuth(): any {
-        return { dispose: () => { /* no-op */ } };
+    private pendingLookup: { promise: Promise<string | undefined>; resolve: (v: string | undefined) => void } | undefined;
+
+    async getMostRecentlyUsedWorkspace(): Promise<string | undefined> {
+        if (this.pendingLookup) {
+            return this.pendingLookup.promise;
+        }
+        return 'file:///workspace';
     }
+
+    /** Makes the NEXT (or currently in-flight) lookup hang until `unblockLookup()` is called. */
+    blockNextLookup(): void {
+        let resolve!: (v: string | undefined) => void;
+        const promise = new Promise<string | undefined>(res => { resolve = res; });
+        this.pendingLookup = { promise, resolve };
+    }
+
+    unblockLookup(): void {
+        this.pendingLookup?.resolve('file:///workspace');
+        this.pendingLookup = undefined;
+    }
+}
+
+/** Builds a fake JWT carrying `{ uid }` in its payload — enough for `extractUserId`. */
+function fakeToken(uid: number, salt: string): string {
+    const payload = Buffer.from(JSON.stringify({ uid })).toString('base64url');
+    return `header.${payload}.${salt}`;
 }
 
 function createService(): { service: SyncServiceImpl; native: FakeNativeModule; auth: FakeAuthService } {
@@ -46,9 +99,13 @@ function createService(): { service: SyncServiceImpl; native: FakeNativeModule; 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (service as any).authService = auth;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).workspaceServer = new FakeWorkspaceServer();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (service as any).syncEnabled = true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (service as any).registerNativeCallback();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).registerAuthListeners();
     return { service, native, auth };
 }
 
@@ -73,5 +130,129 @@ describe('SyncServiceImpl native status passthrough', () => {
             native.callback!(JSON.stringify({ status, lastError: 'boom', lastSynced: null }));
         }
         expect(auth.logoutCalls).to.equal(0);
+    });
+});
+
+describe('SyncServiceImpl token renewal', () => {
+
+    it('restarts the running native sync task with the fresh token on renewal', async () => {
+        const { service, native, auth } = createService();
+        const tokenA = fakeToken(1, 'a');
+        auth.token = tokenA;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).startSyncIfReady();
+        expect(native.startCalls).to.have.length(1);
+        expect(native.startCalls[0].token).to.equal(tokenA);
+
+        const tokenB = fakeToken(1, 'b');
+        auth.fireRenewal(tokenB);
+        // handleTokenRenewed is fire-and-forget from the Emitter — let its promise settle.
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(native.stopCalls).to.equal(1);
+        expect(native.startCalls).to.have.length(2);
+        expect(native.startCalls[1].token).to.equal(tokenB);
+        // Everything else about the restarted task matches the original.
+        expect(native.startCalls[1].recipesDir).to.equal(native.startCalls[0].recipesDir);
+        expect(native.startCalls[1].namespaceId).to.equal(native.startCalls[0].namespaceId);
+        expect(native.startCalls[1].endpoint).to.equal(native.startCalls[0].endpoint);
+        expect(native.startCalls[1].dbPath).to.equal(native.startCalls[0].dbPath);
+    });
+
+    it('no-ops when the renewed token is unchanged', async () => {
+        const { service, native, auth } = createService();
+        const token = fakeToken(1, 'a');
+        auth.token = token;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).startSyncIfReady();
+        expect(native.startCalls).to.have.length(1);
+
+        auth.fireRenewal(token);
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(native.stopCalls).to.equal(0);
+        expect(native.startCalls).to.have.length(1);
+    });
+
+    it('no-ops when sync is not currently running', async () => {
+        const { native, auth } = createService();
+        // Sync was never started — no startSyncIfReady call happened.
+        auth.fireRenewal(fakeToken(1, 'a'));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(native.stopCalls).to.equal(0);
+        expect(native.startCalls).to.have.length(0);
+    });
+
+    it('no-ops when the sync toggle is off, even if a task happens to be tracked as running', async () => {
+        const { service, native, auth } = createService();
+        const tokenA = fakeToken(1, 'a');
+        auth.token = tokenA;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).startSyncIfReady();
+        expect(native.startCalls).to.have.length(1);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).syncEnabled = false;
+        auth.fireRenewal(fakeToken(1, 'b'));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(native.stopCalls).to.equal(0);
+        expect(native.startCalls).to.have.length(1);
+    });
+
+    it('reconciles a renewal that fires while the initial (boot) start is still in flight', async () => {
+        const { service, native, auth } = createService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const workspaceServer: FakeWorkspaceServer = (service as any).workspaceServer;
+        const tokenA = fakeToken(1, 'a');
+        const tokenB = fakeToken(1, 'b');
+        auth.token = tokenA;
+
+        workspaceServer.blockNextLookup();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const bootStart: Promise<void> = (service as any).startSyncIfReady();
+
+        // The renewal fires while the boot start is still awaiting the workspace
+        // lookup, i.e. before `syncStartedWithToken` has been set — the naive
+        // `handleTokenRenewed` guard would (pre-fix) treat this as "not running yet"
+        // and silently drop it.
+        auth.fireRenewal(tokenB);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(native.startCalls, 'boot start should still be blocked on the workspace lookup').to.have.length(0);
+
+        workspaceServer.unblockLookup();
+        await bootStart;
+        // Let the end-of-start reconcile (and any restart it triggers) settle.
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+        await new Promise(resolve => setImmediate(resolve));
+
+        const lastStart = native.startCalls[native.startCalls.length - 1];
+        expect(lastStart.token, 'task must end up on the renewed token, not the pre-renewal one').to.equal(tokenB);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((service as any).syncStartedWithToken).to.equal(tokenB);
+    });
+
+    it('surfaces an error status when reconciling to the fresh token fails to (re)start, instead of leaving it silently stopped', async () => {
+        const { service, native, auth } = createService();
+        const tokenA = fakeToken(1, 'a');
+        auth.token = tokenA;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).startSyncIfReady();
+        expect(native.startCalls).to.have.length(1);
+
+        const statuses: SyncStatus[] = [];
+        service.onDidChangeSyncStatus(status => statuses.push(status));
+
+        native.failNextStart = true;
+        auth.fireRenewal(fakeToken(1, 'b'));
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(native.stopCalls).to.equal(1);
+        expect(statuses.length).to.be.greaterThan(0);
+        const finalStatus = statuses[statuses.length - 1];
+        expect(finalStatus.status).to.equal('error');
+        expect(finalStatus.error).to.be.a('string').and.not.empty;
     });
 });

--- a/packages/cooklang-account/src/node/sync-service.ts
+++ b/packages/cooklang-account/src/node/sync-service.ts
@@ -38,6 +38,14 @@ export class SyncServiceImpl implements SyncService {
     private lastStatus: SyncStatus = { status: 'stopped', lastSyncedAt: undefined, error: undefined };
     private nativeModule: typeof import('@theia/cooklang-native') | undefined;
 
+    /**
+     * The token the currently-running native sync task was started with, or
+     * `undefined` when sync isn't running. Lets us detect a stale token
+     * locally (equality check) without asking the native side.
+     */
+    private syncStartedWithToken: string | undefined;
+    private restartingSync = false;
+
     private readonly onDidChangeSyncStatusEmitter = new Emitter<SyncStatus>();
     readonly onDidChangeSyncStatus: Event<SyncStatus> = this.onDidChangeSyncStatusEmitter.event;
 
@@ -49,11 +57,16 @@ export class SyncServiceImpl implements SyncService {
         // the binding async, breaking synchronous Container.get() in RpcConnectionHandler.
         this.loadPreferences().then(() => {
             this.registerNativeCallback();
-            this.authService.onDidChangeAuth(state => this.handleAuthChange(state));
+            this.registerAuthListeners();
             if (this.syncEnabled) {
                 this.startSyncIfReady();
             }
         });
+    }
+
+    private registerAuthListeners(): void {
+        this.authService.onDidChangeAuth(state => this.handleAuthChange(state));
+        this.authService.onDidRenewToken(token => this.handleTokenRenewed(token));
     }
 
     async enableSync(): Promise<void> {
@@ -141,8 +154,24 @@ export class SyncServiceImpl implements SyncService {
                 token,
                 namespaceId
             );
+            this.syncStartedWithToken = token;
         } catch (err) {
             console.error('Failed to start sync:', err);
+            return;
+        }
+
+        // A renewal can fire while this start was still in flight (most notably
+        // the initial start on app boot, which awaits the workspace lookup above)
+        // — `handleTokenRenewed` would have found `syncStartedWithToken` still
+        // undefined at that moment and treated sync as "not running yet", so it
+        // no-ops rather than restarting. Reconcile once against whatever token is
+        // current now that the start has landed, so that race doesn't leave the
+        // task on a token that's already stale. If another renewal lands during
+        // the resulting restart's own start, that start performs this same
+        // one-pass reconcile — it converges once no further renewal is racing it.
+        const currentToken = await this.authService.getToken();
+        if (currentToken && currentToken !== token) {
+            await this.restartSyncWithFreshToken();
         }
     }
 
@@ -153,6 +182,7 @@ export class SyncServiceImpl implements SyncService {
         } catch {
             // Native module not available
         }
+        this.syncStartedWithToken = undefined;
         this.lastStatus = { status: 'stopped', lastSyncedAt: undefined, error: undefined };
         this.onDidChangeSyncStatusEmitter.fire(this.lastStatus);
     }
@@ -162,6 +192,51 @@ export class SyncServiceImpl implements SyncService {
             await this.stopSync();
         } else if (this.syncEnabled) {
             await this.startSyncIfReady();
+        }
+    }
+
+    /**
+     * Reacts to a successful session-token renewal from auth-service. The
+     * running native sync task captures its token at start time and keeps
+     * using it for the process lifetime, so a long-lived editor session
+     * otherwise ends up presenting a stale (eventually claimless, eventually
+     * expired) token to the sync server. No-ops when sync isn't running,
+     * when the renewed token is unchanged, or (implicitly) when renewal
+     * failed — auth-service only fires this event on success.
+     */
+    private async handleTokenRenewed(token: string): Promise<void> {
+        if (!this.syncEnabled || this.syncStartedWithToken === undefined) {
+            return;
+        }
+        if (token === this.syncStartedWithToken) {
+            return;
+        }
+        await this.restartSyncWithFreshToken();
+    }
+
+    private async restartSyncWithFreshToken(): Promise<void> {
+        if (this.restartingSync) {
+            // Guard against overlapping restarts — at most one restart per renewal event.
+            return;
+        }
+        this.restartingSync = true;
+        try {
+            // Reuse the same stop/start path the sync toggle uses so a normal
+            // restart only ever passes through existing statuses ('stopped'
+            // then whatever the native side reports next) — never a synthetic
+            // 'error'.
+            await this.stopSync();
+            await this.startSyncIfReady();
+            if (this.syncEnabled && this.syncStartedWithToken === undefined) {
+                // The restart's start failed outright (native threw) or bailed
+                // out early (missing workspace/namespace) — don't leave the
+                // widget showing a silent 'stopped' while the toggle is still
+                // on and the user has no running sync and no explanation.
+                this.lastStatus = { status: 'error', lastSyncedAt: this.lastStatus.lastSyncedAt, error: 'Failed to restart sync after token renewal' };
+                this.onDidChangeSyncStatusEmitter.fire(this.lastStatus);
+            }
+        } finally {
+            this.restartingSync = false;
         }
     }
 


### PR DESCRIPTION
## Problem

Verified in production enforcement-soak logs: 14 entitled users are stuck presenting a stale session token to the sync server.

- `auth-service.ts` renews the JWT on app start and every 24h (`RENEWAL_INTERVAL_MS`).
- `sync-service.ts` passes the token to `native.startSync(recipesDir, dbPath, endpoint, token, namespaceId)` once, at start, and the native task holds that token for the process lifetime.

A long-running editor session therefore keeps syncing with an increasingly stale token — first claimless, then outright expired once it crosses the server's `sync_until` window (~72h). This soak finding is what motivated the fix.

## Fix

- `auth-service.ts`: adds a dedicated `onDidRenewToken: Event<string>` on `AuthServiceBackend`, fired only when a renewal **succeeds** (kept separate from `onDidChangeAuth`, which stays login/logout-only, so existing login/logout wiring is untouched).
- `sync-service.ts`: subscribes to `onDidRenewToken`. Tracks `syncStartedWithToken` (the token the running native task was started with) so the equality check is local. On a renewal:
  - if sync isn't running, or the sync toggle is off, or the token is unchanged → no-op.
  - otherwise → stop then start the native task via the existing `stopSync()` / `startSyncIfReady()` path (same `recipesDir`/`dbPath`/`endpoint`/`namespaceId`, fresh token only).
  - a reentrancy guard (`restartingSync`) caps this at one restart per renewal event.
  - the transition only passes through existing statuses (`'stopped'`, then whatever the native side reports next) — never a synthetic `'error'`. D2 gating / `payment_required` handling is untouched.

### Follow-up fixes from review

1. **Boot-race**: a renewal firing while the *initial* `startSyncIfReady()` was still in flight (e.g. still awaiting the workspace lookup) used to be silently dropped — `syncStartedWithToken` is still `undefined` at that moment, so `handleTokenRenewed` treated sync as "not running yet" and no-opped, and the boot start then completed with the pre-renewal token (stale for up to 24h). Fixed by having `startSyncIfReady()` reconcile once against the *current* token right after it lands, triggering a restart if a renewal raced it. The restart's own start performs the same one-pass reconcile, which converges once no further renewal is racing it. Covered by a regression test that blocks the workspace lookup, fires a renewal mid-flight, then asserts the task ends up on the renewed token (verified red before the fix, green after).
2. **Silent-dark restart**: if a renewal-triggered restart's start fails outright (native throw) or bails out early (missing workspace/namespace) while the sync toggle is still on, the status is now set to `'error'` with a message instead of being left silently `'stopped'` with nothing for the widget to show. Covered by a test that forces the native `startSync` to throw during the restart.

**Known non-fix (documented, not addressed here):** `tryRenewToken()` in auth-service has no reentrancy guard of its own — concurrent invocations (e.g. the app-boot renewal and the 24h interval firing close together) could in principle race each other's save-to-disk. Left as-is: the 24h cadence makes this theoretical, and guarding it is a separate, unrelated change.

## Tests

Extended `packages/cooklang-account/src/node/sync-service.spec.ts` (TDD, 8/8 passing):
- renewal while sync is running → stop + start with the new token, all other params unchanged
- renewal with the same token → no-op
- renewal while sync was never started → no-op
- renewal while the sync toggle is off → no-op, even with a tracked "running" token
- renewal racing the in-flight boot start → task still lands on the renewed token
- native throw during a renewal-triggered restart → surfaces an `'error'` status instead of a silent `'stopped'`

## Verification

- `npx tsc --build packages/cooklang-account --force` — clean
- `npx eslint packages/cooklang-account/src/node/{auth-service,sync-service,sync-service.spec}.ts` — clean
- `npx mocha packages/cooklang-account/lib/node/sync-service.spec.js` — 8/8 passing

No native (`cooklang-native`) changes — this is TS-layer only, so no `cargo test` run.