### PR TITLE
Recipe preview: clickable URLs and working timers

### DIFF
--- a/app/proto/cookbot.proto
+++ b/app/proto/cookbot.proto
@@ -24,6 +24,9 @@ service CookbotService {
   // Curated recipe catalog (Rails kickstart matcher, forwarded with the session JWT)
   rpc SearchRecipeCatalog(SearchRecipeCatalogRequest) returns (SearchRecipeCatalogResponse);
   rpc GetCatalogRecipe(GetCatalogRecipeRequest) returns (CatalogRecipe);
+
+  // Preferences the user already gave cook.md (kickstart quiz / account profile)
+  rpc GetUserPreferences(GetUserPreferencesRequest) returns (UserPreferencesResponse);
 }
 
 // ============================================================================
@@ -251,4 +254,16 @@ message CatalogRecipe {
   string course = 4;
   string content = 5;         // .cook file body incl. YAML frontmatter
   string suggested_path = 6;  // e.g. "Dinner/Spaghetti Carbonara.cook"
+}
+
+// Saved preferences (cook.md kickstart quiz and account profile)
+
+message GetUserPreferencesRequest {
+  string session_id = 1;
+}
+
+message UserPreferencesResponse {
+  bool has_preferences = 1;
+  repeated string sources = 2;    // "kickstart_quiz" and/or "profile"
+  string preferences_json = 3;    // Rails' merged `preferences` object verbatim
 }

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -2724,6 +2724,13 @@ In `InstructionsPanel`, capture the step's global index before it is incremented
 
 - [ ] **Step 4: Make `scale` a controlled prop**
 
+> Making these props required breaks `recipe-preview-widget.tsx`, whose
+> `RecipeView` call site does not pass them yet. Fix that in this same commit
+> so the package always compiles — add `protected scale = 1;` and a
+> `handleScaleChange` to the widget and pass both down. Nothing else from
+> Task 9: no `setScale()`, no timer service, no subscriptions.
+
+
 Still in `recipe-preview-components.tsx`, change `RecipeViewProps` and the top of `RecipeView`:
 
 ```tsx
@@ -2865,13 +2872,9 @@ and next to the other `@inject` fields:
 
 - [ ] **Step 2: Own the scale and expose a setter**
 
-Add the field next to `protected recipe`:
-
-```tsx
-    protected scale = 1;
-```
-
-and these members next to `handleShowSource`:
+Task 8 already added `protected scale = 1;` and `handleScaleChange`, and
+already passes both to `RecipeView`. Only the external setter is missing.
+Add it next to `handleShowSource`:
 
 ```tsx
     /**
@@ -2884,11 +2887,6 @@ and these members next to `handleShowSource`:
             this.update();
         }
     }
-
-    protected handleScaleChange = (scale: number): void => {
-        this.scale = scale;
-        this.update();
-    };
 ```
 
 - [ ] **Step 3: Build the timer binding**

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -3387,7 +3387,7 @@ Bake for ~{50-60%minutes} and reduce ~{until thick}.
 - [ ] Tab through a Timers panel row: the recipe control and all four buttons take focus and activate from the keyboard.
 - [ ] The Timers view (right side bar, `codicon-watch`) lists the running timers with recipe name, `+1 min`, play/pause, reset and delete.
 - [ ] Drag the right sidebar as narrow as it goes with a long recipe name and a `4d 08:05:30` clock on screen. The name truncates with an ellipsis rather than being clipped, and the four row controls stay reachable.
-- [ ] "Clear all" with a timer running asks for confirmation; with only finished timers it clears immediately.
+- [ ] "Clear all" asks for confirmation when any timer is running or paused; with only finished timers it clears immediately.
 - [ ] Set Scale to 2, start a timer, then click that timer's recipe link in the panel — the preview opens with Scale showing 2.
 - [ ] Let a 10-second timer finish with the editor window **in the background**: an OS notification appears and the chime plays.
 - [ ] The chime specifically: start a timer and let it finish **without clicking anything else in the window first**, with the window backgrounded. A renderer `AudioContext` starts suspended until a user gesture, and the whole promise of this feature is that it fires while you are not interacting with the app. Electron defaults `autoplayPolicy` to `no-user-gesture-required`, so this should work — but that is reasoning, not evidence, and this is the check that turns it into evidence. If it is silent, the fix is `webPreferences.autoplayPolicy`, not the chime code.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -887,6 +887,51 @@ describe('linkify', () => {
             { type: 'text', value: 'Cook: 1.5 hours' },
         ]);
     });
+
+    it('does not emit a link when trimming eats the scheme', () => {
+        expect(linkify('mailto:.')).to.deep.equal([{ type: 'text', value: 'mailto:.' }]);
+        expect(linkify('www..')).to.deep.equal([{ type: 'text', value: 'www..' }]);
+        expect(linkify('Check www.: it works')).to.deep.equal([
+            { type: 'text', value: 'Check www.: it works' },
+        ]);
+    });
+
+    it('reproduces the input exactly, whatever the tokens', () => {
+        const inputs = [
+            '',
+            '.',
+            'www.',
+            'mailto:.',
+            'https://',
+            'https://a.example',
+            'a https://b.example',
+            'https://a.example b',
+            'https://a.example https://a.example',
+            'Boil at 100°C — see https://a.example/√ for why.',
+            'no links at all',
+            'bare @ sign and a lone www without a dot',
+        ];
+        for (const input of inputs) {
+            const rebuilt = linkify(input).map(token => token.value).join('');
+            expect(rebuilt, `round trip of ${JSON.stringify(input)}`).to.equal(input);
+        }
+    });
+
+    it('stays linear on long input without links', function (): void {
+        this.timeout(5000);
+        const haystack = `${'a.'.repeat(100_000)} end`;
+        const started = Date.now();
+        expect(linkify(haystack)).to.have.length(1);
+        expect(Date.now() - started, 'linkify should not backtrack quadratically').to.be.lessThan(1000);
+    });
+
+    it('stays linear when trimming a long run of brackets', function (): void {
+        this.timeout(5000);
+        const haystack = `https://a.example${')'.repeat(50_000)}`;
+        const started = Date.now();
+        linkify(haystack);
+        expect(Date.now() - started, 'trimTrailing should not rescan per character').to.be.lessThan(1000);
+    });
 });
 ```
 
@@ -906,11 +951,13 @@ Create `packages/cooklang/src/common/recipe-links.ts`:
 ```ts
 <LICENSE HEADER>
 
+/** A run of plain, non-link text. */
 export interface TextToken {
     type: 'text';
     value: string;
 }
 
+/** A run of text that should be rendered as a clickable link. */
 export interface LinkToken {
     type: 'link';
     /** The text as written in the recipe. */
@@ -919,18 +966,32 @@ export interface LinkToken {
     href: string;
 }
 
+/** One token produced by {@link linkify}: either plain text or a link. */
 export type LinkifyToken = TextToken | LinkToken;
 
 /**
  * Matches, in order: an explicit http(s) URL, a bare `www.` host, an explicit
  * `mailto:`, and a bare email address. Deliberately greedy up to whitespace or
  * a quote/angle bracket; trailing punctuation is trimmed afterwards.
+ *
+ * Two adjacent links with no separating whitespace collapse into a single
+ * token (e.g. the greedy `https?://` alternative swallows a `www.` host that
+ * immediately follows it). That is a known and accepted ambiguity, not an
+ * oversight.
+ *
+ * The `(?<!...)` lookbehind on the bare-email alternative is purely a
+ * performance guard, not a semantic requirement: without it, a long run of
+ * local-part characters with no `@` (a hash, a base64 paste, a run-on word)
+ * makes the engine retry the greedy character class from every offset inside
+ * the run, which is quadratic in the run's length. The lookbehind stops a
+ * match attempt from starting partway through such a run, so only the run's
+ * first offset does real backtracking work.
  */
 const LINK_PATTERN = new RegExp([
     'https?://[^\\s<>"\']+',
     'www\\.[^\\s<>"\']+',
     'mailto:[^\\s<>"\']+',
-    '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
+    '(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
 ].join('|'), 'g');
 
 const TRAILING_PUNCTUATION = '.,;:!?';
@@ -948,30 +1009,35 @@ function count(text: string, character: string): number {
 /**
  * Drop characters a writer meant as prose rather than as part of the URL: a
  * full stop that ends the sentence, or a closing bracket that was never opened
- * inside the URL itself.
+ * inside the URL itself. Counts brackets once up front and adjusts
+ * incrementally rather than rescanning the shrinking value on every
+ * character, which keeps this linear in the length of `match`.
  */
 function trimTrailing(match: string): string {
-    let value = match;
-    for (;;) {
-        const last = value.charAt(value.length - 1);
-        if (last === '') {
-            break;
-        }
+    let end = match.length;
+    const openParens = count(match, '(');
+    let closeParens = count(match, ')');
+    const openBrackets = count(match, '[');
+    let closeBrackets = count(match, ']');
+    while (end > 0) {
+        const last = match.charAt(end - 1);
         if (TRAILING_PUNCTUATION.includes(last)) {
-            value = value.slice(0, -1);
+            end--;
             continue;
         }
-        if (last === ')' && count(value, ')') > count(value, '(')) {
-            value = value.slice(0, -1);
+        if (last === ')' && closeParens > openParens) {
+            closeParens--;
+            end--;
             continue;
         }
-        if (last === ']' && count(value, ']') > count(value, '[')) {
-            value = value.slice(0, -1);
+        if (last === ']' && closeBrackets > openBrackets) {
+            closeBrackets--;
+            end--;
             continue;
         }
         break;
     }
-    return value;
+    return match.substring(0, end);
 }
 
 function hrefFor(value: string): string {
@@ -982,6 +1048,23 @@ function hrefFor(value: string): string {
         return `https://${value}`;
     }
     return `mailto:${value}`;
+}
+
+/**
+ * Whether a match still looks like a link after {@link trimTrailing} has had
+ * its way with it. Trimming can eat a scheme down to nothing meaningful —
+ * `mailto:.` becomes `mailto`, `www..` becomes `www` — and those must render
+ * as plain text rather than as an anchor pointing somewhere nonsensical.
+ */
+function isUsableLink(value: string): boolean {
+    if (/^https?:\/\//i.test(value)) {
+        return value.replace(/^https?:\/\//i, '').length > 0;
+    }
+    if (/^www\./i.test(value)) {
+        return value.length > 'www.'.length;
+    }
+    const address = /^mailto:/i.test(value) ? value.substring('mailto:'.length) : value;
+    return /^[^@\s]+@[^@\s]+\.[^@\s.]+$/.test(address);
 }
 
 /**
@@ -996,10 +1079,10 @@ export function linkify(text: string): LinkifyToken[] {
     let cursor = 0;
     LINK_PATTERN.lastIndex = 0;
     let match = LINK_PATTERN.exec(text);
-    while (match !== null) {
+    while (match) {
         const start = match.index;
         const value = trimTrailing(match[0]);
-        if (value.length > 0) {
+        if (isUsableLink(value)) {
             if (start > cursor) {
                 tokens.push({ type: 'text', value: text.substring(cursor, start) });
             }
@@ -1024,7 +1107,7 @@ npx lerna run compile --scope @theia/cooklang
 cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/common/recipe-links.spec.js"; cd ../..
 ```
 
-Expected: all 12 tests PASS.
+Expected: all 11 tests PASS.
 
 - [ ] **Step 5: Lint and commit**
 

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -2818,9 +2818,13 @@ Replace the `.theia-recipe-preview .timer-badge` rule in `packages/cooklang/src/
 }
 
 .theia-recipe-preview .timer-badge-finished {
-    background: var(--theia-editorWarning-foreground);
-    border-color: var(--theia-editorWarning-foreground);
-    color: var(--theia-editor-background);
+    /* The inputValidation warning pair is designed as background-plus-text and
+       stays legible in both themes. Using editorWarning-foreground as a
+       background instead only reached ~3.1:1 against editor-background in the
+       light theme, under the 4.5:1 needed for text this size. */
+    background: var(--theia-inputValidation-warningBackground);
+    border-color: var(--theia-inputValidation-warningBorder, var(--theia-editorWarning-foreground));
+    color: var(--theia-foreground);
 }
 ```
 
@@ -3378,6 +3382,7 @@ Bake for ~{50-60%minutes} and reduce ~{until thick}.
 - [ ] `~{10%seconds}` and `~dough{15%seconds}` render as clickable badges; `~{until thick}` renders as plain, unclickable text.
 - [ ] `~{50-60%minutes}` shows the range as written and starts a 50-minute timer.
 - [ ] Clicking a badge starts it; the badge counts down; clicking again pauses; clicking again resumes.
+- [ ] Switch between a light and a dark theme with a running, a paused and a finished badge on screen. All three read clearly and are distinguishable from an unstarted badge in both.
 - [ ] Tab to a timer badge and press Enter, then Space. Both start it. The badge is a `span` with `role='button'`, which gets no keyboard activation from the browser, and `renderToStaticMarkup` cannot exercise handlers — so this is only ever verified here.
 - [ ] Tab through a Timers panel row: the recipe control and all four buttons take focus and activate from the keyboard.
 - [ ] The Timers view (right side bar, `codicon-watch`) lists the running timers with recipe name, `+1 min`, play/pause, reset and delete.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -3386,6 +3386,8 @@ Bake for ~{50-60%minutes} and reduce ~{until thick}.
 - [ ] Tab to a timer badge and press Enter, then Space. Both start it. The badge is a `span` with `role='button'`, which gets no keyboard activation from the browser, and `renderToStaticMarkup` cannot exercise handlers — so this is only ever verified here.
 - [ ] Tab through a Timers panel row: the recipe control and all four buttons take focus and activate from the keyboard.
 - [ ] The Timers view (right side bar, `codicon-watch`) lists the running timers with recipe name, `+1 min`, play/pause, reset and delete.
+- [ ] Drag the right sidebar as narrow as it goes with a long recipe name and a `4d 08:05:30` clock on screen. The name truncates with an ellipsis rather than being clipped, and the four row controls stay reachable.
+- [ ] "Clear all" with a timer running asks for confirmation; with only finished timers it clears immediately.
 - [ ] Set Scale to 2, start a timer, then click that timer's recipe link in the panel — the preview opens with Scale showing 2.
 - [ ] Let a 10-second timer finish with the editor window **in the background**: an OS notification appears and the chime plays.
 - [ ] The chime specifically: start a timer and let it finish **without clicking anything else in the window first**, with the window backgrounded. A renderer `AudioContext` starts suspended until a user gesture, and the whole promise of this feature is that it fires while you are not interacting with the app. Electron defaults `autoplayPolicy` to `no-user-gesture-required`, so this should work — but that is reasoning, not evidence, and this is the check that turns it into evidence. If it is silent, the fix is `webPreferences.autoplayPolicy`, not the chime code.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -3299,7 +3299,6 @@ Create `packages/cooklang/src/browser/style/timers.css`:
 In `packages/cooklang/src/browser/cooklang-frontend-module.ts`, add the imports:
 
 ```ts
-import { CookingTimerService } from './cooking-timer-service';
 import { TimerChime } from './timer-chime';
 import { TimerAlarmService } from './timer-alarm-service';
 import { TimersWidget, TIMERS_WIDGET_ID } from './timers-widget';
@@ -3310,7 +3309,8 @@ and add this block next to the shopping-list bindings:
 
 ```ts
     // --- Timers ---
-    bind(CookingTimerService).toSelf().inSingletonScope();
+    // CookingTimerService is already bound; Task 9 pulled it forward because
+    // the preview widget injects it and every preview threw without it.
     bind(TimerChime).toSelf().inSingletonScope();
     bind(TimerAlarmService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TimerAlarmService);

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -3390,6 +3390,7 @@ Bake for ~{50-60%minutes} and reduce ~{until thick}.
 - [ ] "Clear all" asks for confirmation when any timer is running or paused; with only finished timers it clears immediately.
 - [ ] Set Scale to 2, start a timer, then click that timer's recipe link in the panel — the preview opens with Scale showing 2.
 - [ ] Let a 10-second timer finish with the editor window **in the background**: an OS notification appears and the chime plays.
+- [ ] Click that notification **while the Timers panel is already open and focused**. It must reveal/keep the panel, not collapse the sidebar. This is the case the toggle command got wrong.
 - [ ] The chime specifically: start a timer and let it finish **without clicking anything else in the window first**, with the window backgrounded. A renderer `AudioContext` starts suspended until a user gesture, and the whole promise of this feature is that it fires while you are not interacting with the app. Electron defaults `autoplayPolicy` to `no-user-gesture-required`, so this should work — but that is reasoning, not evidence, and this is the check that turns it into evidence. If it is silent, the fix is `webPreferences.autoplayPolicy`, not the chime code.
 - [ ] Two timers finishing within a second of each other: both notifications appear, and the chime does not distort.
 - [ ] Reload the window (`Ctrl/Cmd+R`) mid-countdown: the timer is still there with the right remaining time.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -3236,9 +3236,19 @@ Create `packages/cooklang/src/browser/style/timers.css`:
     display: inline-flex;
     align-items: center;
     gap: 4px;
+    /* A real button for keyboard and assistive tech, styled as a link. */
+    background: none;
+    border: none;
+    padding: 0;
     color: var(--theia-textLink-foreground);
     cursor: pointer;
     font-size: 0.92em;
+    font-family: inherit;
+}
+
+.theia-cooklang-timers .timer-row-recipe:focus-visible {
+    outline: 1px solid var(--theia-focusBorder);
+    outline-offset: 2px;
 }
 
 .theia-cooklang-timers .timer-row-recipe:hover {
@@ -3370,6 +3380,8 @@ Bake for ~{50-60%minutes} and reduce ~{until thick}.
 - [ ] `~{10%seconds}` and `~dough{15%seconds}` render as clickable badges; `~{until thick}` renders as plain, unclickable text.
 - [ ] `~{50-60%minutes}` shows the range as written and starts a 50-minute timer.
 - [ ] Clicking a badge starts it; the badge counts down; clicking again pauses; clicking again resumes.
+- [ ] Tab to a timer badge and press Enter, then Space. Both start it. The badge is a `span` with `role='button'`, which gets no keyboard activation from the browser, and `renderToStaticMarkup` cannot exercise handlers — so this is only ever verified here.
+- [ ] Tab through a Timers panel row: the recipe control and all four buttons take focus and activate from the keyboard.
 - [ ] The Timers view (right side bar, `codicon-watch`) lists the running timers with recipe name, `+1 min`, play/pause, reset and delete.
 - [ ] Set Scale to 2, start a timer, then click that timer's recipe link in the panel — the preview opens with Scale showing 2.
 - [ ] Let a 10-second timer finish with the editor window **in the background**: an OS notification appears and the chime plays.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -1,0 +1,3295 @@
+# Recipe Preview Timers and Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make URLs in the recipe preview clickable and make `~timer` values runnable — inline countdowns in the step plus a Timers side panel that survives restarts and links back to each recipe at the scale it was started at.
+
+**Architecture:** Pure, DI-free, Monaco-free modules in `packages/cooklang/src/common/` hold the timer state machine, duration parsing and URL tokenizer. A `CookingTimerService` singleton in `src/browser/` owns all live timers, persists them through Theia's `StorageService`, and drives a single 1s tick. Presentational React lives in `timer-components.tsx` and reaches the service through a React context supplied by `RecipePreviewWidget`, so `recipe-preview-components.tsx` stays free of services and its existing spec keeps passing. This is a port of the iOS app's `Packages/Timers` (`ActiveTimer`, `TimerManager`, `TimerStorage`, `DurationFormatter`, `TimerCellView`).
+
+**Tech Stack:** TypeScript 5.4 (strict), React 18, InversifyJS property injection, Eclipse Theia 1.70 (`ReactWidget`, `AbstractViewContribution`, `StorageService`, `WindowService`), `OSNotificationService` from `@theia/ai-core`, Web Audio API, mocha + chai against compiled `lib/**/*.spec.js`.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md`
+
+---
+
+## Before you start
+
+Everything below runs from the repo root `/Users/alexeydubovskoy/Cooklang/editor` on branch `feature/preview-timers-and-links`.
+
+**The default `node` on this machine is v20, and mocha needs v22.** Every shell that runs tests must start with:
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+node -v   # must print v22.23.2
+```
+
+Tests run against **compiled JavaScript**, not TypeScript. The loop is always:
+
+```bash
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/<path>/<name>.spec.js" && cd ../..
+```
+
+To run every spec in the package: `npx lerna run test --scope @theia/cooklang`.
+
+**House style** (from `doc/coding-guidelines.md`): 4-space indent, single quotes, `undefined` never `null`, explicit return types on every function including local helpers, arrow functions, kebab-case file names, PascalCase types. Every new file starts with the 12-line license header — copy it verbatim from the top of `packages/cooklang/src/common/recipe-types.ts`. In this plan that header is written as `<LICENSE HEADER>`; replace it with the real thing.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+| --- | --- |
+| `packages/cooklang/src/common/timer-duration.ts` | Cooklang `Timer` → seconds; clock and duration formatting |
+| `packages/cooklang/src/common/timer-duration.spec.ts` | Tests for the above |
+| `packages/cooklang/src/common/cooking-timer.ts` | `ActiveTimer` type + pure state transitions |
+| `packages/cooklang/src/common/cooking-timer.spec.ts` | Tests for the above |
+| `packages/cooklang/src/common/recipe-links.ts` | `linkify(text)` URL tokenizer |
+| `packages/cooklang/src/common/recipe-links.spec.ts` | Tests for the above |
+| `packages/cooklang/src/browser/cooking-timer-service.ts` | Singleton owning live timers, tick, persistence |
+| `packages/cooklang/src/browser/cooking-timer-service.spec.ts` | Tests with a fake clock and in-memory storage |
+| `packages/cooklang/src/browser/timer-chime.ts` | Web Audio bell |
+| `packages/cooklang/src/browser/timer-alarm-service.ts` | Notification + sound on timer completion |
+| `packages/cooklang/src/browser/timer-components.tsx` | `TimerBinding` context, `TimerBadge`, `TimerRow` |
+| `packages/cooklang/src/browser/timer-components.spec.ts` | Static-markup tests for badge and row |
+| `packages/cooklang/src/browser/timers-widget.tsx` | The Timers panel `ReactWidget` |
+| `packages/cooklang/src/browser/timers-view-contribution.ts` | View registration, toggle command |
+| `packages/cooklang/src/browser/style/timers.css` | Panel styling |
+
+**Modified:**
+
+| File | Change |
+| --- | --- |
+| `packages/cooklang/src/browser/recipe-preview-components.tsx` | Linkified text, `TimerBadge` in `StepItemView`, `scale` becomes a controlled prop |
+| `packages/cooklang/src/browser/recipe-preview-widget.tsx` | Supplies the timer binding and link opener, owns `scale`, exposes `setScale` |
+| `packages/cooklang/src/browser/recipe-preview-contribution.ts` | New `cooklang.openPreviewAtScale` command |
+| `packages/cooklang/src/browser/cooklang-frontend-module.ts` | Bindings for the new services, widget and view |
+| `packages/cooklang/src/common/cooklang-preferences.ts` | `cooklang.timers.sound`, `cooklang.timers.notifications` |
+| `packages/cooklang/src/browser/style/recipe-preview.css` | Timer badge states, `.recipe-link` |
+
+---
+
+## Task 1: Timer duration parsing and formatting
+
+Port of iOS `Value.toSeconds` (`CooklangApp/Presentation/Scenes/Base/ViewModel/Providers/RecipesProvider.swift`) and `DurationFormatter.swift`.
+
+**Files:**
+- Create: `packages/cooklang/src/common/timer-duration.ts`
+- Test: `packages/cooklang/src/common/timer-duration.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/common/timer-duration.spec.ts`:
+
+```ts
+<LICENSE HEADER>
+
+/* eslint-disable no-null/no-null */
+
+import { expect } from 'chai';
+import { Timer } from './recipe-types';
+import { timerDurationSeconds, formatClock, formatDuration } from './timer-duration';
+
+/** A timer with a plain numeric quantity, e.g. `~name{value%unit}`. */
+function numberTimer(value: number, unit: string | null, name: string | null = null): Timer {
+    return {
+        name,
+        quantity: {
+            value: { type: 'number', value: { type: 'regular', value } },
+            unit,
+            scalable: true,
+        },
+    };
+}
+
+describe('timerDurationSeconds', () => {
+
+    it('reads the unit from its first character', () => {
+        expect(timerDurationSeconds(numberTimer(30, 'seconds'))).to.equal(30);
+        expect(timerDurationSeconds(numberTimer(10, 'minutes'))).to.equal(600);
+        expect(timerDurationSeconds(numberTimer(2, 'hours'))).to.equal(7200);
+        expect(timerDurationSeconds(numberTimer(3, 'days'))).to.equal(259200);
+    });
+
+    it('accepts abbreviated and capitalised units', () => {
+        expect(timerDurationSeconds(numberTimer(10, 'min'))).to.equal(600);
+        expect(timerDurationSeconds(numberTimer(10, 'M'))).to.equal(600);
+        expect(timerDurationSeconds(numberTimer(1, 'hr'))).to.equal(3600);
+    });
+
+    it('keeps fractional values', () => {
+        expect(timerDurationSeconds(numberTimer(1.5, 'hours'))).to.equal(5400);
+    });
+
+    it('resolves fractions', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: {
+                value: { type: 'number', value: { type: 'fraction', value: { whole: 1, num: 1, den: 2, err: 0 } } },
+                unit: 'hours',
+                scalable: true,
+            },
+        };
+        expect(timerDurationSeconds(timer)).to.equal(5400);
+    });
+
+    it('uses the start of a range', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: {
+                value: {
+                    type: 'range',
+                    value: {
+                        start: { type: 'regular', value: 50 },
+                        end: { type: 'regular', value: 60 },
+                    },
+                },
+                unit: 'minutes',
+                scalable: true,
+            },
+        };
+        expect(timerDurationSeconds(timer)).to.equal(3000);
+    });
+
+    it('uses the first number of a text quantity, which is how the parser returns ranges', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: { value: { type: 'text', value: '50-60' }, unit: 'minutes', scalable: false },
+        };
+        expect(timerDurationSeconds(timer)).to.equal(3000);
+    });
+
+    it('returns undefined when the timer cannot be run', () => {
+        // ~{until golden}: text quantity, no unit
+        expect(timerDurationSeconds({
+            name: null,
+            quantity: { value: { type: 'text', value: 'until golden' }, unit: null, scalable: false },
+        })).to.equal(undefined);
+        // ~sauce: a name and nothing else
+        expect(timerDurationSeconds({ name: 'sauce', quantity: null })).to.equal(undefined);
+        // an unrecognised unit
+        expect(timerDurationSeconds(numberTimer(10, 'cups'))).to.equal(undefined);
+        // a zero or negative duration is not a timer
+        expect(timerDurationSeconds(numberTimer(0, 'minutes'))).to.equal(undefined);
+    });
+});
+
+describe('formatClock', () => {
+
+    it('shows minutes and seconds by default', () => {
+        expect(formatClock(0)).to.equal('00:00');
+        expect(formatClock(62)).to.equal('01:02');
+        expect(formatClock(600)).to.equal('10:00');
+    });
+
+    it('adds hours only when there are hours', () => {
+        expect(formatClock(3930)).to.equal('01:05:30');
+    });
+
+    it('adds days at 24 hours and above', () => {
+        expect(formatClock(4 * 86400 + 8 * 3600 + 5 * 60 + 30)).to.equal('4d 08:05:30');
+    });
+
+    it('rounds up, so a countdown never shows a value it has not reached', () => {
+        expect(formatClock(0.2)).to.equal('00:01');
+    });
+
+    it('clamps negatives to zero', () => {
+        expect(formatClock(-5)).to.equal('00:00');
+    });
+});
+
+describe('formatDuration', () => {
+
+    it('renders the largest units first and skips empty ones', () => {
+        expect(formatDuration(600)).to.equal('10 min');
+        expect(formatDuration(330)).to.equal('5 min 30 sec');
+        expect(formatDuration(3900)).to.equal('1 hour 5 min');
+        expect(formatDuration(4 * 86400 + 8 * 3600)).to.equal('4 day 8 hour');
+    });
+
+    it('renders zero explicitly', () => {
+        expect(formatDuration(0)).to.equal('0 sec');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile FAILS with `Cannot find module './timer-duration'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/common/timer-duration.ts`:
+
+```ts
+<LICENSE HEADER>
+
+/* eslint-disable no-null/no-null */
+
+import { NumberValue, Quantity, QuantityValue, Timer } from './recipe-types';
+
+/**
+ * Seconds per unit, keyed by the unit's first character. This mirrors the iOS
+ * app's `CookingTimerUnit`, which also matches on the first character so that
+ * `m`, `min` and `minutes` all mean the same thing.
+ */
+const UNIT_SECONDS: Record<string, number> = {
+    s: 1,
+    m: 60,
+    h: 3600,
+    d: 86400,
+};
+
+function unitSeconds(unit: string | null): number | undefined {
+    if (!unit) {
+        return undefined;
+    }
+    const first = unit.trim().charAt(0).toLowerCase();
+    return UNIT_SECONDS[first];
+}
+
+function numberValueToNumber(value: NumberValue): number {
+    switch (value.type) {
+        case 'regular':
+            return value.value;
+        case 'fraction': {
+            const { whole, num, den } = value.value;
+            return den === 0 ? whole : whole + num / den;
+        }
+    }
+}
+
+/**
+ * The first number in `text`. The parser hands ranges written as
+ * `~{50-60%minutes}` back as the text `'50-60'`, and the iOS app takes the
+ * first value; we do the same so both apps start the same timer.
+ */
+function firstNumberInText(text: string): number | undefined {
+    const match = /\d+(?:\.\d+)?/.exec(text);
+    return match ? parseFloat(match[0]) : undefined;
+}
+
+function quantityValueToNumber(value: QuantityValue): number | undefined {
+    switch (value.type) {
+        case 'number':
+            return numberValueToNumber(value.value);
+        case 'range':
+            return numberValueToNumber(value.value.start);
+        case 'text':
+            return firstNumberInText(value.value);
+    }
+}
+
+/**
+ * The runnable duration of `quantity` in whole seconds, or `undefined` when it
+ * does not describe a duration (no unit, no number, or a non-time unit).
+ */
+export function quantityDurationSeconds(quantity: Quantity | null): number | undefined {
+    if (quantity === null || quantity === undefined) {
+        return undefined;
+    }
+    const multiplier = unitSeconds(quantity.unit);
+    if (multiplier === undefined) {
+        return undefined;
+    }
+    const value = quantityValueToNumber(quantity.value);
+    if (value === undefined || !Number.isFinite(value) || value <= 0) {
+        return undefined;
+    }
+    return Math.round(value * multiplier);
+}
+
+/**
+ * The runnable duration of `timer`, or `undefined` when the timer cannot be
+ * run — `~{until golden}` and bare named timers like `~sauce` have no duration
+ * and stay as plain decoration in the preview.
+ */
+export function timerDurationSeconds(timer: Timer): number | undefined {
+    return quantityDurationSeconds(timer.quantity);
+}
+
+interface DurationParts {
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+}
+
+function splitDuration(totalSeconds: number): DurationParts {
+    const total = Math.max(0, totalSeconds);
+    return {
+        days: Math.floor(total / 86400),
+        hours: Math.floor((total % 86400) / 3600),
+        minutes: Math.floor((total % 3600) / 60),
+        seconds: total % 60,
+    };
+}
+
+function pad(value: number): string {
+    return String(value).padStart(2, '0');
+}
+
+/**
+ * A countdown clock: `10:00`, `01:05:30`, `4d 08:05:30`. Rounds up, so a
+ * counter started at 10 minutes reads `10:00` rather than `09:59`.
+ */
+export function formatClock(totalSeconds: number): string {
+    const { days, hours, minutes, seconds } = splitDuration(Math.ceil(totalSeconds));
+    if (days > 0) {
+        return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    if (hours > 0) {
+        return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    return `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * A human-readable duration: `10 min`, `5 min 30 sec`, `1 hour 5 min`.
+ */
+export function formatDuration(totalSeconds: number): string {
+    const { days, hours, minutes, seconds } = splitDuration(Math.round(totalSeconds));
+    const parts: string[] = [];
+    if (days > 0) {
+        parts.push(`${days} day`);
+    }
+    if (hours > 0) {
+        parts.push(`${hours} hour`);
+    }
+    if (minutes > 0) {
+        parts.push(`${minutes} min`);
+    }
+    if (seconds > 0) {
+        parts.push(`${seconds} sec`);
+    }
+    return parts.length === 0 ? '0 sec' : parts.join(' ');
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/common/timer-duration.spec.js"; cd ../..
+```
+
+Expected: all `timerDurationSeconds`, `formatClock` and `formatDuration` tests PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/common/timer-duration.ts packages/cooklang/src/common/timer-duration.spec.ts
+git commit -m "feat(cooklang): parse and format timer durations"
+```
+
+---
+
+## Task 2: `ActiveTimer` state machine
+
+Port of iOS `ActiveTimer.swift`. Every function is pure and takes `nowMs`, so tests never touch the real clock.
+
+**Files:**
+- Create: `packages/cooklang/src/common/cooking-timer.ts`
+- Test: `packages/cooklang/src/common/cooking-timer.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/common/cooking-timer.spec.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { expect } from 'chai';
+import {
+    ActiveTimer,
+    TimerRecipeRef,
+    addTime,
+    createAndStart,
+    finish,
+    fireAtMs,
+    isExpired,
+    matchesRef,
+    pause,
+    remainingSeconds,
+    reset,
+    restart,
+    resume,
+} from './cooking-timer';
+
+const T0 = 1_700_000_000_000;
+
+function ref(overrides: Partial<TimerRecipeRef> = {}): TimerRecipeRef {
+    return {
+        recipePath: 'file:///recipes/Soup.cook',
+        recipeName: 'Soup',
+        globalStepIndex: 2,
+        timerPosition: 0,
+        scale: 1,
+        ...overrides,
+    };
+}
+
+function started(): ActiveTimer {
+    return createAndStart('id-1', 'simmer', 600, T0, ref());
+}
+
+describe('createAndStart', () => {
+
+    it('produces a running timer anchored to now', () => {
+        const timer = started();
+        expect(timer.state).to.equal('running');
+        expect(timer.startedAtMs).to.equal(T0);
+        expect(timer.pausedRemainingSeconds).to.equal(undefined);
+        expect(timer.durationSeconds).to.equal(600);
+        expect(timer.updatedAtMs).to.equal(T0);
+        expect(timer.recipeRef?.recipeName).to.equal('Soup');
+    });
+});
+
+describe('remainingSeconds', () => {
+
+    it('counts down while running', () => {
+        expect(remainingSeconds(started(), T0)).to.equal(600);
+        expect(remainingSeconds(started(), T0 + 90_000)).to.equal(510);
+    });
+
+    it('never goes below zero', () => {
+        expect(remainingSeconds(started(), T0 + 999_000)).to.equal(0);
+    });
+
+    it('freezes while paused', () => {
+        const paused = pause(started(), T0 + 90_000);
+        expect(remainingSeconds(paused, T0 + 90_000)).to.equal(510);
+        expect(remainingSeconds(paused, T0 + 900_000)).to.equal(510);
+    });
+
+    it('is zero once finished', () => {
+        expect(remainingSeconds(finish(started(), T0 + 600_000), T0 + 700_000)).to.equal(0);
+    });
+});
+
+describe('pause and resume', () => {
+
+    it('does not drift across repeated cycles', () => {
+        let timer = started();
+        // run 100s, pause 1000s, run 100s, pause 1000s
+        timer = pause(timer, T0 + 100_000);
+        timer = resume(timer, T0 + 1_100_000);
+        timer = pause(timer, T0 + 1_200_000);
+        timer = resume(timer, T0 + 2_200_000);
+        // 200 seconds of running have elapsed in total
+        expect(remainingSeconds(timer, T0 + 2_200_000)).to.equal(400);
+    });
+
+    it('ignores a pause on an already paused timer', () => {
+        const paused = pause(started(), T0 + 60_000);
+        expect(pause(paused, T0 + 300_000)).to.deep.equal(paused);
+    });
+
+    it('ignores a resume on a running timer', () => {
+        const running = started();
+        expect(resume(running, T0 + 60_000)).to.deep.equal(running);
+    });
+});
+
+describe('reset and restart', () => {
+
+    it('reset returns a paused timer at full duration', () => {
+        const timer = reset(pause(started(), T0 + 60_000), T0 + 70_000);
+        expect(timer.state).to.equal('paused');
+        expect(remainingSeconds(timer, T0 + 70_000)).to.equal(600);
+    });
+
+    it('restart returns a running timer at full duration', () => {
+        const timer = restart(finish(started(), T0 + 600_000), T0 + 700_000);
+        expect(timer.state).to.equal('running');
+        expect(remainingSeconds(timer, T0 + 700_000)).to.equal(600);
+        expect(remainingSeconds(timer, T0 + 760_000)).to.equal(540);
+    });
+});
+
+describe('addTime', () => {
+
+    it('extends a running timer', () => {
+        const timer = addTime(started(), 60, T0 + 60_000);
+        expect(remainingSeconds(timer, T0 + 60_000)).to.equal(600);
+    });
+
+    it('extends a paused timer', () => {
+        const timer = addTime(pause(started(), T0 + 60_000), 60, T0 + 60_000);
+        expect(remainingSeconds(timer, T0 + 60_000)).to.equal(600);
+    });
+
+    it('revives a finished timer as paused with just the added time', () => {
+        const timer = addTime(finish(started(), T0 + 600_000), 60, T0 + 700_000);
+        expect(timer.state).to.equal('paused');
+        expect(remainingSeconds(timer, T0 + 700_000)).to.equal(60);
+    });
+});
+
+describe('isExpired and fireAtMs', () => {
+
+    it('expires exactly at the end of the duration', () => {
+        expect(isExpired(started(), T0 + 599_000)).to.equal(false);
+        expect(isExpired(started(), T0 + 600_000)).to.equal(true);
+    });
+
+    it('does not expire while paused', () => {
+        expect(isExpired(pause(started(), T0 + 60_000), T0 + 10_000_000)).to.equal(false);
+    });
+
+    it('reports when a running timer will fire', () => {
+        expect(fireAtMs(started())).to.equal(T0 + 600_000);
+        expect(fireAtMs(pause(started(), T0 + 60_000))).to.equal(undefined);
+    });
+});
+
+describe('matchesRef', () => {
+
+    it('matches on recipe, step and position, ignoring scale', () => {
+        const timer = started();
+        expect(matchesRef(timer, ref({ scale: 4 }))).to.equal(true);
+        expect(matchesRef(timer, ref({ timerPosition: 1 }))).to.equal(false);
+        expect(matchesRef(timer, ref({ globalStepIndex: 3 }))).to.equal(false);
+        expect(matchesRef(timer, ref({ recipePath: 'file:///other.cook' }))).to.equal(false);
+    });
+
+    it('never matches a timer with no recipe', () => {
+        const orphan: ActiveTimer = { ...started(), recipeRef: undefined };
+        expect(matchesRef(orphan, ref())).to.equal(false);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile FAILS with `Cannot find module './cooking-timer'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/common/cooking-timer.ts`:
+
+```ts
+<LICENSE HEADER>
+
+/**
+ * The live state of a cooking timer. This is a port of the iOS app's
+ * `ActiveTimer` (`Packages/Timers/Sources/Timers/Models/ActiveTimer.swift`),
+ * minus its `idle` state: here a record only exists once the timer has been
+ * started, because the Timers panel lists started timers only.
+ *
+ * Every function is pure and takes the current time as an argument, so the
+ * whole state machine is testable with a fake clock.
+ */
+
+export type TimerState = 'running' | 'paused' | 'finished';
+
+/** Where a timer came from, and how to get back there. */
+export interface TimerRecipeRef {
+    /** Full URI string of the `.cook` file. */
+    recipePath: string;
+    /** Display name of the recipe, for the panel row. */
+    recipeName: string;
+    /** Index of the step across the whole recipe, 0-based. */
+    globalStepIndex: number;
+    /** Index of this timer among the timers of that step, 0-based. */
+    timerPosition: number;
+    /** Recipe scale factor in force when the timer was started. */
+    scale: number;
+}
+
+export interface ActiveTimer {
+    id: string;
+    title: string;
+    durationSeconds: number;
+    state: TimerState;
+    /**
+     * When the timer's countdown is anchored. While running this may be in the
+     * past by more than the elapsed wall time: `resume` back-dates it so that
+     * `remainingSeconds` stays a pure function of the clock.
+     */
+    startedAtMs?: number;
+    /** Frozen remaining time; set while paused. */
+    pausedRemainingSeconds?: number;
+    recipeRef?: TimerRecipeRef;
+    updatedAtMs: number;
+}
+
+export function createAndStart(
+    id: string,
+    title: string,
+    durationSeconds: number,
+    nowMs: number,
+    recipeRef?: TimerRecipeRef
+): ActiveTimer {
+    return {
+        id,
+        title,
+        durationSeconds,
+        state: 'running',
+        startedAtMs: nowMs,
+        recipeRef,
+        updatedAtMs: nowMs,
+    };
+}
+
+export function remainingSeconds(timer: ActiveTimer, nowMs: number): number {
+    switch (timer.state) {
+        case 'running': {
+            if (timer.startedAtMs === undefined) {
+                return timer.durationSeconds;
+            }
+            const elapsed = (nowMs - timer.startedAtMs) / 1000;
+            return Math.max(0, timer.durationSeconds - elapsed);
+        }
+        case 'paused':
+            return timer.pausedRemainingSeconds ?? timer.durationSeconds;
+        case 'finished':
+            return 0;
+    }
+}
+
+/** When a running timer will fire, or `undefined` if it is not running. */
+export function fireAtMs(timer: ActiveTimer): number | undefined {
+    if (timer.state !== 'running' || timer.startedAtMs === undefined) {
+        return undefined;
+    }
+    return timer.startedAtMs + timer.durationSeconds * 1000;
+}
+
+export function isExpired(timer: ActiveTimer, nowMs: number): boolean {
+    return timer.state === 'running' && remainingSeconds(timer, nowMs) <= 0;
+}
+
+export function pause(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    if (timer.state !== 'running') {
+        return timer;
+    }
+    return {
+        ...timer,
+        state: 'paused',
+        pausedRemainingSeconds: remainingSeconds(timer, nowMs),
+        startedAtMs: undefined,
+        updatedAtMs: nowMs,
+    };
+}
+
+export function resume(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    if (timer.state === 'running') {
+        return timer;
+    }
+    const remaining = timer.state === 'paused'
+        ? (timer.pausedRemainingSeconds ?? timer.durationSeconds)
+        : timer.durationSeconds;
+    // Back-date the anchor by the portion already spent, so that
+    // `remainingSeconds` needs nothing but the clock.
+    return {
+        ...timer,
+        state: 'running',
+        startedAtMs: nowMs - (timer.durationSeconds - remaining) * 1000,
+        pausedRemainingSeconds: undefined,
+        updatedAtMs: nowMs,
+    };
+}
+
+export function finish(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    return {
+        ...timer,
+        state: 'finished',
+        startedAtMs: undefined,
+        pausedRemainingSeconds: 0,
+        updatedAtMs: nowMs,
+    };
+}
+
+/** Back to the full duration, paused. */
+export function reset(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    return {
+        ...timer,
+        state: 'paused',
+        startedAtMs: undefined,
+        pausedRemainingSeconds: timer.durationSeconds,
+        updatedAtMs: nowMs,
+    };
+}
+
+/** Back to the full duration, running. */
+export function restart(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    return resume(reset(timer, nowMs), nowMs);
+}
+
+export function addTime(timer: ActiveTimer, seconds: number, nowMs: number): ActiveTimer {
+    switch (timer.state) {
+        case 'running':
+            return {
+                ...timer,
+                startedAtMs: (timer.startedAtMs ?? nowMs) + seconds * 1000,
+                updatedAtMs: nowMs,
+            };
+        case 'paused':
+            return {
+                ...timer,
+                pausedRemainingSeconds: (timer.pausedRemainingSeconds ?? timer.durationSeconds) + seconds,
+                updatedAtMs: nowMs,
+            };
+        case 'finished':
+            return {
+                ...timer,
+                state: 'paused',
+                pausedRemainingSeconds: seconds,
+                updatedAtMs: nowMs,
+            };
+    }
+}
+
+/**
+ * Whether `timer` is the timer at `ref`'s position. The scale is deliberately
+ * ignored: re-scaling the preview must not lose a running timer.
+ */
+export function matchesRef(timer: ActiveTimer, ref: TimerRecipeRef): boolean {
+    const own = timer.recipeRef;
+    if (!own) {
+        return false;
+    }
+    return own.recipePath === ref.recipePath
+        && own.globalStepIndex === ref.globalStepIndex
+        && own.timerPosition === ref.timerPosition;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/common/cooking-timer.spec.js"; cd ../..
+```
+
+Expected: every describe block PASSES.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/common/cooking-timer.ts packages/cooklang/src/common/cooking-timer.spec.ts
+git commit -m "feat(cooklang): add ActiveTimer state machine"
+```
+
+---
+
+## Task 3: URL tokenizer
+
+**Files:**
+- Create: `packages/cooklang/src/common/recipe-links.ts`
+- Test: `packages/cooklang/src/common/recipe-links.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/common/recipe-links.spec.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { expect } from 'chai';
+import { linkify } from './recipe-links';
+
+describe('linkify', () => {
+
+    it('returns a single text token when there is no link', () => {
+        expect(linkify('Simmer for a while.')).to.deep.equal([
+            { type: 'text', value: 'Simmer for a while.' },
+        ]);
+    });
+
+    it('returns an empty array for empty text', () => {
+        expect(linkify('')).to.deep.equal([]);
+    });
+
+    it('splits text around an http url', () => {
+        expect(linkify('See https://cooklang.org/spec now')).to.deep.equal([
+            { type: 'text', value: 'See ' },
+            { type: 'link', value: 'https://cooklang.org/spec', href: 'https://cooklang.org/spec' },
+            { type: 'text', value: ' now' },
+        ]);
+    });
+
+    it('upgrades a bare www host to https', () => {
+        expect(linkify('www.cook.md')).to.deep.equal([
+            { type: 'link', value: 'www.cook.md', href: 'https://www.cook.md' },
+        ]);
+    });
+
+    it('links a bare email address through mailto', () => {
+        expect(linkify('ask chef@cook.md')).to.deep.equal([
+            { type: 'text', value: 'ask ' },
+            { type: 'link', value: 'chef@cook.md', href: 'mailto:chef@cook.md' },
+        ]);
+    });
+
+    it('keeps an explicit mailto scheme', () => {
+        expect(linkify('mailto:chef@cook.md')).to.deep.equal([
+            { type: 'link', value: 'mailto:chef@cook.md', href: 'mailto:chef@cook.md' },
+        ]);
+    });
+
+    it('leaves trailing sentence punctuation outside the link', () => {
+        expect(linkify('Source: https://cook.md/x.')).to.deep.equal([
+            { type: 'text', value: 'Source: ' },
+            { type: 'link', value: 'https://cook.md/x', href: 'https://cook.md/x' },
+            { type: 'text', value: '.' },
+        ]);
+    });
+
+    it('leaves an unbalanced closing paren outside the link', () => {
+        expect(linkify('(see https://cook.md/x)')).to.deep.equal([
+            { type: 'text', value: '(see ' },
+            { type: 'link', value: 'https://cook.md/x', href: 'https://cook.md/x' },
+            { type: 'text', value: ')' },
+        ]);
+    });
+
+    it('keeps a balanced paren inside the link', () => {
+        expect(linkify('https://en.wikipedia.org/wiki/Roux_(cooking)')).to.deep.equal([
+            {
+                type: 'link',
+                value: 'https://en.wikipedia.org/wiki/Roux_(cooking)',
+                href: 'https://en.wikipedia.org/wiki/Roux_(cooking)',
+            },
+        ]);
+    });
+
+    it('finds several links in one run of text', () => {
+        const tokens = linkify('a https://one.example b https://two.example c');
+        expect(tokens.filter(t => t.type === 'link').map(t => t.value)).to.deep.equal([
+            'https://one.example',
+            'https://two.example',
+        ]);
+        expect(tokens).to.have.length(5);
+    });
+
+    it('does not mistake a plain colon or a decimal for a link', () => {
+        expect(linkify('Cook: 1.5 hours')).to.deep.equal([
+            { type: 'text', value: 'Cook: 1.5 hours' },
+        ]);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile FAILS with `Cannot find module './recipe-links'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/common/recipe-links.ts`:
+
+```ts
+<LICENSE HEADER>
+
+export interface TextToken {
+    type: 'text';
+    value: string;
+}
+
+export interface LinkToken {
+    type: 'link';
+    /** The text as written in the recipe. */
+    value: string;
+    /** The absolute URL to open. */
+    href: string;
+}
+
+export type LinkifyToken = TextToken | LinkToken;
+
+/**
+ * Matches, in order: an explicit http(s) URL, a bare `www.` host, an explicit
+ * `mailto:`, and a bare email address. Deliberately greedy up to whitespace or
+ * a quote/angle bracket; trailing punctuation is trimmed afterwards.
+ */
+const LINK_PATTERN = new RegExp([
+    'https?://[^\\s<>"\']+',
+    'www\\.[^\\s<>"\']+',
+    'mailto:[^\\s<>"\']+',
+    '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
+].join('|'), 'g');
+
+const TRAILING_PUNCTUATION = '.,;:!?';
+
+function count(text: string, character: string): number {
+    let total = 0;
+    for (const c of text) {
+        if (c === character) {
+            total++;
+        }
+    }
+    return total;
+}
+
+/**
+ * Drop characters a writer meant as prose rather than as part of the URL: a
+ * full stop that ends the sentence, or a closing bracket that was never opened
+ * inside the URL itself.
+ */
+function trimTrailing(match: string): string {
+    let value = match;
+    for (;;) {
+        const last = value.charAt(value.length - 1);
+        if (last === '') {
+            break;
+        }
+        if (TRAILING_PUNCTUATION.includes(last)) {
+            value = value.slice(0, -1);
+            continue;
+        }
+        if (last === ')' && count(value, ')') > count(value, '(')) {
+            value = value.slice(0, -1);
+            continue;
+        }
+        if (last === ']' && count(value, ']') > count(value, '[')) {
+            value = value.slice(0, -1);
+            continue;
+        }
+        break;
+    }
+    return value;
+}
+
+function hrefFor(value: string): string {
+    if (/^https?:\/\//i.test(value) || /^mailto:/i.test(value)) {
+        return value;
+    }
+    if (/^www\./i.test(value)) {
+        return `https://${value}`;
+    }
+    return `mailto:${value}`;
+}
+
+/**
+ * Split `text` into plain runs and links. Text with no links yields a single
+ * text token; empty text yields no tokens at all.
+ */
+export function linkify(text: string): LinkifyToken[] {
+    if (text.length === 0) {
+        return [];
+    }
+    const tokens: LinkifyToken[] = [];
+    let cursor = 0;
+    LINK_PATTERN.lastIndex = 0;
+    let match = LINK_PATTERN.exec(text);
+    while (match !== null) {
+        const start = match.index;
+        const value = trimTrailing(match[0]);
+        if (value.length > 0) {
+            if (start > cursor) {
+                tokens.push({ type: 'text', value: text.substring(cursor, start) });
+            }
+            tokens.push({ type: 'link', value, href: hrefFor(value) });
+            cursor = start + value.length;
+            LINK_PATTERN.lastIndex = cursor;
+        }
+        match = LINK_PATTERN.exec(text);
+    }
+    if (cursor < text.length) {
+        tokens.push({ type: 'text', value: text.substring(cursor) });
+    }
+    return tokens;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/common/recipe-links.spec.js"; cd ../..
+```
+
+Expected: all 12 tests PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/common/recipe-links.ts packages/cooklang/src/common/recipe-links.spec.ts
+git commit -m "feat(cooklang): add URL tokenizer for recipe text"
+```
+
+---
+
+## Task 4: Render links in the preview
+
+Renders `linkify` output in metadata pill values, step text and notes. The link opener arrives through a React context so `recipe-preview-components.tsx` keeps no service dependency and the existing spec still renders.
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/recipe-preview-components.tsx`
+- Modify: `packages/cooklang/src/browser/recipe-preview-widget.tsx`
+- Modify: `packages/cooklang/src/browser/style/recipe-preview.css`
+- Test: `packages/cooklang/src/browser/recipe-preview-links.spec.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/browser/recipe-preview-links.spec.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MetadataPills, LinkedText } from './recipe-preview-components';
+
+describe('LinkedText', () => {
+
+    it('renders plain text unchanged', () => {
+        const markup = renderToStaticMarkup(React.createElement(LinkedText, { text: 'Simmer gently.' }));
+        expect(markup).to.equal('Simmer gently.');
+    });
+
+    it('renders an anchor for a url in step text', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(LinkedText, { text: 'Method from https://cook.md/x here' })
+        );
+        expect(markup).to.contain('<a class="recipe-link" href="https://cook.md/x">https://cook.md/x</a>');
+        expect(markup).to.contain('Method from ');
+        expect(markup).to.contain(' here');
+    });
+});
+
+describe('MetadataPills', () => {
+
+    it('links a url in a metadata value', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(MetadataPills, { meta: { source: 'https://cook.md/recipes/soup' } })
+        );
+        expect(markup).to.contain('href="https://cook.md/recipes/soup"');
+    });
+
+    it('leaves a non-url metadata value alone', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(MetadataPills, { meta: { servings: '4' } })
+        );
+        expect(markup).to.not.contain('<a');
+        expect(markup).to.contain('4');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile FAILS with `Module '"./recipe-preview-components"' has no exported member 'LinkedText'`.
+
+- [ ] **Step 3: Add `LinkedText` and use it in the three text sites**
+
+In `packages/cooklang/src/browser/recipe-preview-components.tsx`, add to the imports:
+
+```tsx
+import { linkify } from '../common/recipe-links';
+```
+
+Add this section immediately after the `// Internal helpers` block (before `StepItemView`):
+
+```tsx
+// ---------------------------------------------------------------------------
+// Links
+// ---------------------------------------------------------------------------
+
+/** Opens a URL outside the preview. Supplied by the widget. */
+export type LinkOpener = (url: string) => void;
+
+const LinkOpenerContext = React.createContext<LinkOpener | undefined>(undefined);
+
+/** Wraps a subtree so the links inside it open through `value`. */
+export const LinkOpenerProvider = LinkOpenerContext.Provider;
+
+interface LinkedTextProps {
+    text: string;
+}
+
+/**
+ * Recipe text with any URLs in it turned into links. Without a
+ * {@link LinkOpenerProvider} above it the anchors still render with their
+ * `href`, they just have no click behaviour — which is what keeps this
+ * component renderable in tests.
+ */
+export const LinkedText = ({ text }: LinkedTextProps): React.ReactElement => {
+    const openLink = React.useContext(LinkOpenerContext);
+    const tokens = linkify(text);
+    if (tokens.length === 0) {
+        return <></>;
+    }
+    if (tokens.length === 1 && tokens[0].type === 'text') {
+        return <React.Fragment>{text}</React.Fragment>;
+    }
+    return (
+        <React.Fragment>
+            {tokens.map((token, idx) => token.type === 'text' ? (
+                <React.Fragment key={idx}>{token.value}</React.Fragment>
+            ) : (
+                <a key={idx} className='recipe-link' href={token.href}
+                    onClick={e => {
+                        if (openLink) {
+                            e.preventDefault();
+                            openLink(token.href);
+                        }
+                    }}>
+                    {token.value}
+                </a>
+            ))}
+        </React.Fragment>
+    );
+};
+```
+
+In `StepItemView`, replace the text case:
+
+```tsx
+        case 'text':
+            return <LinkedText text={item.value} />;
+```
+
+In `SectionContentView`, replace the note branch:
+
+```tsx
+    if (content.type === 'text') {
+        return <div className='note-item'><LinkedText text={content.value} /></div>;
+    }
+```
+
+In `MetadataPills`, replace the pill body:
+
+```tsx
+                <span key={idx} className='metadata-pill'>
+                    <strong>{pill.label}:</strong> <LinkedText text={pill.value} />
+                </span>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/browser/recipe-preview-links.spec.js" "./lib/browser/recipe-preview-components.spec.js"; cd ../..
+```
+
+Expected: the new link tests PASS **and** the pre-existing `InstructionsPanel step image indices` suite still PASSES.
+
+- [ ] **Step 5: Wire the opener into the widget**
+
+In `packages/cooklang/src/browser/recipe-preview-widget.tsx` add the import:
+
+```tsx
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+```
+
+change the `RecipeView` import to:
+
+```tsx
+import { RecipeView, LinkOpenerProvider } from './recipe-preview-components';
+```
+
+add the injection next to the other `@inject` fields:
+
+```tsx
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+```
+
+add the handler next to `handleNavigateToRecipe`:
+
+```tsx
+    protected handleOpenLink = (url: string): void => {
+        this.windowService.openNewWindow(url, { external: true });
+    };
+```
+
+and wrap the rendered `RecipeView` in `render()`:
+
+```tsx
+        if (this.recipe) {
+            return (
+                <LinkOpenerProvider value={this.handleOpenLink}>
+                    <RecipeView
+                        recipe={this.recipe}
+                        fileName={this.uri?.path.base ?? ''}
+                        images={this.images}
+                        onShowSource={this.handleShowSource}
+                        onAddToShoppingList={this.handleAddToShoppingList}
+                        onNavigateToRecipe={this.handleNavigateToRecipe}
+                    />
+                </LinkOpenerProvider>
+            );
+        }
+```
+
+- [ ] **Step 6: Style the link**
+
+Append to `packages/cooklang/src/browser/style/recipe-preview.css`:
+
+```css
+/* Links found in metadata values, step text and notes */
+.theia-recipe-preview .recipe-link {
+    color: var(--theia-textLink-foreground);
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.theia-recipe-preview .recipe-link:hover {
+    color: var(--theia-textLink-activeForeground);
+    text-decoration: underline;
+}
+```
+
+- [ ] **Step 7: Compile, lint and commit**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/browser/recipe-preview-components.tsx \
+        packages/cooklang/src/browser/recipe-preview-widget.tsx \
+        packages/cooklang/src/browser/recipe-preview-links.spec.ts \
+        packages/cooklang/src/browser/style/recipe-preview.css
+git commit -m "feat(cooklang): make URLs in the recipe preview clickable"
+```
+
+---
+
+## Task 5: `CookingTimerService`
+
+Port of iOS `TimerManager` + `TimerStorage`. Persistence writes on every mutation rather than on a debounce: mutations are user-driven (start, pause, reset) plus one write per expiry, so there is nothing to debounce and the code stays testable.
+
+**Files:**
+- Create: `packages/cooklang/src/browser/cooking-timer-service.ts`
+- Test: `packages/cooklang/src/browser/cooking-timer-service.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/browser/cooking-timer-service.spec.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { expect } from 'chai';
+import { StorageService } from '@theia/core/lib/browser/storage-service';
+import { ActiveTimer, TimerRecipeRef, remainingSeconds } from '../common/cooking-timer';
+import { CookingTimerService } from './cooking-timer-service';
+
+const T0 = 1_700_000_000_000;
+
+class FakeStorage {
+    data = new Map<string, unknown>();
+    writes = 0;
+    async setData<T>(key: string, value: T): Promise<void> {
+        this.writes++;
+        this.data.set(key, JSON.parse(JSON.stringify(value)));
+    }
+    async getData<T>(key: string, defaultValue?: T): Promise<T | undefined> {
+        return this.data.has(key) ? this.data.get(key) as T : defaultValue;
+    }
+}
+
+/** Exposes the clock, the id generator and the protected lifecycle to tests. */
+class TestTimerService extends CookingTimerService {
+    currentTimeMs = T0;
+    protected idCounter = 0;
+    protected override now(): number {
+        return this.currentTimeMs;
+    }
+    protected override newId(): string {
+        return `t${++this.idCounter}`;
+    }
+    /** Number of live tick intervals; 0 or 1. */
+    get ticking(): boolean {
+        return this.tickHandle !== undefined;
+    }
+    async load(): Promise<void> {
+        await this.restore();
+    }
+    tickNow(): void {
+        this.tick();
+    }
+}
+
+function ref(overrides: Partial<TimerRecipeRef> = {}): TimerRecipeRef {
+    return {
+        recipePath: 'file:///recipes/Soup.cook',
+        recipeName: 'Soup',
+        globalStepIndex: 2,
+        timerPosition: 0,
+        scale: 1,
+        ...overrides,
+    };
+}
+
+function createService(storage: FakeStorage): TestTimerService {
+    const service = new TestTimerService();
+    (service as unknown as { storageService: StorageService }).storageService =
+        storage as unknown as StorageService;
+    return service;
+}
+
+describe('CookingTimerService', () => {
+
+    it('starts a timer, keeps it, and persists it', async () => {
+        const storage = new FakeStorage();
+        const service = createService(storage);
+        await service.load();
+
+        service.start(ref(), 'simmer', 600);
+
+        expect(service.list()).to.have.length(1);
+        expect(service.list()[0].title).to.equal('simmer');
+        expect(service.find(ref())?.id).to.equal('t1');
+        expect(storage.data.get('cooklang.timers')).to.have.length(1);
+        expect(service.ticking).to.equal(true);
+    });
+
+    it('finds a timer regardless of the scale in the lookup ref', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref({ scale: 1 }), 'simmer', 600);
+        expect(service.find(ref({ scale: 4 }))?.id).to.equal('t1');
+    });
+
+    it('restarts an existing timer instead of creating a second one for the same step', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        service.start(ref(), 'simmer', 600);
+        expect(service.list()).to.have.length(1);
+    });
+
+    it('fires onDidFinishTimer when a running timer expires', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        const finished: ActiveTimer[] = [];
+        service.onDidFinishTimer(timer => finished.push(timer));
+
+        service.start(ref(), 'simmer', 600);
+        service.currentTimeMs = T0 + 599_000;
+        service.tickNow();
+        expect(finished).to.have.length(0);
+
+        service.currentTimeMs = T0 + 600_000;
+        service.tickNow();
+        expect(finished.map(t => t.id)).to.deep.equal(['t1']);
+        expect(service.list()[0].state).to.equal('finished');
+    });
+
+    it('stops ticking once nothing is running', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        expect(service.ticking).to.equal(true);
+        service.pause('t1');
+        expect(service.ticking).to.equal(false);
+        service.resume('t1');
+        expect(service.ticking).to.equal(true);
+    });
+
+    it('restores timers and keeps counting down', async () => {
+        const storage = new FakeStorage();
+        const first = createService(storage);
+        await first.load();
+        first.start(ref(), 'simmer', 600);
+        first.dispose();
+
+        const second = createService(storage);
+        second.currentTimeMs = T0 + 120_000;
+        await second.load();
+
+        expect(second.list()).to.have.length(1);
+        expect(remainingSeconds(second.list()[0], second.currentTimeMs)).to.equal(480);
+    });
+
+    it('restores a timer that expired while the app was closed as finished, without alarming', async () => {
+        const storage = new FakeStorage();
+        const first = createService(storage);
+        await first.load();
+        first.start(ref(), 'simmer', 600);
+        first.dispose();
+
+        const second = createService(storage);
+        second.currentTimeMs = T0 + 3_600_000;
+        const finished: ActiveTimer[] = [];
+        second.onDidFinishTimer(timer => finished.push(timer));
+        await second.load();
+
+        expect(second.list()[0].state).to.equal('finished');
+        expect(finished).to.have.length(0);
+    });
+
+    it('keeps only the 20 most recently updated timers', async () => {
+        const storage = new FakeStorage();
+        const service = createService(storage);
+        await service.load();
+        for (let i = 0; i < 25; i++) {
+            service.currentTimeMs = T0 + i * 1000;
+            service.start(ref({ globalStepIndex: i }), `timer ${i}`, 600);
+        }
+        expect(service.list()).to.have.length(20);
+        expect(service.find(ref({ globalStepIndex: 0 }))).to.equal(undefined);
+        expect(service.find(ref({ globalStepIndex: 24 }))).to.not.equal(undefined);
+    });
+
+    it('removes finished timers on request and leaves the rest', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref({ globalStepIndex: 1 }), 'a', 600);
+        service.start(ref({ globalStepIndex: 2 }), 'b', 600);
+        service.currentTimeMs = T0 + 600_000;
+        service.tickNow();
+        service.resume('t1');
+        service.removeFinished();
+        expect(service.list().map(t => t.id)).to.deep.equal(['t1']);
+    });
+
+    it('notifies listeners on every change', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        let changes = 0;
+        service.onDidChangeTimers(() => changes++);
+        service.start(ref(), 'simmer', 600);
+        service.pause('t1');
+        service.addTime('t1', 60);
+        service.remove('t1');
+        expect(changes).to.equal(4);
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile FAILS with `Cannot find module './cooking-timer-service'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/browser/cooking-timer-service.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { StorageService } from '@theia/core/lib/browser/storage-service';
+import {
+    ActiveTimer,
+    TimerRecipeRef,
+    addTime,
+    createAndStart,
+    finish,
+    fireAtMs,
+    isExpired,
+    matchesRef,
+    pause,
+    reset,
+    restart,
+    resume,
+} from '../common/cooking-timer';
+
+/**
+ * Owns every live cooking timer for the window. A port of the iOS app's
+ * `TimerManager` plus `TimerStorage`
+ * (`Packages/Timers/Sources/Timers/Core/`).
+ *
+ * A single interval ticks once a second while at least one timer is running:
+ * it both detects expiry and drives countdown re-renders in the preview and
+ * the Timers panel. It is torn down as soon as nothing is running.
+ */
+@injectable()
+export class CookingTimerService implements Disposable {
+
+    static readonly STORAGE_KEY = 'cooklang.timers';
+    /** Matches the iOS `TimerManager.maxRetainedTimers`. */
+    static readonly MAX_TIMERS = 20;
+
+    @inject(StorageService)
+    protected readonly storageService: StorageService;
+
+    protected readonly timers = new Map<string, ActiveTimer>();
+
+    protected readonly onDidChangeTimersEmitter = new Emitter<void>();
+    readonly onDidChangeTimers: Event<void> = this.onDidChangeTimersEmitter.event;
+
+    protected readonly onDidFinishTimerEmitter = new Emitter<ActiveTimer>();
+    readonly onDidFinishTimer: Event<ActiveTimer> = this.onDidFinishTimerEmitter.event;
+
+    protected tickHandle: ReturnType<typeof setInterval> | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        // Never make this method async: Inversify 6.2.2 treats an async
+        // @postConstruct as an async binding and the whole frontend fails to
+        // construct. Kick the load off and let it settle on its own.
+        this.restore().catch(e => console.warn('Could not restore cooking timers', e));
+    }
+
+    // --- Overridable seams (tests substitute a fake clock and ids) ---
+
+    protected now(): number {
+        return Date.now();
+    }
+
+    protected newId(): string {
+        return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    // --- Query ---
+
+    /** Every timer, in insertion order. */
+    list(): ActiveTimer[] {
+        return Array.from(this.timers.values());
+    }
+
+    get(id: string): ActiveTimer | undefined {
+        return this.timers.get(id);
+    }
+
+    /** The timer started for `ref`'s step and position, whatever its scale. */
+    find(ref: TimerRecipeRef): ActiveTimer | undefined {
+        for (const timer of this.timers.values()) {
+            if (matchesRef(timer, ref)) {
+                return timer;
+            }
+        }
+        return undefined;
+    }
+
+    nowMs(): number {
+        return this.now();
+    }
+
+    // --- Commands ---
+
+    /**
+     * Start the timer for `ref`. If one is already there — paused, finished, or
+     * still running — it is restarted rather than duplicated.
+     */
+    start(ref: TimerRecipeRef, title: string, durationSeconds: number): ActiveTimer {
+        const now = this.now();
+        const existing = this.find(ref);
+        if (existing) {
+            // Re-read title, duration and scale: the recipe may have been
+            // edited or re-scaled since this timer was first started.
+            const updated = { ...existing, title, durationSeconds, recipeRef: ref };
+            return this.replace(restart(updated, now));
+        }
+        return this.replace(createAndStart(this.newId(), title, durationSeconds, now, ref));
+    }
+
+    pause(id: string): void {
+        this.mutate(id, timer => pause(timer, this.now()));
+    }
+
+    resume(id: string): void {
+        this.mutate(id, timer => resume(timer, this.now()));
+    }
+
+    /** Pause a running timer, resume a paused one, restart a finished one. */
+    toggle(id: string): void {
+        const timer = this.timers.get(id);
+        if (!timer) {
+            return;
+        }
+        const now = this.now();
+        this.mutate(id, () => {
+            switch (timer.state) {
+                case 'running':
+                    return pause(timer, now);
+                case 'paused':
+                    return resume(timer, now);
+                case 'finished':
+                    return restart(timer, now);
+            }
+        });
+    }
+
+    reset(id: string): void {
+        this.mutate(id, timer => reset(timer, this.now()));
+    }
+
+    restart(id: string): void {
+        this.mutate(id, timer => restart(timer, this.now()));
+    }
+
+    addTime(id: string, seconds: number): void {
+        this.mutate(id, timer => addTime(timer, seconds, this.now()));
+    }
+
+    remove(id: string): void {
+        if (this.timers.delete(id)) {
+            this.changed();
+        }
+    }
+
+    removeFinished(): void {
+        let removed = false;
+        for (const timer of this.list()) {
+            if (timer.state === 'finished') {
+                this.timers.delete(timer.id);
+                removed = true;
+            }
+        }
+        if (removed) {
+            this.changed();
+        }
+    }
+
+    removeAll(): void {
+        if (this.timers.size > 0) {
+            this.timers.clear();
+            this.changed();
+        }
+    }
+
+    dispose(): void {
+        this.stopTicking();
+        this.onDidChangeTimersEmitter.dispose();
+        this.onDidFinishTimerEmitter.dispose();
+    }
+
+    // --- Internals ---
+
+    protected replace(timer: ActiveTimer): ActiveTimer {
+        this.timers.set(timer.id, timer);
+        this.evictOldest();
+        this.changed();
+        return timer;
+    }
+
+    protected mutate(id: string, transform: (timer: ActiveTimer) => ActiveTimer): void {
+        const timer = this.timers.get(id);
+        if (!timer) {
+            return;
+        }
+        this.timers.set(id, transform(timer));
+        this.changed();
+    }
+
+    protected changed(): void {
+        void this.persist();
+        this.updateTicking();
+        this.onDidChangeTimersEmitter.fire();
+    }
+
+    /**
+     * Drop the least recently touched timers once there are more than
+     * {@link MAX_TIMERS}, matching iOS `cleanupOldTimers`.
+     */
+    protected evictOldest(): void {
+        if (this.timers.size <= CookingTimerService.MAX_TIMERS) {
+            return;
+        }
+        const keep = new Set(
+            this.list()
+                .sort((a, b) => b.updatedAtMs - a.updatedAtMs)
+                .slice(0, CookingTimerService.MAX_TIMERS)
+                .map(timer => timer.id)
+        );
+        for (const timer of this.list()) {
+            if (!keep.has(timer.id)) {
+                this.timers.delete(timer.id);
+            }
+        }
+    }
+
+    protected async persist(): Promise<void> {
+        try {
+            await this.storageService.setData(CookingTimerService.STORAGE_KEY, this.list());
+        } catch (e) {
+            console.warn('Could not persist cooking timers', e);
+        }
+    }
+
+    /**
+     * Reload timers saved by an earlier session. A timer whose fire time has
+     * already passed comes back finished, but no `onDidFinishTimer` is fired:
+     * the alarm belongs to the moment it expired, not to startup.
+     */
+    protected async restore(): Promise<void> {
+        const stored = await this.storageService.getData<ActiveTimer[]>(CookingTimerService.STORAGE_KEY, []);
+        const now = this.now();
+        for (const timer of stored ?? []) {
+            this.timers.set(timer.id, isExpired(timer, now) ? finish(timer, now) : timer);
+        }
+        this.evictOldest();
+        this.updateTicking();
+        this.onDidChangeTimersEmitter.fire();
+    }
+
+    protected hasRunning(): boolean {
+        return this.list().some(timer => timer.state === 'running');
+    }
+
+    protected updateTicking(): void {
+        if (this.hasRunning()) {
+            this.startTicking();
+        } else {
+            this.stopTicking();
+        }
+    }
+
+    protected startTicking(): void {
+        if (this.tickHandle === undefined) {
+            this.tickHandle = setInterval(() => this.tick(), 1000);
+        }
+    }
+
+    protected stopTicking(): void {
+        if (this.tickHandle !== undefined) {
+            clearInterval(this.tickHandle);
+            this.tickHandle = undefined;
+        }
+    }
+
+    protected tick(): void {
+        const now = this.now();
+        const finished: ActiveTimer[] = [];
+        for (const timer of this.list()) {
+            if (isExpired(timer, now)) {
+                const done = finish(timer, now);
+                this.timers.set(done.id, done);
+                finished.push(done);
+            }
+        }
+        if (finished.length > 0) {
+            void this.persist();
+        }
+        this.updateTicking();
+        // Fired every second so countdowns re-render, not only on state change.
+        this.onDidChangeTimersEmitter.fire();
+        for (const timer of finished) {
+            this.onDidFinishTimerEmitter.fire(timer);
+        }
+    }
+
+    /** Running timers first, soonest to fire at the top, then paused, then finished. */
+    static sortForDisplay(timers: ActiveTimer[]): ActiveTimer[] {
+        const rank: Record<string, number> = { running: 0, paused: 1, finished: 2 };
+        return [...timers].sort((a, b) => {
+            const byState = rank[a.state] - rank[b.state];
+            if (byState !== 0) {
+                return byState;
+            }
+            if (a.state === 'running') {
+                return (fireAtMs(a) ?? 0) - (fireAtMs(b) ?? 0);
+            }
+            return b.updatedAtMs - a.updatedAtMs;
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/browser/cooking-timer-service.spec.js"; cd ../..
+```
+
+Expected: all 10 `CookingTimerService` tests PASS.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/browser/cooking-timer-service.ts packages/cooklang/src/browser/cooking-timer-service.spec.ts
+git commit -m "feat(cooklang): add CookingTimerService with persistence"
+```
+
+---
+
+## Task 6: Alarm — preferences, chime and notification
+
+**Files:**
+- Modify: `packages/cooklang/src/common/cooklang-preferences.ts`
+- Create: `packages/cooklang/src/browser/timer-chime.ts`
+- Create: `packages/cooklang/src/browser/timer-alarm-service.ts`
+
+There is no unit test here: the payload is a `Notification` and an `AudioContext`, both of which only exist in the real renderer. This task is verified manually in Task 12.
+
+- [ ] **Step 1: Add the preferences**
+
+In `packages/cooklang/src/common/cooklang-preferences.ts`, add two properties to `cooklangPreferencesSchema.properties`, after `cooklang.nutrition.serviceUrl`:
+
+```ts
+        'cooklang.timers.notifications': {
+            'type': 'boolean',
+            'description': 'Show a system notification when a recipe timer finishes.',
+            'default': true
+        },
+        'cooklang.timers.sound': {
+            'type': 'boolean',
+            'description': 'Play a sound when a recipe timer finishes.',
+            'default': true
+        }
+```
+
+and the matching entries in `CooklangConfiguration`:
+
+```ts
+export interface CooklangConfiguration {
+    'cooklang.openInPreviewMode': boolean;
+    'cooklang.nutrition.serviceUrl': string;
+    'cooklang.timers.notifications': boolean;
+    'cooklang.timers.sound': boolean;
+}
+```
+
+- [ ] **Step 2: Write the chime**
+
+Create `packages/cooklang/src/browser/timer-chime.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { injectable } from '@theia/core/shared/inversify';
+
+/** Frequency in Hz and relative level for each partial of one bell strike. */
+const PARTIALS: ReadonlyArray<readonly [number, number]> = [
+    [880, 1],
+    [1320, 0.4],
+    [1760, 0.2],
+];
+
+const STRIKES = 3;
+const STRIKE_SPACING_SECONDS = 0.45;
+const STRIKE_LENGTH_SECONDS = 0.4;
+
+/**
+ * The sound a finished timer makes. Synthesized rather than shipped as an
+ * audio file: the generated webpack config has no rule for audio assets, so a
+ * `.wav` import would silently fail to bundle.
+ */
+@injectable()
+export class TimerChime {
+
+    protected context: AudioContext | undefined;
+
+    play(): void {
+        try {
+            const context = this.audioContext();
+            // A context created before any user gesture starts suspended.
+            void context.resume();
+            for (let i = 0; i < STRIKES; i++) {
+                this.strike(context, context.currentTime + i * STRIKE_SPACING_SECONDS);
+            }
+        } catch (e) {
+            console.debug('Could not play the timer chime', e);
+        }
+    }
+
+    protected audioContext(): AudioContext {
+        if (!this.context) {
+            this.context = new AudioContext();
+        }
+        return this.context;
+    }
+
+    /** One bell strike: a struck-metal spectrum under an exponential decay. */
+    protected strike(context: AudioContext, at: number): void {
+        const envelope = context.createGain();
+        envelope.gain.setValueAtTime(0.0001, at);
+        envelope.gain.exponentialRampToValueAtTime(0.3, at + 0.01);
+        envelope.gain.exponentialRampToValueAtTime(0.0001, at + STRIKE_LENGTH_SECONDS);
+        envelope.connect(context.destination);
+
+        for (const [frequency, level] of PARTIALS) {
+            const oscillator = context.createOscillator();
+            oscillator.type = 'sine';
+            oscillator.frequency.setValueAtTime(frequency, at);
+
+            const partialGain = context.createGain();
+            partialGain.gain.setValueAtTime(level, at);
+
+            oscillator.connect(partialGain);
+            partialGain.connect(envelope);
+            oscillator.start(at);
+            oscillator.stop(at + STRIKE_SPACING_SECONDS);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Write the alarm service**
+
+Create `packages/cooklang/src/browser/timer-alarm-service.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { CommandRegistry } from '@theia/core/lib/common/command';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application-contribution';
+import { OSNotificationService } from '@theia/ai-core/lib/browser/os-notification-service';
+import { ActiveTimer } from '../common/cooking-timer';
+import { CooklangPreferences } from '../common/cooklang-preferences';
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerChime } from './timer-chime';
+import { TimersCommands } from './timers-view-contribution';
+
+/**
+ * Turns a finished timer into something you notice from the other side of the
+ * kitchen: a system notification (so it lands even when the window is in the
+ * background) and a chime.
+ */
+@injectable()
+export class TimerAlarmService implements FrontendApplicationContribution {
+
+    @inject(CookingTimerService)
+    protected readonly timerService: CookingTimerService;
+
+    @inject(OSNotificationService)
+    protected readonly notificationService: OSNotificationService;
+
+    @inject(TimerChime)
+    protected readonly chime: TimerChime;
+
+    @inject(CooklangPreferences)
+    protected readonly preferences: CooklangPreferences;
+
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
+
+    protected permissionRequested = false;
+
+    onStart(): void {
+        this.timerService.onDidFinishTimer(timer => this.alarm(timer));
+        // Ask for notification permission the first time a timer exists, not at
+        // startup: nobody wants a permission prompt for opening a recipe.
+        this.timerService.onDidChangeTimers(() => this.ensurePermission());
+    }
+
+    protected ensurePermission(): void {
+        if (this.permissionRequested || this.timerService.list().length === 0) {
+            return;
+        }
+        this.permissionRequested = true;
+        void this.notificationService.requestPermission();
+    }
+
+    protected alarm(timer: ActiveTimer): void {
+        if (this.preferences['cooklang.timers.sound']) {
+            this.chime.play();
+        }
+        if (!this.preferences['cooklang.timers.notifications']) {
+            return;
+        }
+        void this.notificationService.showNotification(
+            `${timer.title} — done`,
+            {
+                body: timer.recipeRef?.recipeName,
+                requireInteraction: true,
+                tag: `cooklang-timer-${timer.id}`,
+            },
+            () => {
+                void this.commands.executeCommand(TimersCommands.TOGGLE_VIEW.id);
+            }
+        );
+    }
+}
+```
+
+> `TimersCommands` does not exist yet — it arrives in Task 11. This file will not compile until then, which is expected; it is committed together with the view in Task 11.
+
+- [ ] **Step 4: Commit the preferences and the chime**
+
+The chime compiles on its own; the alarm service does not until Task 11.
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+git add packages/cooklang/src/common/cooklang-preferences.ts \
+        packages/cooklang/src/browser/timer-chime.ts \
+        packages/cooklang/src/browser/timer-alarm-service.ts
+git commit -m "feat(cooklang): add timer alarm preferences, chime and notification service"
+```
+
+---
+
+## Task 7: Timer badge and panel row components
+
+`timer-components.tsx` holds every timer-shaped piece of React: the context that hands the service to the tree, the inline badge, and the panel row. It imports only from `common/`, so it is testable with `renderToStaticMarkup`.
+
+**Files:**
+- Create: `packages/cooklang/src/browser/timer-components.tsx`
+- Test: `packages/cooklang/src/browser/timer-components.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cooklang/src/browser/timer-components.spec.ts`:
+
+```ts
+<LICENSE HEADER>
+
+/* eslint-disable no-null/no-null */
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ActiveTimer, TimerRecipeRef, createAndStart, finish, pause } from '../common/cooking-timer';
+import { Timer } from '../common/recipe-types';
+import { TimerBadge, TimerBinding, TimerBindingProvider, TimerRow } from './timer-components';
+
+const T0 = 1_700_000_000_000;
+
+function ref(): TimerRecipeRef {
+    return {
+        recipePath: 'file:///recipes/Soup.cook',
+        recipeName: 'Soup',
+        globalStepIndex: 2,
+        timerPosition: 0,
+        scale: 1,
+    };
+}
+
+function minuteTimer(minutes: number, name: string | null = null): Timer {
+    return {
+        name,
+        quantity: {
+            value: { type: 'number', value: { type: 'regular', value: minutes } },
+            unit: 'minutes',
+            scalable: true,
+        },
+    };
+}
+
+function binding(active: ActiveTimer | undefined): TimerBinding {
+    return {
+        ref: () => ref(),
+        find: () => active,
+        start: () => undefined,
+        toggle: () => undefined,
+        reset: () => undefined,
+        addTime: () => undefined,
+        nowMs: () => T0,
+    };
+}
+
+function renderBadge(timer: Timer, active: ActiveTimer | undefined): string {
+    return renderToStaticMarkup(
+        React.createElement(
+            TimerBindingProvider,
+            { value: binding(active) },
+            React.createElement(TimerBadge, { timer, globalStepIndex: 2, timerPosition: 0 })
+        )
+    );
+}
+
+describe('TimerBadge', () => {
+
+    it('renders a plain badge with no binding above it', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(TimerBadge, { timer: minuteTimer(10), globalStepIndex: 2, timerPosition: 0 })
+        );
+        expect(markup).to.contain('class="timer-badge"');
+        expect(markup).to.contain('10 minutes');
+    });
+
+    it('renders a startable badge when the timer has a duration', () => {
+        const markup = renderBadge(minuteTimer(10), undefined);
+        expect(markup).to.contain('timer-badge-idle');
+        expect(markup).to.contain('10 minutes');
+    });
+
+    it('shows the name alongside the duration', () => {
+        const markup = renderBadge(minuteTimer(10, 'sauce'), undefined);
+        expect(markup).to.contain('sauce');
+        expect(markup).to.contain('10 minutes');
+    });
+
+    it('stays a plain badge when the timer has no runnable duration', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: { value: { type: 'text', value: 'until golden' }, unit: null, scalable: false },
+        };
+        const markup = renderBadge(timer, undefined);
+        expect(markup).to.equal('<span class="timer-badge">until golden</span>');
+    });
+
+    it('shows a running countdown', () => {
+        const active = createAndStart('t1', 'sauce', 600, T0 - 90_000, ref());
+        const markup = renderBadge(minuteTimer(10, 'sauce'), active);
+        expect(markup).to.contain('timer-badge-running');
+        expect(markup).to.contain('08:30');
+    });
+
+    it('marks a paused timer', () => {
+        const active = pause(createAndStart('t1', 'sauce', 600, T0 - 90_000, ref()), T0);
+        expect(renderBadge(minuteTimer(10, 'sauce'), active)).to.contain('timer-badge-paused');
+    });
+
+    it('marks a finished timer at zero', () => {
+        const active = finish(createAndStart('t1', 'sauce', 600, T0 - 600_000, ref()), T0);
+        const markup = renderBadge(minuteTimer(10, 'sauce'), active);
+        expect(markup).to.contain('timer-badge-finished');
+        expect(markup).to.contain('00:00');
+    });
+});
+
+describe('TimerRow', () => {
+
+    function renderRow(active: ActiveTimer): string {
+        return renderToStaticMarkup(
+            React.createElement(TimerRow, {
+                timer: active,
+                nowMs: T0,
+                onToggle: () => undefined,
+                onReset: () => undefined,
+                onAddTime: () => undefined,
+                onRemove: () => undefined,
+                onOpenRecipe: () => undefined,
+            })
+        );
+    }
+
+    it('shows the countdown, the title and the recipe', () => {
+        const markup = renderRow(createAndStart('t1', 'simmer sauce', 600, T0 - 90_000, ref()));
+        expect(markup).to.contain('08:30');
+        expect(markup).to.contain('simmer sauce');
+        expect(markup).to.contain('Soup');
+    });
+
+    it('carries its state as a class', () => {
+        expect(renderRow(createAndStart('t1', 'a', 600, T0, ref()))).to.contain('timer-row-running');
+        expect(renderRow(finish(createAndStart('t1', 'a', 600, T0 - 600_000, ref()), T0)))
+            .to.contain('timer-row-finished');
+    });
+
+    it('omits the recipe link for a timer with no recipe', () => {
+        const orphan: ActiveTimer = { ...createAndStart('t1', 'a', 600, T0, ref()), recipeRef: undefined };
+        expect(renderRow(orphan)).to.not.contain('timer-row-recipe');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+```
+
+Expected: compile FAILS with `Cannot find module './timer-components'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/cooklang/src/browser/timer-components.tsx`:
+
+```tsx
+<LICENSE HEADER>
+
+/* eslint-disable no-null/no-null */
+
+import * as React from '@theia/core/shared/react';
+import { ActiveTimer, TimerRecipeRef, remainingSeconds } from '../common/cooking-timer';
+import { Timer, formatQuantity } from '../common/recipe-types';
+import { formatClock, formatDuration, timerDurationSeconds } from '../common/timer-duration';
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything a timer badge needs from the outside world. `RecipePreviewWidget`
+ * supplies one; without it the badges render as inert decoration, which is what
+ * keeps this module testable and `recipe-preview-components.tsx` service-free.
+ */
+export interface TimerBinding {
+    /** Build the identity of the timer at this position in the open recipe. */
+    ref(globalStepIndex: number, timerPosition: number): TimerRecipeRef;
+    find(ref: TimerRecipeRef): ActiveTimer | undefined;
+    start(ref: TimerRecipeRef, title: string, durationSeconds: number): void;
+    toggle(id: string): void;
+    reset(id: string): void;
+    addTime(id: string, seconds: number): void;
+    nowMs(): number;
+}
+
+const TimerBindingContext = React.createContext<TimerBinding | undefined>(undefined);
+
+export const TimerBindingProvider = TimerBindingContext.Provider;
+
+// ---------------------------------------------------------------------------
+// TimerBadge
+// ---------------------------------------------------------------------------
+
+/**
+ * The text shown on a badge that has not been started: the name and the
+ * duration together, so `~sauce{10%minutes}` reads `sauce 10 minutes` rather
+ * than hiding the duration behind the name.
+ */
+export function timerBadgeLabel(timer: Timer): string {
+    const quantity = timer.quantity ? formatQuantity(timer.quantity) : '';
+    if (timer.name && quantity) {
+        return `${timer.name} ${quantity}`;
+    }
+    return timer.name ?? quantity;
+}
+
+export interface TimerBadgeProps {
+    timer: Timer;
+    globalStepIndex: number;
+    timerPosition: number;
+}
+
+export const TimerBadge = ({ timer, globalStepIndex, timerPosition }: TimerBadgeProps): React.ReactElement => {
+    const binding = React.useContext(TimerBindingContext);
+    const label = timerBadgeLabel(timer);
+    const duration = timerDurationSeconds(timer);
+
+    if (!binding || duration === undefined) {
+        // `~{until golden}` and bare named timers have nothing to count down.
+        return <span className='timer-badge'>{label}</span>;
+    }
+
+    const ref = binding.ref(globalStepIndex, timerPosition);
+    const active = binding.find(ref);
+
+    if (!active) {
+        return (
+            <span className='timer-badge timer-badge-idle' role='button' tabIndex={0}
+                title={`Start a ${formatDuration(duration)} timer`}
+                onClick={() => binding.start(ref, timer.name ?? label, duration)}>
+                <span className='codicon codicon-watch timer-badge-icon'></span>
+                {label}
+            </span>
+        );
+    }
+
+    const titles: Record<string, string> = {
+        running: 'Pause timer',
+        paused: 'Resume timer',
+        finished: 'Restart timer',
+    };
+
+    return (
+        <span className={`timer-badge timer-badge-${active.state}`} role='button' tabIndex={0}
+            title={titles[active.state]}
+            onClick={() => binding.toggle(active.id)}>
+            <span className='codicon codicon-watch timer-badge-icon'></span>
+            <span className='timer-badge-clock'>{formatClock(remainingSeconds(active, binding.nowMs()))}</span>
+        </span>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// TimerRow  (one entry in the Timers panel)
+// ---------------------------------------------------------------------------
+
+export interface TimerRowProps {
+    timer: ActiveTimer;
+    nowMs: number;
+    onToggle: (id: string) => void;
+    onReset: (id: string) => void;
+    onAddTime: (id: string, seconds: number) => void;
+    onRemove: (id: string) => void;
+    onOpenRecipe?: (ref: TimerRecipeRef) => void;
+}
+
+export const TimerRow = ({
+    timer,
+    nowMs,
+    onToggle,
+    onReset,
+    onAddTime,
+    onRemove,
+    onOpenRecipe,
+}: TimerRowProps): React.ReactElement => {
+    const remaining = remainingSeconds(timer, nowMs);
+    const elapsedFraction = timer.durationSeconds > 0
+        ? Math.min(1, Math.max(0, 1 - remaining / timer.durationSeconds))
+        : 0;
+    const toggleIcon = timer.state === 'running' ? 'codicon-debug-pause' : 'codicon-play';
+    const toggleTitle = timer.state === 'running'
+        ? 'Pause'
+        : timer.state === 'paused' ? 'Resume' : 'Restart';
+
+    return (
+        <div className={`timer-row timer-row-${timer.state}`}>
+            <div className='timer-row-main'>
+                <div className='timer-row-clock'>{formatClock(remaining)}</div>
+                <div className='timer-row-title'>{timer.title}</div>
+                {timer.recipeRef && onOpenRecipe && (
+                    <a className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
+                        onClick={() => onOpenRecipe(timer.recipeRef!)}>
+                        <span className='codicon codicon-go-to-file'></span>
+                        {timer.recipeRef.recipeName}
+                        {timer.recipeRef.scale !== 1 && (
+                            <span className='timer-row-scale'>×{timer.recipeRef.scale}</span>
+                        )}
+                    </a>
+                )}
+            </div>
+            <div className='timer-row-progress'>
+                <div className='timer-row-progress-fill' style={{ width: `${elapsedFraction * 100}%` }}></div>
+            </div>
+            <div className='timer-row-actions'>
+                <button className='timer-row-action' title='Add one minute'
+                    onClick={() => onAddTime(timer.id, 60)}>+1 min</button>
+                <button className='timer-row-action' title={toggleTitle} onClick={() => onToggle(timer.id)}>
+                    <span className={`codicon ${toggleIcon}`}></span>
+                </button>
+                <button className='timer-row-action' title='Reset' onClick={() => onReset(timer.id)}>
+                    <span className='codicon codicon-debug-restart'></span>
+                </button>
+                <button className='timer-row-action' title='Delete' onClick={() => onRemove(timer.id)}>
+                    <span className='codicon codicon-trash'></span>
+                </button>
+            </div>
+        </div>
+    );
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/browser/timer-components.spec.js"; cd ../..
+```
+
+Expected: all `TimerBadge` and `TimerRow` tests PASS.
+
+> The `timer-alarm-service.ts` file from Task 6 still fails to compile until Task 11. If `lerna run compile` fails only on `Cannot find module './timers-view-contribution'`, that is expected — the spec above still runs because mocha loads the compiled files that did emit. If TypeScript refuses to emit at all, temporarily comment out the `TimersCommands` import and its use in `timer-alarm-service.ts`, and restore them in Task 11.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/browser/timer-components.tsx packages/cooklang/src/browser/timer-components.spec.ts
+git commit -m "feat(cooklang): add timer badge and panel row components"
+```
+
+---
+
+## Task 8: Inline timers in the preview
+
+Thread the step and timer position down to `StepItemView`, swap the static timer span for `TimerBadge`, and lift `scale` out of `RecipeView` so the widget owns it.
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/recipe-preview-components.tsx`
+- Modify: `packages/cooklang/src/browser/style/recipe-preview.css`
+- Test: `packages/cooklang/src/browser/recipe-preview-components.spec.ts` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/cooklang/src/browser/recipe-preview-components.spec.ts`:
+
+```ts
+describe('InstructionsPanel timer positions', () => {
+
+    it('numbers timers within their step and steps across sections', () => {
+        const sections: Section[] = [
+            {
+                name: null,
+                content: [
+                    {
+                        type: 'step',
+                        value: {
+                            number: 1,
+                            items: [
+                                { type: 'timer', index: 0 },
+                                { type: 'text', value: ' then ' },
+                                { type: 'timer', index: 1 },
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                name: null,
+                content: [
+                    { type: 'step', value: { number: 1, items: [{ type: 'timer', index: 2 }] } },
+                ],
+            },
+        ];
+        const seen: Array<[number, number]> = [];
+        const markup = renderToStaticMarkup(
+            React.createElement(
+                TimerBindingProvider,
+                {
+                    value: {
+                        ref: (globalStepIndex: number, timerPosition: number) => {
+                            seen.push([globalStepIndex, timerPosition]);
+                            return {
+                                recipePath: 'file:///a.cook',
+                                recipeName: 'a',
+                                globalStepIndex,
+                                timerPosition,
+                                scale: 1,
+                            };
+                        },
+                        find: () => undefined,
+                        start: () => undefined,
+                        toggle: () => undefined,
+                        reset: () => undefined,
+                        addTime: () => undefined,
+                        nowMs: () => 0,
+                    },
+                },
+                React.createElement(InstructionsPanel, {
+                    sections,
+                    ingredients: [],
+                    cookware: [],
+                    timers: [
+                        { name: null, quantity: { value: { type: 'number', value: { type: 'regular', value: 5 } }, unit: 'minutes', scalable: true } },
+                        { name: null, quantity: { value: { type: 'number', value: { type: 'regular', value: 6 } }, unit: 'minutes', scalable: true } },
+                        { name: null, quantity: { value: { type: 'number', value: { type: 'regular', value: 7 } }, unit: 'minutes', scalable: true } },
+                    ],
+                    inlineQuantities: [],
+                    images: { steps: {} },
+                })
+            )
+        );
+        expect(seen).to.deep.equal([[0, 0], [0, 1], [1, 0]]);
+        expect(markup).to.contain('5 minutes');
+        expect(markup).to.contain('7 minutes');
+    });
+});
+```
+
+Add one import to the top of that spec file — everything else it needs (`expect`, `React`, `renderToStaticMarkup`, `Section`, `InstructionsPanel`) is already imported there:
+
+```ts
+import { TimerBindingProvider } from './timer-components';
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/browser/recipe-preview-components.spec.js"; cd ../..
+```
+
+Expected: FAIL — `seen` is empty, because `StepItemView` still renders a static span.
+
+- [ ] **Step 3: Thread the positions and render the badge**
+
+In `packages/cooklang/src/browser/recipe-preview-components.tsx`:
+
+Add the import:
+
+```tsx
+import { TimerBadge } from './timer-components';
+```
+
+Delete the now-unused `formatTimer` helper (its job moved to `timerBadgeLabel` in `timer-components.tsx`) and the `Timer` entry stays in the type imports because the props still carry timers.
+
+Give `StepItemViewProps` the two new fields and use them:
+
+```tsx
+interface StepItemViewProps {
+    item: StepItem;
+    ingredients: Ingredient[];
+    cookware: Cookware[];
+    timers: Timer[];
+    inlineQuantities: InlineQuantity[];
+    globalStepIndex: number;
+    /** Index of this item among the timer items of its step. */
+    timerPosition: number;
+}
+
+const StepItemView = ({
+    item,
+    ingredients,
+    cookware,
+    timers,
+    inlineQuantities,
+    globalStepIndex,
+    timerPosition,
+}: StepItemViewProps): React.ReactElement => {
+```
+
+and replace the timer case:
+
+```tsx
+        case 'timer': {
+            const timer = timers[item.index];
+            if (!timer) {
+                return <span className='timer-badge'>{`timer[${item.index}]`}</span>;
+            }
+            return (
+                <TimerBadge timer={timer} globalStepIndex={globalStepIndex} timerPosition={timerPosition} />
+            );
+        }
+```
+
+In `SectionContentView`, accept `globalStepIndex` and count the timers as it maps:
+
+```tsx
+interface SectionContentViewProps {
+    content: SectionContent;
+    ingredients: Ingredient[];
+    cookware: Cookware[];
+    timers: Timer[];
+    inlineQuantities: InlineQuantity[];
+    imageSrc?: string;
+    globalStepIndex: number;
+}
+```
+
+and inside its step branch replace the `items.map(...)` call with:
+
+```tsx
+                {(() => {
+                    let timerPosition = 0;
+                    return items.map((item, idx) => {
+                        const position = item.type === 'timer' ? timerPosition++ : 0;
+                        return (
+                            <StepItemView
+                                key={idx}
+                                item={item}
+                                ingredients={ingredients}
+                                cookware={cookware}
+                                timers={timers}
+                                inlineQuantities={inlineQuantities}
+                                globalStepIndex={globalStepIndex}
+                                timerPosition={position}
+                            />
+                        );
+                    });
+                })()}
+```
+
+In `InstructionsPanel`, capture the step's global index before it is incremented and pass it down:
+
+```tsx
+                        {section.content.map((content, cIdx) => {
+                            let imageSrc: string | undefined;
+                            const stepIndex = globalStepIndex;
+                            if (content.type === 'step') {
+                                if (images) {
+                                    imageSrc = lookupStepImage(images, sIdx, stepInSection, globalStepIndex);
+                                }
+                                stepInSection++;
+                                globalStepIndex++;
+                            }
+                            return (
+                                <SectionContentView
+                                    key={cIdx}
+                                    content={content}
+                                    ingredients={ingredients}
+                                    cookware={cookware}
+                                    timers={timers}
+                                    inlineQuantities={inlineQuantities}
+                                    imageSrc={imageSrc}
+                                    globalStepIndex={stepIndex}
+                                />
+                            );
+                        })}
+```
+
+- [ ] **Step 4: Make `scale` a controlled prop**
+
+Still in `recipe-preview-components.tsx`, change `RecipeViewProps` and the top of `RecipeView`:
+
+```tsx
+export interface RecipeViewProps {
+    recipe: Recipe;
+    fileName: string;
+    images?: ResolvedRecipeImages;
+    scale: number;
+    onScaleChange: (scale: number) => void;
+    onShowSource?: () => void;
+    onAddToShoppingList?: (scale: number) => void;
+    onNavigateToRecipe?: (referencePath: string) => void;
+}
+
+export const RecipeView = ({
+    recipe,
+    fileName,
+    images,
+    scale,
+    onScaleChange,
+    onShowSource,
+    onAddToShoppingList,
+    onNavigateToRecipe,
+}: RecipeViewProps): React.ReactElement => {
+    const meta = recipe.metadata.map;
+```
+
+(delete the `const [scale, setScale] = React.useState(1);` line) and change the input's handler:
+
+```tsx
+                            onChange={e => {
+                                const val = parseFloat(e.target.value);
+                                if (Number.isFinite(val) && val > 0) {
+                                    onScaleChange(val);
+                                }
+                            }}
+```
+
+- [ ] **Step 5: Style the badge states**
+
+Replace the `.theia-recipe-preview .timer-badge` rule in `packages/cooklang/src/browser/style/recipe-preview.css` with:
+
+```css
+.theia-recipe-preview .timer-badge {
+    display: inline;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: var(--theia-textCodeBlock-background, rgba(128, 128, 128, 0.15));
+    border: 1px solid var(--theia-panel-border);
+    font-weight: 700;
+    font-size: 0.92em;
+    white-space: nowrap;
+}
+
+.theia-recipe-preview .timer-badge-icon {
+    margin-right: 3px;
+    font-size: 0.9em;
+    vertical-align: baseline;
+}
+
+.theia-recipe-preview .timer-badge-clock {
+    font-family: var(--theia-editor-font-family, monospace);
+}
+
+.theia-recipe-preview .timer-badge-idle,
+.theia-recipe-preview .timer-badge-running,
+.theia-recipe-preview .timer-badge-paused,
+.theia-recipe-preview .timer-badge-finished {
+    cursor: pointer;
+}
+
+.theia-recipe-preview .timer-badge-idle:hover {
+    border-color: var(--theia-focusBorder);
+}
+
+.theia-recipe-preview .timer-badge-running {
+    background: var(--theia-editorInfo-foreground);
+    border-color: var(--theia-editorInfo-foreground);
+    color: var(--theia-editor-background);
+}
+
+.theia-recipe-preview .timer-badge-paused {
+    opacity: 0.7;
+    border-style: dashed;
+}
+
+.theia-recipe-preview .timer-badge-finished {
+    background: var(--theia-editorWarning-foreground);
+    border-color: var(--theia-editorWarning-foreground);
+    color: var(--theia-editor-background);
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/browser/recipe-preview-components.spec.js"; cd ../..
+```
+
+Expected: the new `InstructionsPanel timer positions` test PASSES **and** the original `InstructionsPanel step image indices` tests still PASS.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/browser/recipe-preview-components.tsx \
+        packages/cooklang/src/browser/recipe-preview-components.spec.ts \
+        packages/cooklang/src/browser/style/recipe-preview.css
+git commit -m "feat(cooklang): render runnable timer badges in recipe steps"
+```
+
+---
+
+## Task 9: Widget supplies the timer binding and owns the scale
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/recipe-preview-widget.tsx`
+
+No new spec: this file imports `MonacoWorkspace`, so a spec for it would break the mocha harness (see `feedback_spec_monaco_css_harness`). Its logic is thin glue over already-tested pieces.
+
+- [ ] **Step 1: Add the imports and injections**
+
+In `packages/cooklang/src/browser/recipe-preview-widget.tsx` add:
+
+```tsx
+import { TimerRecipeRef } from '../common/cooking-timer';
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerBinding, TimerBindingProvider } from './timer-components';
+```
+
+and next to the other `@inject` fields:
+
+```tsx
+    @inject(CookingTimerService)
+    protected readonly timerService: CookingTimerService;
+```
+
+- [ ] **Step 2: Own the scale and expose a setter**
+
+Add the field next to `protected recipe`:
+
+```tsx
+    protected scale = 1;
+```
+
+and these members next to `handleShowSource`:
+
+```tsx
+    /**
+     * Set the displayed scale from outside the React tree — used when opening a
+     * recipe from a timer that was started at a different scale.
+     */
+    setScale(scale: number): void {
+        if (Number.isFinite(scale) && scale > 0 && scale !== this.scale) {
+            this.scale = scale;
+            this.update();
+        }
+    }
+
+    protected handleScaleChange = (scale: number): void => {
+        this.scale = scale;
+        this.update();
+    };
+```
+
+- [ ] **Step 3: Build the timer binding**
+
+Add next to the other handlers:
+
+```tsx
+    /** The recipe's display name, used to label timers in the Timers panel. */
+    protected recipeName(): string {
+        const name = this.recipe?.metadata.map['name'];
+        if (name !== undefined && name !== '') {
+            return String(name);
+        }
+        return (this.uri?.path.base ?? '').replace(/\.cook$/i, '');
+    }
+
+    protected readonly timerBinding: TimerBinding = {
+        ref: (globalStepIndex: number, timerPosition: number): TimerRecipeRef => ({
+            recipePath: this.uri?.toString() ?? '',
+            recipeName: this.recipeName(),
+            globalStepIndex,
+            timerPosition,
+            scale: this.scale,
+        }),
+        find: ref => this.timerService.find(ref),
+        start: (ref, title, durationSeconds) => this.timerService.start(ref, title, durationSeconds),
+        toggle: id => this.timerService.toggle(id),
+        reset: id => this.timerService.reset(id),
+        addTime: (id, seconds) => this.timerService.addTime(id, seconds),
+        nowMs: () => this.timerService.nowMs(),
+    };
+```
+
+- [ ] **Step 4: Re-render on every tick**
+
+In `init()`, after `this.listenToDocumentChanges();`, add:
+
+```tsx
+        this.toDispose.push(this.timerService.onDidChangeTimers(() => this.update()));
+```
+
+- [ ] **Step 5: Wrap the view**
+
+Replace the `this.recipe` branch of `render()`:
+
+```tsx
+        if (this.recipe) {
+            return (
+                <TimerBindingProvider value={this.timerBinding}>
+                    <LinkOpenerProvider value={this.handleOpenLink}>
+                        <RecipeView
+                            recipe={this.recipe}
+                            fileName={this.uri?.path.base ?? ''}
+                            images={this.images}
+                            scale={this.scale}
+                            onScaleChange={this.handleScaleChange}
+                            onShowSource={this.handleShowSource}
+                            onAddToShoppingList={this.handleAddToShoppingList}
+                            onNavigateToRecipe={this.handleNavigateToRecipe}
+                        />
+                    </LinkOpenerProvider>
+                </TimerBindingProvider>
+            );
+        }
+```
+
+- [ ] **Step 6: Compile, lint and commit**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/browser/recipe-preview-widget.tsx
+git commit -m "feat(cooklang): connect the recipe preview to the timer service"
+```
+
+> Compile still fails on `timer-alarm-service.ts` until Task 11. Keep that import commented out if you did so in Task 7.
+
+---
+
+## Task 10: Open a recipe at a recorded scale
+
+**Files:**
+- Modify: `packages/cooklang/src/browser/recipe-preview-contribution.ts`
+
+- [ ] **Step 1: Add the command**
+
+In `packages/cooklang/src/browser/recipe-preview-contribution.ts`, add to the `CooklangPreviewCommands` namespace:
+
+```ts
+    export const OPEN_PREVIEW_AT_SCALE: Command = {
+        id: 'cooklang.openPreviewAtScale',
+        label: 'Cooklang: Open Preview at Scale',
+    };
+```
+
+- [ ] **Step 2: Register it**
+
+In `registerCommands`, after the existing `OPEN_SOURCE` registration:
+
+```ts
+        commands.registerCommand(CooklangPreviewCommands.OPEN_PREVIEW_AT_SCALE, {
+            execute: (uri: URI | string, scale: number) => this.openPreviewAtScale(uri, scale),
+            // Invoked from the Timers panel, never from the command palette.
+            isVisible: () => false,
+        });
+```
+
+- [ ] **Step 3: Implement it**
+
+Add next to `togglePreview`:
+
+```ts
+    /**
+     * Open (or reveal) the preview for `uri` and set its scale — the way back
+     * from a timer in the Timers panel to the recipe it came from.
+     */
+    protected async openPreviewAtScale(uri: URI | string, scale: number): Promise<void> {
+        const target = typeof uri === 'string' ? new URI(uri) : uri;
+        if (!CooklangUri.isRecipe(target)) {
+            return;
+        }
+        const preview = await this.getOrCreatePreview(target);
+        preview.setScale(scale);
+        await this.shell.addWidget(preview, { area: 'main' });
+        this.shell.activateWidget(preview.id);
+    }
+```
+
+- [ ] **Step 4: Compile, lint and commit**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+git add packages/cooklang/src/browser/recipe-preview-contribution.ts
+git commit -m "feat(cooklang): add openPreviewAtScale command"
+```
+
+---
+
+## Task 11: Timers panel, view contribution and bindings
+
+**Files:**
+- Create: `packages/cooklang/src/browser/timers-widget.tsx`
+- Create: `packages/cooklang/src/browser/timers-view-contribution.ts`
+- Create: `packages/cooklang/src/browser/style/timers.css`
+- Modify: `packages/cooklang/src/browser/cooklang-frontend-module.ts`
+
+- [ ] **Step 1: Write the widget**
+
+Create `packages/cooklang/src/browser/timers-widget.tsx`:
+
+```tsx
+<LICENSE HEADER>
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { CommandRegistry } from '@theia/core/lib/common/command';
+import * as React from '@theia/core/shared/react';
+import { TimerRecipeRef } from '../common/cooking-timer';
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerRow } from './timer-components';
+
+import '../../src/browser/style/timers.css';
+
+export const TIMERS_WIDGET_ID = 'cooklang-timers';
+
+/**
+ * Lists every started timer across every recipe, so a timer stays visible after
+ * you scroll past its step or close its preview. A port of the iOS app's
+ * `TimersView`.
+ */
+@injectable()
+export class TimersWidget extends ReactWidget {
+
+    static readonly ID = TIMERS_WIDGET_ID;
+    static readonly LABEL = 'Timers';
+
+    @inject(CookingTimerService)
+    protected readonly timerService: CookingTimerService;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = TIMERS_WIDGET_ID;
+        this.title.label = TimersWidget.LABEL;
+        this.title.caption = TimersWidget.LABEL;
+        this.title.iconClass = 'codicon codicon-watch';
+        this.title.closable = true;
+        this.addClass('theia-cooklang-timers');
+        this.scrollOptions = {
+            suppressScrollX: true,
+            minScrollbarLength: 35,
+        };
+        this.toDispose.push(this.timerService.onDidChangeTimers(() => this.update()));
+        this.update();
+    }
+
+    protected handleToggle = (id: string): void => this.timerService.toggle(id);
+    protected handleReset = (id: string): void => this.timerService.reset(id);
+    protected handleAddTime = (id: string, seconds: number): void => this.timerService.addTime(id, seconds);
+    protected handleRemove = (id: string): void => this.timerService.remove(id);
+    protected handleRemoveFinished = (): void => this.timerService.removeFinished();
+    protected handleRemoveAll = (): void => this.timerService.removeAll();
+
+    protected handleOpenRecipe = (ref: TimerRecipeRef): void => {
+        this.commandRegistry.executeCommand('cooklang.openPreviewAtScale', ref.recipePath, ref.scale);
+    };
+
+    protected render(): React.ReactNode {
+        const timers = CookingTimerService.sortForDisplay(this.timerService.list());
+        if (timers.length === 0) {
+            return (
+                <div className='timers-empty'>
+                    No timers yet. Click a time in a recipe step to start one.
+                </div>
+            );
+        }
+        const hasFinished = timers.some(timer => timer.state === 'finished');
+        const nowMs = this.timerService.nowMs();
+        return (
+            <div className='timers-body'>
+                <div className='timers-header'>
+                    {hasFinished && (
+                        <button className='timers-header-action' onClick={this.handleRemoveFinished}>
+                            Clear finished
+                        </button>
+                    )}
+                    <button className='timers-header-action' onClick={this.handleRemoveAll}>
+                        Clear all
+                    </button>
+                </div>
+                {timers.map(timer => (
+                    <TimerRow
+                        key={timer.id}
+                        timer={timer}
+                        nowMs={nowMs}
+                        onToggle={this.handleToggle}
+                        onReset={this.handleReset}
+                        onAddTime={this.handleAddTime}
+                        onRemove={this.handleRemove}
+                        onOpenRecipe={this.handleOpenRecipe}
+                    />
+                ))}
+            </div>
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Write the view contribution**
+
+Create `packages/cooklang/src/browser/timers-view-contribution.ts`:
+
+```ts
+<LICENSE HEADER>
+
+import { injectable } from '@theia/core/shared/inversify';
+import { Command } from '@theia/core/lib/common/command';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { TimersWidget, TIMERS_WIDGET_ID } from './timers-widget';
+
+export namespace TimersCommands {
+    export const TOGGLE_VIEW: Command = {
+        id: 'cooklang.toggleTimers',
+        label: 'Cooklang: Toggle Timers',
+    };
+}
+
+@injectable()
+export class TimersViewContribution extends AbstractViewContribution<TimersWidget> {
+
+    constructor() {
+        super({
+            widgetId: TIMERS_WIDGET_ID,
+            widgetName: TimersWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'right',
+            },
+            toggleCommandId: TimersCommands.TOGGLE_VIEW.id,
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Write the stylesheet**
+
+Create `packages/cooklang/src/browser/style/timers.css`:
+
+```css
+.theia-cooklang-timers {
+    padding: 8px;
+    color: var(--theia-foreground);
+    font-size: var(--theia-ui-font-size1);
+}
+
+.theia-cooklang-timers .timers-empty {
+    padding: 16px 8px;
+    color: var(--theia-descriptionForeground);
+    line-height: 1.5;
+}
+
+.theia-cooklang-timers .timers-header {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.theia-cooklang-timers .timers-header-action {
+    background: none;
+    border: none;
+    color: var(--theia-textLink-foreground);
+    cursor: pointer;
+    padding: 2px 4px;
+}
+
+.theia-cooklang-timers .timer-row {
+    border: 1px solid var(--theia-panel-border);
+    border-radius: 4px;
+    padding: 8px;
+    margin-bottom: 8px;
+}
+
+.theia-cooklang-timers .timer-row-finished {
+    border-color: var(--theia-editorWarning-foreground);
+}
+
+.theia-cooklang-timers .timer-row-paused {
+    opacity: 0.75;
+}
+
+.theia-cooklang-timers .timer-row-clock {
+    font-family: var(--theia-editor-font-family, monospace);
+    font-size: 1.8em;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.theia-cooklang-timers .timer-row-title {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.theia-cooklang-timers .timer-row-recipe {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--theia-textLink-foreground);
+    cursor: pointer;
+    font-size: 0.92em;
+}
+
+.theia-cooklang-timers .timer-row-recipe:hover {
+    text-decoration: underline;
+}
+
+.theia-cooklang-timers .timer-row-scale {
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-cooklang-timers .timer-row-progress {
+    height: 3px;
+    background: var(--theia-panel-border);
+    border-radius: 2px;
+    margin: 8px 0;
+    overflow: hidden;
+}
+
+.theia-cooklang-timers .timer-row-progress-fill {
+    height: 100%;
+    background: var(--theia-progressBar-background);
+}
+
+.theia-cooklang-timers .timer-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.theia-cooklang-timers .timer-row-action {
+    background: none;
+    border: 1px solid var(--theia-panel-border);
+    border-radius: 3px;
+    color: var(--theia-foreground);
+    cursor: pointer;
+    padding: 2px 6px;
+}
+
+.theia-cooklang-timers .timer-row-action:hover {
+    border-color: var(--theia-focusBorder);
+}
+```
+
+- [ ] **Step 4: Restore the alarm service import**
+
+If you commented out the `TimersCommands` import in `timer-alarm-service.ts` during Task 7, restore it now:
+
+```ts
+import { TimersCommands } from './timers-view-contribution';
+```
+
+- [ ] **Step 5: Bind everything**
+
+In `packages/cooklang/src/browser/cooklang-frontend-module.ts`, add the imports:
+
+```ts
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerChime } from './timer-chime';
+import { TimerAlarmService } from './timer-alarm-service';
+import { TimersWidget, TIMERS_WIDGET_ID } from './timers-widget';
+import { TimersViewContribution } from './timers-view-contribution';
+```
+
+and add this block next to the shopping-list bindings:
+
+```ts
+    // --- Timers ---
+    bind(CookingTimerService).toSelf().inSingletonScope();
+    bind(TimerChime).toSelf().inSingletonScope();
+    bind(TimerAlarmService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(TimerAlarmService);
+
+    bind(TimersWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: TIMERS_WIDGET_ID,
+        createWidget: () => ctx.container.get<TimersWidget>(TimersWidget),
+    })).inSingletonScope();
+
+    bindViewContribution(bind, TimersViewContribution);
+```
+
+- [ ] **Step 6: Compile, lint and run the whole suite**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+npx lerna run test --scope @theia/cooklang
+```
+
+Expected: compile succeeds with no errors, lint is clean, every spec in `@theia/cooklang` passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cooklang/src/browser/timers-widget.tsx \
+        packages/cooklang/src/browser/timers-view-contribution.ts \
+        packages/cooklang/src/browser/style/timers.css \
+        packages/cooklang/src/browser/timer-alarm-service.ts \
+        packages/cooklang/src/browser/cooklang-frontend-module.ts
+git commit -m "feat(cooklang): add the Timers panel"
+```
+
+---
+
+## Task 12: Verify in the real app
+
+- [ ] **Step 1: Build and launch**
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+cd app && npm run bundle && cd ..
+npm run start:electron
+```
+
+- [ ] **Step 2: Write a test recipe**
+
+Create a `.cook` file in the open workspace. Use YAML frontmatter — the `>>` metadata syntax is deprecated and must not be used.
+
+```
+---
+title: Timer Check
+source: https://cooklang.org/docs/spec/
+author: chef@cook.md
+---
+
+Boil the @water{1%l} for ~{10%seconds} then rest ~dough{15%seconds}.
+
+Bake for ~{50-60%minutes} and reduce ~{until thick}.
+
+> Notes at https://cook.md/help/ios/using-the-app are worth reading.
+```
+
+- [ ] **Step 3: Walk the checklist**
+
+- [ ] The `source` URL and the `author` email in the metadata pills are links; clicking one opens the system browser, not a tab inside the editor.
+- [ ] The URL in the note block is a link.
+- [ ] `~{10%seconds}` and `~dough{15%seconds}` render as clickable badges; `~{until thick}` renders as plain, unclickable text.
+- [ ] `~{50-60%minutes}` shows the range as written and starts a 50-minute timer.
+- [ ] Clicking a badge starts it; the badge counts down; clicking again pauses; clicking again resumes.
+- [ ] The Timers view (right side bar, `codicon-watch`) lists the running timers with recipe name, `+1 min`, play/pause, reset and delete.
+- [ ] Set Scale to 2, start a timer, then click that timer's recipe link in the panel — the preview opens with Scale showing 2.
+- [ ] Let a 10-second timer finish with the editor window **in the background**: an OS notification appears and the chime plays.
+- [ ] Reload the window (`Ctrl/Cmd+R`) mid-countdown: the timer is still there with the right remaining time.
+- [ ] Quit and relaunch with a timer whose duration has passed in the meantime: it comes back finished, with no notification replayed.
+- [ ] Turn off `cooklang.timers.sound` in Preferences: a finishing timer notifies silently.
+
+- [ ] **Step 4: Commit any fixes and open the PR**
+
+```bash
+git add -A
+git commit -m "fix(cooklang): address manual verification findings"
+git push -u origin feature/preview-timers-and-links
+gh pr create --fill --base main
+```
+
+The PR body should close the issue: add `Closes #95`.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -3373,6 +3373,8 @@ Bake for ~{50-60%minutes} and reduce ~{until thick}.
 - [ ] The Timers view (right side bar, `codicon-watch`) lists the running timers with recipe name, `+1 min`, play/pause, reset and delete.
 - [ ] Set Scale to 2, start a timer, then click that timer's recipe link in the panel — the preview opens with Scale showing 2.
 - [ ] Let a 10-second timer finish with the editor window **in the background**: an OS notification appears and the chime plays.
+- [ ] The chime specifically: start a timer and let it finish **without clicking anything else in the window first**, with the window backgrounded. A renderer `AudioContext` starts suspended until a user gesture, and the whole promise of this feature is that it fires while you are not interacting with the app. Electron defaults `autoplayPolicy` to `no-user-gesture-required`, so this should work — but that is reasoning, not evidence, and this is the check that turns it into evidence. If it is silent, the fix is `webPreferences.autoplayPolicy`, not the chime code.
+- [ ] Two timers finishing within a second of each other: both notifications appear, and the chime does not distort.
 - [ ] Reload the window (`Ctrl/Cmd+R`) mid-countdown: the timer is still there with the right remaining time.
 - [ ] Quit and relaunch with a timer whose duration has passed in the meantime: it comes back finished, with no notification replayed.
 - [ ] Turn off `cooklang.timers.sound` in Preferences: a finishing timer notifies silently.

--- a/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
+++ b/docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md
@@ -2041,7 +2041,7 @@ import { ActiveTimer } from '../common/cooking-timer';
 import { CooklangPreferences } from '../common/cooklang-preferences';
 import { CookingTimerService } from './cooking-timer-service';
 import { TimerChime } from './timer-chime';
-import { TimersCommands } from './timers-view-contribution';
+import { TimersCommands } from './timers-commands';
 
 /**
  * Turns a finished timer into something you notice from the other side of the
@@ -2105,15 +2105,40 @@ export class TimerAlarmService implements FrontendApplicationContribution {
 }
 ```
 
-> `TimersCommands` does not exist yet — it arrives in Task 11. This file will not compile until then, which is expected; it is committed together with the view in Task 11.
+- [ ] **Step 3b: Create the commands module**
 
-- [ ] **Step 4: Commit the preferences and the chime**
+`TimersCommands` lives in its own file so the alarm service compiles now
+rather than waiting for the view in Task 11. Create
+`packages/cooklang/src/browser/timers-commands.ts`:
 
-The chime compiles on its own; the alarm service does not until Task 11.
+```ts
+<LICENSE HEADER>
+
+import { Command } from '@theia/core/lib/common/command';
+
+export namespace TimersCommands {
+    export const TOGGLE_VIEW: Command = {
+        id: 'cooklang.toggleTimers',
+        label: 'Cooklang: Toggle Timers',
+    };
+}
+```
+
+- [ ] **Step 4: Compile, lint and commit**
+
+Everything in this task compiles on its own — there is nothing left pending on
+a later task.
+
+```bash
+export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
+npx lerna run compile --scope @theia/cooklang
+npx lerna run lint --scope @theia/cooklang
+```
 
 ```bash
 export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
 git add packages/cooklang/src/common/cooklang-preferences.ts \
+        packages/cooklang/src/browser/timers-commands.ts \
         packages/cooklang/src/browser/timer-chime.ts \
         packages/cooklang/src/browser/timer-alarm-service.ts
 git commit -m "feat(cooklang): add timer alarm preferences, chime and notification service"
@@ -2466,7 +2491,8 @@ cd packages/cooklang && npx mocha --config ../../configs/mocharc.yml "./lib/brow
 
 Expected: all `TimerBadge` and `TimerRow` tests PASS.
 
-> The `timer-alarm-service.ts` file from Task 6 still fails to compile until Task 11. If `lerna run compile` fails only on `Cannot find module './timers-view-contribution'`, that is expected — the spec above still runs because mocha loads the compiled files that did emit. If TypeScript refuses to emit at all, temporarily comment out the `TimersCommands` import and its use in `timer-alarm-service.ts`, and restore them in Task 11.
+> Everything from Task 6 compiles already, so a compile failure here is a real
+> failure — do not work around it.
 
 - [ ] **Step 5: Lint and commit**
 
@@ -2939,7 +2965,8 @@ git add packages/cooklang/src/browser/recipe-preview-widget.tsx
 git commit -m "feat(cooklang): connect the recipe preview to the timer service"
 ```
 
-> Compile still fails on `timer-alarm-service.ts` until Task 11. Keep that import commented out if you did so in Task 7.
+> The package compiles cleanly at this point. A compile failure here is a real
+> failure — do not work around it.
 
 ---
 
@@ -3124,16 +3151,9 @@ Create `packages/cooklang/src/browser/timers-view-contribution.ts`:
 <LICENSE HEADER>
 
 import { injectable } from '@theia/core/shared/inversify';
-import { Command } from '@theia/core/lib/common/command';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { TimersWidget, TIMERS_WIDGET_ID } from './timers-widget';
-
-export namespace TimersCommands {
-    export const TOGGLE_VIEW: Command = {
-        id: 'cooklang.toggleTimers',
-        label: 'Cooklang: Toggle Timers',
-    };
-}
+import { TimersCommands } from './timers-commands';
 
 @injectable()
 export class TimersViewContribution extends AbstractViewContribution<TimersWidget> {
@@ -3262,15 +3282,7 @@ Create `packages/cooklang/src/browser/style/timers.css`:
 }
 ```
 
-- [ ] **Step 4: Restore the alarm service import**
-
-If you commented out the `TimersCommands` import in `timer-alarm-service.ts` during Task 7, restore it now:
-
-```ts
-import { TimersCommands } from './timers-view-contribution';
-```
-
-- [ ] **Step 5: Bind everything**
+- [ ] **Step 4: Bind everything**
 
 In `packages/cooklang/src/browser/cooklang-frontend-module.ts`, add the imports:
 
@@ -3300,7 +3312,7 @@ and add this block next to the shopping-list bindings:
     bindViewContribution(bind, TimersViewContribution);
 ```
 
-- [ ] **Step 6: Compile, lint and run the whole suite**
+- [ ] **Step 5: Compile, lint and run the whole suite**
 
 ```bash
 export PATH="$HOME/.local/node-v22.23.2-darwin-x64/bin:$PATH"
@@ -3311,13 +3323,12 @@ npx lerna run test --scope @theia/cooklang
 
 Expected: compile succeeds with no errors, lint is clean, every spec in `@theia/cooklang` passes.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add packages/cooklang/src/browser/timers-widget.tsx \
         packages/cooklang/src/browser/timers-view-contribution.ts \
         packages/cooklang/src/browser/style/timers.css \
-        packages/cooklang/src/browser/timer-alarm-service.ts \
         packages/cooklang/src/browser/cooklang-frontend-module.ts
 git commit -m "feat(cooklang): add the Timers panel"
 ```

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -148,8 +148,13 @@ An `@injectable()` singleton, the port of `TimerManager` + `TimerStorage`.
   running**, so an idle window has no permanent interval.
 - Persistence: Theia's `StorageService` under key `cooklang.timers`. That
   service is workspace-scoped, so timers do not leak between workspaces; the
-  stored `recipePath` is still the full absolute URI string. Writes are
-  debounced; the stored shape is the `ActiveTimer[]` JSON directly.
+  stored `recipePath` is still the full absolute URI string. The stored shape
+  is the `ActiveTimer[]` JSON directly, written on every mutation — mutations
+  are user-driven plus one write per expiry, so there is nothing to debounce.
+- Restore validates every record and drops the ones it cannot run, rather than
+  trusting what storage returns. Persisted timers outlive the build that wrote
+  them, and an unvalidated record with a non-finite duration would produce a
+  timer that never expires and a tick interval that never stops.
 - Restore: remaining time is recomputed from `startedAtMs + durationSeconds`, so
   a timer that expired while the app was closed comes back as `finished`
   **without replaying the alarm**. The 20-most-recent cleanup rule from

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -254,8 +254,9 @@ icon `codicon-watch`, toggled by `cooklang.timers.toggle`.
 Rows are sorted running (soonest to fire first) → paused → finished. Each row is
 a port of `TimerCellView`: large monospace countdown, timer title, recipe name
 rendered as a link, a progress indicator, and the controls the iOS help page
-documents — `+1 min`, play/pause, reset, delete. The view title menu carries
-"Clear finished" and "Clear all".
+documents — `+1 min`, play/pause, reset, delete. A header row inside the panel
+carries "Clear finished" and "Clear all"; the latter asks for confirmation when
+a timer is still running, since that one represents something actually cooking.
 
 Empty state: a short line pointing at the inline badges — "No timers yet. Click a
 time in a recipe step to start one."

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -255,8 +255,9 @@ Rows are sorted running (soonest to fire first) → paused → finished. Each ro
 a port of `TimerCellView`: large monospace countdown, timer title, recipe name
 rendered as a link, a progress indicator, and the controls the iOS help page
 documents — `+1 min`, play/pause, reset, delete. A header row inside the panel
-carries "Clear finished" and "Clear all"; the latter asks for confirmation when
-a timer is still running, since that one represents something actually cooking.
+carries "Clear finished" and "Clear all"; the latter asks for confirmation unless
+every timer has finished, since a running or paused one is state the cook
+deliberately still has in play.
 
 Empty state: a short line pointing at the inline badges — "No timers yet. Click a
 time in a recipe step to start one."

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -256,11 +256,14 @@ time in a recipe step to start one."
 
 ### 7. URLs
 
-`linkify` is applied in three places in `recipe-preview-components.tsx`:
+`linkify` is applied in four places in `recipe-preview-components.tsx`:
 
 - `MetadataPills` — pill values (this is where `source:` URLs live).
 - `StepItemView` `case 'text'` — step body text.
 - The `note-item` block.
+- The `recipe-description` paragraph. `description` is a metadata value too; it
+  is only rendered apart from the pills because `SKIP_META_KEYS` excludes it,
+  and it is a natural place to paste the URL a recipe was adapted from.
 
 Matches render as `<a className='recipe-link' href={href}>` whose `onClick`
 prevents default and calls an `openExternal(url)` callback supplied by the

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -236,7 +236,8 @@ callback. That makes the scale settable from outside the React tree.
 Each timer records the scale in force when it was started, in
 `TimerRecipeRef.scale`. A new command `cooklang.openPreviewAtScale(uri, scale)`
 in `recipe-preview-contribution.ts` reuses the existing `getOrCreatePreview` +
-`shell.addWidget` + `activateWidget` path and then calls `setScale`. The panel's
+`shell.addWidget` + `activateWidget` path, calling `setScale` before the widget
+is revealed so no stale scale is ever painted. The panel's
 recipe link invokes that command.
 
 Timer durations already reflect scaling: `scaleRecipe` scales `timers[].quantity`

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -1,0 +1,320 @@
+# Recipe preview: clickable URLs and working timers
+
+Design for [issue #95](https://github.com/cook-md/editor/issues/95).
+
+Date: 2026-09-01
+
+## Problem
+
+The recipe preview was built on the assumption that people read recipes in the
+editor but cook from the mobile app. A trialing user wants to cook directly from
+the editor, and hit two gaps:
+
+- URLs in metadata and step text render as plain, unclickable text.
+- `~timer` values render as a static highlighted badge — they look like timers
+  but do nothing.
+
+## Goals
+
+- Every URL in the rendered recipe is clickable and opens in the system browser.
+- Every `~timer` with a numeric duration can be started from the step it appears
+  in, counts down in place, and keeps running while you navigate away.
+- A Timers panel lists all started timers across recipes, with a link back to the
+  recipe each one came from — at the scale that recipe was at when the timer
+  started.
+- When a timer finishes you get an OS notification and a sound, even if the
+  editor is in the background.
+
+## Non-goals
+
+- Quick/custom timers not bound to a recipe step (the iOS app has these).
+- LLM-generated timer labels (iOS `TimerNameHelper`).
+- Lock-screen / Live Activity / tray-icon equivalents.
+- Changing how timers are parsed or scaled — the existing `scaleRecipe`
+  behaviour is kept as-is.
+
+## Reference implementation
+
+The iOS app (`../mobile-app-ios`) already solves this, and this design is a
+deliberate port of its model so the two apps behave the same:
+
+| iOS | Here |
+| --- | --- |
+| `Packages/Timers/.../Models/ActiveTimer.swift` | `common/cooking-timer.ts` |
+| `Packages/Timers/.../Core/TimerManager.swift` | `browser/cooking-timer-service.ts` |
+| `Packages/Timers/.../Core/TimerStorage.swift` | persistence inside the same service |
+| `Packages/Timers/.../DurationFormatter.swift` | `common/timer-duration.ts` |
+| `extractTimers` in `RecipesProvider.swift` | `timerDurationSeconds` in `common/timer-duration.ts` |
+| `Presentation/Views/TimerCellView.swift` | `browser/timer-components.tsx` (`TimerRow`) |
+| `Presentation/Views/TimersView.swift` | `browser/timers-widget.tsx` |
+
+User-facing behaviour reference: <https://cook.md/help/ios/using-the-app>
+(multiple simultaneous timers, play/pause, stop, `+1 minute`, notification with
+sound when the app is backgrounded).
+
+## Architecture
+
+### 1. Pure core — `packages/cooklang/src/common/`
+
+No dependency injection, no Monaco imports, no React. These are the pieces that
+get real unit tests; keeping them Monaco-free is required, otherwise the browser
+spec harness dies with the `.css` ESM error (see
+`feedback_spec_monaco_css_harness`).
+
+#### `cooking-timer.ts`
+
+```ts
+export type TimerState = 'running' | 'paused' | 'finished';
+
+export interface TimerRecipeRef {
+    /** URI string of the .cook file. */
+    recipePath: string;
+    /** Display name, for the panel row. */
+    recipeName: string;
+    /** Index of the step across the whole recipe, 0-based. */
+    globalStepIndex: number;
+    /** Index of this timer among the timers of that step, 0-based. */
+    timerPosition: number;
+    /** Recipe scale factor in force when the timer was started. */
+    scale: number;
+}
+
+export interface ActiveTimer {
+    id: string;
+    title: string;
+    durationSeconds: number;
+    state: TimerState;
+    startedAtMs?: number;
+    pausedRemainingSeconds?: number;
+    recipeRef?: TimerRecipeRef;
+    updatedAtMs: number;
+}
+```
+
+iOS's `idle` state is deliberately dropped: a record only exists once the timer
+has been started, because the panel lists started timers only (see decisions).
+
+Pure transition functions, each taking `nowMs` so tests use a fake clock:
+`createAndStart`, `pause`, `resume`, `reset`, `restart`, `finish`, `addTime`,
+plus `remainingSeconds(timer, nowMs)`, `isExpired(timer, nowMs)` and
+`fireAtMs(timer)`.
+
+`resume` follows the iOS trick of back-dating `startedAtMs` by the elapsed
+portion, so `remainingSeconds` stays a pure function of the clock and never
+drifts across pause/resume cycles.
+
+#### `timer-duration.ts`
+
+`timerDurationSeconds(timer: Timer): number | undefined` — the port of iOS
+`extractTimers` + `Value.toSeconds`:
+
+- Unit is matched on its **first character**: `s` → seconds, `m` → minutes,
+  `h` → hours, `d` → days. (iOS supports s/m/h; `d` is added here for
+  fermentation and proving times.)
+- `number` → value × multiplier, keeping fractions (`1.5 hours` → 5400).
+- `range` → the **start** value.
+- `text` → the first number parsed out of it. The parser returns
+  `~{50-60%minutes}` as the text `"50-60"`, which must yield 3000.
+- No unit, or no quantity → `undefined`. Such timers (`~{until golden}`, or a
+  bare named `~sauce`) are **not startable** and keep rendering exactly as they
+  do today.
+
+`formatClock(seconds)` → `07:42`, `01:05:30`, `4d 08:05:30` (hours only when
+non-zero, days only at ≥ 24h). `formatDuration(seconds)` → `10 min`,
+`1 hour 5 min`.
+
+#### `recipe-links.ts`
+
+`linkify(text: string): Array<TextToken | LinkToken>` — a pure tokenizer over a
+run of text, recognising `http(s)://…`, `www.…` (linked as `https://…`),
+`mailto:…` and bare email addresses. Trailing sentence punctuation is trimmed
+off the match and unbalanced closing parens are excluded, so `(see
+https://example.com/x).` links only `https://example.com/x`.
+
+### 2. `CookingTimerService` — `browser/cooking-timer-service.ts`
+
+An `@injectable()` singleton, the port of `TimerManager` + `TimerStorage`.
+
+- State: `Map<string, ActiveTimer>`.
+- Events: `onDidChangeTimers: Event<void>`, `onDidFinishTimer: Event<ActiveTimer>`.
+- Query: `list()`, `get(id)`, `find(ref)` — matching on `recipePath` +
+  `globalStepIndex` + `timerPosition` only, ignoring `scale`, so re-scaling the
+  preview still finds the running timer.
+- Commands: `start(ref, title, durationSeconds)`, `pause`, `resume`, `toggle`,
+  `reset`, `restart`, `addTime(id, seconds)`, `remove`, `removeFinished`,
+  `removeAll`.
+- One shared 1s tick drives both expiry detection and countdown re-renders. It
+  is started when the first timer starts running and **stopped when none are
+  running**, so an idle window has no permanent interval.
+- Persistence: Theia's `StorageService` under key `cooklang.timers`. That
+  service is workspace-scoped, so timers do not leak between workspaces; the
+  stored `recipePath` is still the full absolute URI string. Writes are
+  debounced; the stored shape is the `ActiveTimer[]` JSON directly.
+- Restore: remaining time is recomputed from `startedAtMs + durationSeconds`, so
+  a timer that expired while the app was closed comes back as `finished`
+  **without replaying the alarm**. The 20-most-recent cleanup rule from
+  `TimerManager.cleanupOldTimers` is kept.
+- The load is kicked off from a **synchronous** `@postConstruct` that calls an
+  async helper without awaiting. `@postConstruct` must never be `async` —
+  Inversify 6.2.2 breaks sync DI and the frontend fails to start (see
+  `feedback_async_postconstruct`).
+
+### 3. Alarm — `browser/timer-alarm-service.ts`
+
+A `FrontendApplicationContribution` that subscribes to `onDidFinishTimer`:
+
+- **Notification**: reuses the existing `OSNotificationService` from
+  `@theia/ai-core/lib/browser/os-notification-service`. `@theia/ai-core` is
+  already a dependency of `@theia/cooklang` and already binds the service in
+  singleton scope, so nothing new is wired up. Title = timer title, body =
+  recipe name, `requireInteraction: true`; clicking reveals the Timers view.
+  Permission is requested the first time a timer is started, not at startup.
+- **Sound**: a bell chime synthesized with the Web Audio API — sine strikes with
+  an exponential decay envelope, three of them. It is synthesized rather than
+  shipped as `ShortBell.wav` because the generated webpack config has no audio
+  asset rule (`dev-packages/application-manager/src/generator/webpack-generator.ts`
+  handles `jpg|png|gif|svg|woff|wasm|plist` only), and adding one means editing
+  an upstream file. Swapping in the real iOS bell later is a one-line rule
+  addition.
+
+Both are gated on new preferences in `common/cooklang-preferences.ts`:
+
+- `cooklang.timers.sound` — boolean, default `true`.
+- `cooklang.timers.notifications` — boolean, default `true`.
+
+### 4. Inline timers in the preview
+
+`recipe-preview-components.tsx` stays presentational: no service imports, no DI.
+The widget supplies a `TimerBinding` through a new React context:
+
+```ts
+export interface TimerBinding {
+    find(ref: TimerRecipeRef): ActiveTimer | undefined;
+    start(ref: TimerRecipeRef, title: string, durationSeconds: number): void;
+    toggle(id: string): void;
+    reset(id: string): void;
+    addTime(id: string, seconds: number): void;
+}
+```
+
+`StepItemView`'s `case 'timer'` renders a `TimerBadge` when the context provides
+a binding, and otherwise falls back to today's static
+`<span className='timer-badge'>`. That fallback is what keeps the existing
+`renderToStaticMarkup` spec (`recipe-preview-components.spec.ts`) working
+untouched.
+
+Badge states:
+
+| State | Rendering |
+| --- | --- |
+| not started | `⏱ 10 min`, clickable, `timer-badge timer-badge-idle` |
+| running | `⏱ 07:42` + pause affordance |
+| paused | dimmed, resume + reset affordances |
+| finished | highlighted `00:00`, restart affordance |
+| not startable | exactly today's static badge |
+
+Countdown re-renders are driven by the service's shared tick calling the
+widget's `update()` — no per-badge `setInterval`.
+
+Timer identity is iOS's triple: `recipePath` + `globalStepIndex` +
+`timerPosition`. `globalStepIndex` is already tracked by `InstructionsPanel` for
+step images; `timerPosition` is the nth timer item within the step, computed in
+`SectionContentView`.
+
+### 5. Scale
+
+`scale` moves out of `RecipeView`'s local `useState` and up into
+`RecipePreviewWidget` (a `protected scale` field plus `setScale(n)` that calls
+`update()`), passed back down as a controlled prop with an `onScaleChange`
+callback. That makes the scale settable from outside the React tree.
+
+Each timer records the scale in force when it was started, in
+`TimerRecipeRef.scale`. A new command `cooklang.openPreviewAtScale(uri, scale)`
+in `recipe-preview-contribution.ts` reuses the existing `getOrCreatePreview` +
+`shell.addWidget` + `activateWidget` path and then calls `setScale`. The panel's
+recipe link invokes that command.
+
+Timer durations already reflect scaling: `scaleRecipe` scales `timers[].quantity`
+whenever the parser marks the quantity scalable, so the badge shows — and the
+started timer uses — the scaled duration. No change needed.
+
+### 6. Timers panel
+
+`browser/timers-widget.tsx` (`TimersWidget extends ReactWidget`) plus
+`browser/timers-view-contribution.ts` (`AbstractViewContribution`), docked with
+`area: 'right'` — the same area as the Shopping List view, id `cooklang-timers`,
+icon `codicon-watch`, toggled by `cooklang.timers.toggle`.
+
+Rows are sorted running (soonest to fire first) → paused → finished. Each row is
+a port of `TimerCellView`: large monospace countdown, timer title, recipe name
+rendered as a link, a progress indicator, and the controls the iOS help page
+documents — `+1 min`, play/pause, reset, delete. The view title menu carries
+"Clear finished" and "Clear all".
+
+Empty state: a short line pointing at the inline badges — "No timers yet. Click a
+time in a recipe step to start one."
+
+### 7. URLs
+
+`linkify` is applied in three places in `recipe-preview-components.tsx`:
+
+- `MetadataPills` — pill values (this is where `source:` URLs live).
+- `StepItemView` `case 'text'` — step body text.
+- The `note-item` block.
+
+Matches render as `<a className='recipe-link' href={href}>` whose `onClick`
+prevents default and calls an `openExternal(url)` callback supplied by the
+widget, which delegates to `WindowService.openNewWindow(url, { external: true })`
+— the same path already used by `cooklang-account` and the branding chat widget.
+When no callback is supplied (specs), the anchor renders with its `href` and no
+handler, so the components stay pure.
+
+## Decisions
+
+These were settled during brainstorming and are recorded so the plan does not
+relitigate them:
+
+- **Both inline and panel.** Inline countdown in the step, plus a side panel of
+  all timers. Not either/or.
+- **Panel lists started timers only** — across all recipes, in running, paused
+  and finished states. It does not list not-yet-started timers of the open
+  recipe (iOS's merged `RecipeTimerItem` list), which keeps panel state simple.
+- **Full persistence.** Timers survive closing the preview, reloading, and
+  restarting the app, with expiry recomputed on restore.
+- **OS notification + sound** on completion. No in-app toast; the visual state
+  change in badge and panel covers the foreground case.
+- **URLs in both metadata and step text**, opened in the system browser rather
+  than the mini-browser.
+- **Right dock area** for the panel, matching Shopping List.
+
+## Testing
+
+New specs, all Monaco-free:
+
+- `common/cooking-timer.spec.ts` — state machine: pause/resume with no drift
+  across repeated cycles, `addTime` in each state, expiry boundary, `reset` and
+  `restart`.
+- `common/timer-duration.spec.ts` — unit first-char matching for s/m/h/d,
+  fractional hours, range → start value, text `"50-60"` → 3000, missing
+  unit/quantity → `undefined`; clock and duration formatting including the days
+  form.
+- `common/recipe-links.spec.ts` — plain text passthrough, bare and `www` URLs,
+  mailto and bare email, trailing punctuation, parens, multiple links in one
+  run, and text that merely contains a colon.
+- `browser/cooking-timer-service.spec.ts` — fake clock plus an in-memory
+  `StorageService` double: start → persist → restore, a timer that expired while
+  "closed" restores as finished without firing `onDidFinishTimer`, the 20-timer
+  cap evicts oldest by `updatedAtMs`, and the tick stops when no timer runs.
+- `browser/timer-components.spec.ts` — `renderToStaticMarkup` of the badge in
+  each state and of a panel row.
+
+The existing `recipe-preview-components.spec.ts` must keep passing unchanged;
+that is the regression check on the presentational fallback path.
+
+Manual verification: `npm run start:electron`, start a short timer, background
+the window, confirm the OS notification and chime; reload the window mid-timer
+and confirm the countdown resumes correctly; click a recipe link in the panel
+and confirm the preview opens at the recorded scale.
+
+Note that mocha needs the Node 22 at `~/.local/node-v22.23.2-darwin-x64/bin`;
+the default `node` on this machine is 20.

--- a/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
+++ b/docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md
@@ -249,7 +249,10 @@ started timer uses — the scaled duration. No change needed.
 `browser/timers-widget.tsx` (`TimersWidget extends ReactWidget`) plus
 `browser/timers-view-contribution.ts` (`AbstractViewContribution`), docked with
 `area: 'right'` — the same area as the Shopping List view, id `cooklang-timers`,
-icon `codicon-watch`, toggled by `cooklang.timers.toggle`.
+icon `codicon-watch`, toggled by `cooklang.toggleTimers`. The finish
+notification reveals the view rather than toggling it — the toggle collapses
+the panel when it is already the active tab, which is exactly where someone
+watching a countdown would be.
 
 Rows are sorted running (soonest to fire first) → paused → finished. Each row is
 a port of `TimerCellView`: large monospace countdown, timer title, recipe name

--- a/packages/cooklang/src/browser/cooking-timer-service.spec.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.spec.ts
@@ -101,6 +101,32 @@ describe('CookingTimerService', () => {
         expect(service.list()).to.have.length(1);
     });
 
+    it('announces a deliberately started timer', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        const started: string[] = [];
+        service.onDidStartTimer(timer => started.push(timer.id));
+        service.start(ref(), 'simmer', 600);
+        service.start(ref(), 'simmer', 600);
+        expect(started).to.deep.equal(['t1', 't1']);
+    });
+
+    it('stays quiet about timers that merely came back from storage', async () => {
+        const storage = new FakeStorage();
+        const first = createService(storage);
+        await first.load();
+        first.start(ref(), 'simmer', 600);
+        first.dispose();
+
+        const second = createService(storage);
+        const started: string[] = [];
+        second.onDidStartTimer(timer => started.push(timer.id));
+        await second.load();
+
+        expect(second.list()).to.have.length(1);
+        expect(started).to.deep.equal([]);
+    });
+
     it('fires onDidFinishTimer when a running timer expires', async () => {
         const service = createService(new FakeStorage());
         await service.load();

--- a/packages/cooklang/src/browser/cooking-timer-service.spec.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.spec.ts
@@ -13,7 +13,7 @@
 
 import { expect } from 'chai';
 import { StorageService } from '@theia/core/lib/browser/storage-service';
-import { ActiveTimer, TimerRecipeRef, remainingSeconds } from '../common/cooking-timer';
+import { ActiveTimer, TimerRecipeRef, remainingSeconds, createAndStart, pause, finish } from '../common/cooking-timer';
 import { CookingTimerService } from './cooking-timer-service';
 
 const T0 = 1_700_000_000_000;
@@ -196,5 +196,108 @@ describe('CookingTimerService', () => {
         service.addTime('t1', 60);
         service.remove('t1');
         expect(changes).to.equal(4);
+    });
+
+    it('drops unreadable records without losing the good ones', async () => {
+        const storage = new FakeStorage();
+        const good = {
+            id: 'keep', title: 'good', durationSeconds: 600,
+            state: 'paused', pausedRemainingSeconds: 600, updatedAtMs: T0,
+        };
+        storage.data.set('cooklang.timers', [
+            undefined,
+            'nonsense',
+            42,
+            { id: 'no-state', title: 'x', durationSeconds: 60, updatedAtMs: T0 },
+            { id: 'bad-state', title: 'x', durationSeconds: 60, state: 'idle', updatedAtMs: T0 },
+            { title: 'no id', durationSeconds: 60, state: 'paused', updatedAtMs: T0 },
+            good,
+        ]);
+        const service = createService(storage);
+        await service.load();
+        expect(service.list().map(t => t.id)).to.deep.equal(['keep']);
+    });
+
+    it('ignores stored data that is not a list', async () => {
+        const storage = new FakeStorage();
+        storage.data.set('cooklang.timers', { nope: true });
+        const service = createService(storage);
+        await service.load();
+        expect(service.list()).to.have.length(0);
+    });
+
+    it('refuses a timer that could never expire, so the tick cannot be held open', async () => {
+        const storage = new FakeStorage();
+        storage.data.set('cooklang.timers', [
+            { id: 'nan', title: 'x', durationSeconds: NaN, state: 'running', startedAtMs: T0, updatedAtMs: T0 },
+            { id: 'anchorless', title: 'x', durationSeconds: 600, state: 'running', updatedAtMs: T0 },
+        ]);
+        const service = createService(storage);
+        await service.load();
+        expect(service.list()).to.have.length(0);
+        expect(service.ticking).to.equal(false);
+    });
+
+    it('survives a listener that removes a timer while events are firing', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        service.onDidFinishTimer(timer => service.remove(timer.id));
+        service.currentTimeMs = T0 + 600_000;
+        service.tickNow();
+        expect(service.list()).to.have.length(0);
+        expect(service.ticking).to.equal(false);
+    });
+
+    it('resets a timer to its full duration, paused', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        service.currentTimeMs = T0 + 90_000;
+        service.reset('t1');
+        expect(service.get('t1')?.state).to.equal('paused');
+        expect(remainingSeconds(service.get('t1')!, service.currentTimeMs)).to.equal(600);
+        expect(service.ticking).to.equal(false);
+    });
+
+    it('restarts a finished timer and starts ticking again', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        service.currentTimeMs = T0 + 600_000;
+        service.tickNow();
+        expect(service.get('t1')?.state).to.equal('finished');
+        service.toggle('t1');
+        expect(service.get('t1')?.state).to.equal('running');
+        expect(remainingSeconds(service.get('t1')!, service.currentTimeMs)).to.equal(600);
+        expect(service.ticking).to.equal(true);
+    });
+
+    it('removes everything on removeAll', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref({ globalStepIndex: 1 }), 'a', 600);
+        service.start(ref({ globalStepIndex: 2 }), 'b', 600);
+        service.removeAll();
+        expect(service.list()).to.have.length(0);
+        expect(service.ticking).to.equal(false);
+    });
+
+    it('stops ticking and forgets everything on dispose', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        service.dispose();
+        expect(service.ticking).to.equal(false);
+        expect(service.list()).to.have.length(0);
+    });
+
+    it('sorts running first by soonest fire, then paused, then finished', () => {
+        const soon = createAndStart('soon', 'soon', 60, T0, ref());
+        const later = createAndStart('later', 'later', 600, T0, ref());
+        const held = pause(createAndStart('held', 'held', 600, T0, ref()), T0);
+        const done = finish(createAndStart('done', 'done', 600, T0, ref()), T0);
+        expect(CookingTimerService.sortForDisplay([done, held, later, soon]).map(t => t.id))
+            .to.deep.equal(['soon', 'later', 'held', 'done']);
     });
 });

--- a/packages/cooklang/src/browser/cooking-timer-service.spec.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.spec.ts
@@ -292,6 +292,39 @@ describe('CookingTimerService', () => {
         expect(service.list()).to.have.length(0);
     });
 
+    it('keeps a timer whose recipe reference is unusable, but drops the reference', async () => {
+        const storage = new FakeStorage();
+        storage.data.set('cooklang.timers', [
+            {
+                id: 'bad-ref', title: 'simmer', durationSeconds: 600, state: 'paused',
+                pausedRemainingSeconds: 600, updatedAtMs: T0,
+                recipeRef: { recipePath: 12345, recipeName: 7, globalStepIndex: 'a', timerPosition: undefined, scale: 'x' },
+            },
+            {
+                id: 'no-ref-object', title: 'rest', durationSeconds: 60, state: 'paused',
+                pausedRemainingSeconds: 60, updatedAtMs: T0, recipeRef: 'not an object',
+            },
+        ]);
+        const service = createService(storage);
+        await service.load();
+        expect(service.list().map(t => t.id)).to.deep.equal(['bad-ref', 'no-ref-object']);
+        expect(service.list().every(t => t.recipeRef === undefined)).to.equal(true);
+    });
+
+    it('keeps a well-formed recipe reference intact', async () => {
+        const storage = new FakeStorage();
+        storage.data.set('cooklang.timers', [
+            {
+                id: 'good-ref', title: 'simmer', durationSeconds: 600, state: 'paused',
+                pausedRemainingSeconds: 600, updatedAtMs: T0, recipeRef: ref(),
+            },
+        ]);
+        const service = createService(storage);
+        await service.load();
+        expect(service.get('good-ref')?.recipeRef?.recipeName).to.equal('Soup');
+        expect(service.find(ref())?.id).to.equal('good-ref');
+    });
+
     it('sorts running first by soonest fire, then paused, then finished', () => {
         const soon = createAndStart('soon', 'soon', 60, T0, ref());
         const later = createAndStart('later', 'later', 600, T0, ref());

--- a/packages/cooklang/src/browser/cooking-timer-service.spec.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.spec.ts
@@ -1,0 +1,200 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { StorageService } from '@theia/core/lib/browser/storage-service';
+import { ActiveTimer, TimerRecipeRef, remainingSeconds } from '../common/cooking-timer';
+import { CookingTimerService } from './cooking-timer-service';
+
+const T0 = 1_700_000_000_000;
+
+class FakeStorage {
+    data = new Map<string, unknown>();
+    writes = 0;
+    async setData<T>(key: string, value: T): Promise<void> {
+        this.writes++;
+        this.data.set(key, JSON.parse(JSON.stringify(value)));
+    }
+    async getData<T>(key: string, defaultValue?: T): Promise<T | undefined> {
+        return this.data.has(key) ? this.data.get(key) as T : defaultValue;
+    }
+}
+
+/** Exposes the clock, the id generator and the protected lifecycle to tests. */
+class TestTimerService extends CookingTimerService {
+    currentTimeMs = T0;
+    protected idCounter = 0;
+    protected override now(): number {
+        return this.currentTimeMs;
+    }
+    protected override newId(): string {
+        return `t${++this.idCounter}`;
+    }
+    /** Number of live tick intervals; 0 or 1. */
+    get ticking(): boolean {
+        return this.tickHandle !== undefined;
+    }
+    async load(): Promise<void> {
+        await this.restore();
+    }
+    tickNow(): void {
+        this.tick();
+    }
+}
+
+function ref(overrides: Partial<TimerRecipeRef> = {}): TimerRecipeRef {
+    return {
+        recipePath: 'file:///recipes/Soup.cook',
+        recipeName: 'Soup',
+        globalStepIndex: 2,
+        timerPosition: 0,
+        scale: 1,
+        ...overrides,
+    };
+}
+
+function createService(storage: FakeStorage): TestTimerService {
+    const service = new TestTimerService();
+    (service as unknown as { storageService: StorageService }).storageService =
+        storage as unknown as StorageService;
+    return service;
+}
+
+describe('CookingTimerService', () => {
+
+    it('starts a timer, keeps it, and persists it', async () => {
+        const storage = new FakeStorage();
+        const service = createService(storage);
+        await service.load();
+
+        service.start(ref(), 'simmer', 600);
+
+        expect(service.list()).to.have.length(1);
+        expect(service.list()[0].title).to.equal('simmer');
+        expect(service.find(ref())?.id).to.equal('t1');
+        expect(storage.data.get('cooklang.timers')).to.have.length(1);
+        expect(service.ticking).to.equal(true);
+    });
+
+    it('finds a timer regardless of the scale in the lookup ref', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref({ scale: 1 }), 'simmer', 600);
+        expect(service.find(ref({ scale: 4 }))?.id).to.equal('t1');
+    });
+
+    it('restarts an existing timer instead of creating a second one for the same step', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        service.start(ref(), 'simmer', 600);
+        expect(service.list()).to.have.length(1);
+    });
+
+    it('fires onDidFinishTimer when a running timer expires', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        const finished: ActiveTimer[] = [];
+        service.onDidFinishTimer(timer => finished.push(timer));
+
+        service.start(ref(), 'simmer', 600);
+        service.currentTimeMs = T0 + 599_000;
+        service.tickNow();
+        expect(finished).to.have.length(0);
+
+        service.currentTimeMs = T0 + 600_000;
+        service.tickNow();
+        expect(finished.map(t => t.id)).to.deep.equal(['t1']);
+        expect(service.list()[0].state).to.equal('finished');
+    });
+
+    it('stops ticking once nothing is running', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref(), 'simmer', 600);
+        expect(service.ticking).to.equal(true);
+        service.pause('t1');
+        expect(service.ticking).to.equal(false);
+        service.resume('t1');
+        expect(service.ticking).to.equal(true);
+    });
+
+    it('restores timers and keeps counting down', async () => {
+        const storage = new FakeStorage();
+        const first = createService(storage);
+        await first.load();
+        first.start(ref(), 'simmer', 600);
+        first.dispose();
+
+        const second = createService(storage);
+        second.currentTimeMs = T0 + 120_000;
+        await second.load();
+
+        expect(second.list()).to.have.length(1);
+        expect(remainingSeconds(second.list()[0], second.currentTimeMs)).to.equal(480);
+    });
+
+    it('restores a timer that expired while the app was closed as finished, without alarming', async () => {
+        const storage = new FakeStorage();
+        const first = createService(storage);
+        await first.load();
+        first.start(ref(), 'simmer', 600);
+        first.dispose();
+
+        const second = createService(storage);
+        second.currentTimeMs = T0 + 3_600_000;
+        const finished: ActiveTimer[] = [];
+        second.onDidFinishTimer(timer => finished.push(timer));
+        await second.load();
+
+        expect(second.list()[0].state).to.equal('finished');
+        expect(finished).to.have.length(0);
+    });
+
+    it('keeps only the 20 most recently updated timers', async () => {
+        const storage = new FakeStorage();
+        const service = createService(storage);
+        await service.load();
+        for (let i = 0; i < 25; i++) {
+            service.currentTimeMs = T0 + i * 1000;
+            service.start(ref({ globalStepIndex: i }), `timer ${i}`, 600);
+        }
+        expect(service.list()).to.have.length(20);
+        expect(service.find(ref({ globalStepIndex: 0 }))).to.equal(undefined);
+        expect(service.find(ref({ globalStepIndex: 24 }))).to.not.equal(undefined);
+    });
+
+    it('removes finished timers on request and leaves the rest', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        service.start(ref({ globalStepIndex: 1 }), 'a', 600);
+        service.start(ref({ globalStepIndex: 2 }), 'b', 600);
+        service.currentTimeMs = T0 + 600_000;
+        service.tickNow();
+        service.resume('t1');
+        service.removeFinished();
+        expect(service.list().map(t => t.id)).to.deep.equal(['t1']);
+    });
+
+    it('notifies listeners on every change', async () => {
+        const service = createService(new FakeStorage());
+        await service.load();
+        let changes = 0;
+        service.onDidChangeTimers(() => changes++);
+        service.start(ref(), 'simmer', 600);
+        service.pause('t1');
+        service.addTime('t1', 60);
+        service.remove('t1');
+        expect(changes).to.equal(4);
+    });
+});

--- a/packages/cooklang/src/browser/cooking-timer-service.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.ts
@@ -1,0 +1,323 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { StorageService } from '@theia/core/lib/browser/storage-service';
+import {
+    ActiveTimer,
+    TimerRecipeRef,
+    addTime,
+    createAndStart,
+    finish,
+    fireAtMs,
+    isExpired,
+    matchesRef,
+    pause,
+    reset,
+    restart,
+    resume,
+} from '../common/cooking-timer';
+
+/**
+ * Owns every live cooking timer for the window. A port of the iOS app's
+ * `TimerManager` plus `TimerStorage`
+ * (`Packages/Timers/Sources/Timers/Core/`).
+ *
+ * A single interval ticks once a second while at least one timer is running:
+ * it both detects expiry and drives countdown re-renders in the preview and
+ * the Timers panel. It is torn down as soon as nothing is running.
+ */
+@injectable()
+export class CookingTimerService implements Disposable {
+
+    static readonly STORAGE_KEY = 'cooklang.timers';
+    /** Matches the iOS `TimerManager.maxRetainedTimers`. */
+    static readonly MAX_TIMERS = 20;
+
+    @inject(StorageService)
+    protected readonly storageService: StorageService;
+
+    protected readonly timers = new Map<string, ActiveTimer>();
+
+    protected readonly onDidChangeTimersEmitter = new Emitter<void>();
+    readonly onDidChangeTimers: Event<void> = this.onDidChangeTimersEmitter.event;
+
+    protected readonly onDidFinishTimerEmitter = new Emitter<ActiveTimer>();
+    readonly onDidFinishTimer: Event<ActiveTimer> = this.onDidFinishTimerEmitter.event;
+
+    protected tickHandle: ReturnType<typeof setInterval> | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        // Never make this method async: Inversify 6.2.2 treats an async
+        // @postConstruct as an async binding and the whole frontend fails to
+        // construct. Kick the load off and let it settle on its own.
+        this.restore().catch(e => console.warn('Could not restore cooking timers', e));
+    }
+
+    // --- Overridable seams (tests substitute a fake clock and ids) ---
+
+    protected now(): number {
+        return Date.now();
+    }
+
+    protected newId(): string {
+        return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    // --- Query ---
+
+    /** Every timer, in insertion order. */
+    list(): ActiveTimer[] {
+        return Array.from(this.timers.values());
+    }
+
+    get(id: string): ActiveTimer | undefined {
+        return this.timers.get(id);
+    }
+
+    /** The timer started for `ref`'s step and position, whatever its scale. */
+    find(ref: TimerRecipeRef): ActiveTimer | undefined {
+        for (const timer of this.timers.values()) {
+            if (matchesRef(timer, ref)) {
+                return timer;
+            }
+        }
+        return undefined;
+    }
+
+    nowMs(): number {
+        return this.now();
+    }
+
+    // --- Commands ---
+
+    /**
+     * Start the timer for `ref`. If one is already there — paused, finished, or
+     * still running — it is restarted rather than duplicated.
+     */
+    start(ref: TimerRecipeRef, title: string, durationSeconds: number): ActiveTimer {
+        const now = this.now();
+        const existing = this.find(ref);
+        if (existing) {
+            // Re-read title, duration and scale: the recipe may have been
+            // edited or re-scaled since this timer was first started.
+            const updated = { ...existing, title, durationSeconds, recipeRef: ref };
+            return this.replace(restart(updated, now));
+        }
+        return this.replace(createAndStart(this.newId(), title, durationSeconds, now, ref));
+    }
+
+    pause(id: string): void {
+        this.mutate(id, timer => pause(timer, this.now()));
+    }
+
+    resume(id: string): void {
+        this.mutate(id, timer => resume(timer, this.now()));
+    }
+
+    /** Pause a running timer, resume a paused one, restart a finished one. */
+    toggle(id: string): void {
+        const timer = this.timers.get(id);
+        if (!timer) {
+            return;
+        }
+        const now = this.now();
+        this.mutate(id, () => {
+            switch (timer.state) {
+                case 'running':
+                    return pause(timer, now);
+                case 'paused':
+                    return resume(timer, now);
+                case 'finished':
+                    return restart(timer, now);
+            }
+        });
+    }
+
+    reset(id: string): void {
+        this.mutate(id, timer => reset(timer, this.now()));
+    }
+
+    restart(id: string): void {
+        this.mutate(id, timer => restart(timer, this.now()));
+    }
+
+    addTime(id: string, seconds: number): void {
+        this.mutate(id, timer => addTime(timer, seconds, this.now()));
+    }
+
+    remove(id: string): void {
+        if (this.timers.delete(id)) {
+            this.changed();
+        }
+    }
+
+    removeFinished(): void {
+        let removed = false;
+        for (const timer of this.list()) {
+            if (timer.state === 'finished') {
+                this.timers.delete(timer.id);
+                removed = true;
+            }
+        }
+        if (removed) {
+            this.changed();
+        }
+    }
+
+    removeAll(): void {
+        if (this.timers.size > 0) {
+            this.timers.clear();
+            this.changed();
+        }
+    }
+
+    dispose(): void {
+        this.stopTicking();
+        this.onDidChangeTimersEmitter.dispose();
+        this.onDidFinishTimerEmitter.dispose();
+    }
+
+    // --- Internals ---
+
+    protected replace(timer: ActiveTimer): ActiveTimer {
+        this.timers.set(timer.id, timer);
+        this.evictOldest();
+        this.changed();
+        return timer;
+    }
+
+    protected mutate(id: string, transform: (timer: ActiveTimer) => ActiveTimer): void {
+        const timer = this.timers.get(id);
+        if (!timer) {
+            return;
+        }
+        this.timers.set(id, transform(timer));
+        this.changed();
+    }
+
+    protected changed(): void {
+        this.persist();
+        this.updateTicking();
+        this.onDidChangeTimersEmitter.fire();
+    }
+
+    /**
+     * Drop the least recently touched timers once there are more than
+     * {@link MAX_TIMERS}, matching iOS `cleanupOldTimers`.
+     */
+    protected evictOldest(): void {
+        if (this.timers.size <= CookingTimerService.MAX_TIMERS) {
+            return;
+        }
+        const keep = new Set(
+            this.list()
+                .sort((a, b) => b.updatedAtMs - a.updatedAtMs)
+                .slice(0, CookingTimerService.MAX_TIMERS)
+                .map(timer => timer.id)
+        );
+        for (const timer of this.list()) {
+            if (!keep.has(timer.id)) {
+                this.timers.delete(timer.id);
+            }
+        }
+    }
+
+    protected async persist(): Promise<void> {
+        try {
+            await this.storageService.setData(CookingTimerService.STORAGE_KEY, this.list());
+        } catch (e) {
+            console.warn('Could not persist cooking timers', e);
+        }
+    }
+
+    /**
+     * Reload timers saved by an earlier session. A timer whose fire time has
+     * already passed comes back finished, but no `onDidFinishTimer` is fired:
+     * the alarm belongs to the moment it expired, not to startup.
+     */
+    protected async restore(): Promise<void> {
+        const stored = await this.storageService.getData<ActiveTimer[]>(CookingTimerService.STORAGE_KEY, []);
+        const now = this.now();
+        for (const timer of stored ?? []) {
+            this.timers.set(timer.id, isExpired(timer, now) ? finish(timer, now) : timer);
+        }
+        this.evictOldest();
+        this.updateTicking();
+        this.onDidChangeTimersEmitter.fire();
+    }
+
+    protected hasRunning(): boolean {
+        return this.list().some(timer => timer.state === 'running');
+    }
+
+    protected updateTicking(): void {
+        if (this.hasRunning()) {
+            this.startTicking();
+        } else {
+            this.stopTicking();
+        }
+    }
+
+    protected startTicking(): void {
+        if (this.tickHandle === undefined) {
+            this.tickHandle = setInterval(() => this.tick(), 1000);
+        }
+    }
+
+    protected stopTicking(): void {
+        if (this.tickHandle !== undefined) {
+            clearInterval(this.tickHandle);
+            this.tickHandle = undefined;
+        }
+    }
+
+    protected tick(): void {
+        const now = this.now();
+        const finished: ActiveTimer[] = [];
+        for (const timer of this.list()) {
+            if (isExpired(timer, now)) {
+                const done = finish(timer, now);
+                this.timers.set(done.id, done);
+                finished.push(done);
+            }
+        }
+        if (finished.length > 0) {
+            this.persist();
+        }
+        this.updateTicking();
+        // Fired every second so countdowns re-render, not only on state change.
+        this.onDidChangeTimersEmitter.fire();
+        for (const timer of finished) {
+            this.onDidFinishTimerEmitter.fire(timer);
+        }
+    }
+
+    /** Running timers first, soonest to fire at the top, then paused, then finished. */
+    static sortForDisplay(timers: ActiveTimer[]): ActiveTimer[] {
+        const rank: Record<string, number> = { running: 0, paused: 1, finished: 2 };
+        return [...timers].sort((a, b) => {
+            const byState = rank[a.state] - rank[b.state];
+            if (byState !== 0) {
+                return byState;
+            }
+            if (a.state === 'running') {
+                return (fireAtMs(a) ?? 0) - (fireAtMs(b) ?? 0);
+            }
+            return b.updatedAtMs - a.updatedAtMs;
+        });
+    }
+}

--- a/packages/cooklang/src/browser/cooking-timer-service.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.ts
@@ -77,6 +77,25 @@ function isStoredTimer(value: unknown): value is ActiveTimer {
 }
 
 /**
+ * Whether a stored recipe reference is usable. A malformed one costs the
+ * timer its link back to a recipe but not the timer itself, so callers drop
+ * the reference rather than the record. `recipePath` in particular reaches
+ * `new URI(...)` when the Timers panel navigates, and a non-string there
+ * would throw.
+ */
+function isStoredRecipeRef(value: unknown): value is TimerRecipeRef {
+    if (typeof value !== 'object' || !value) {
+        return false;
+    }
+    const ref = value as Partial<TimerRecipeRef>;
+    return typeof ref.recipePath === 'string' && ref.recipePath.length > 0
+        && typeof ref.recipeName === 'string'
+        && isFiniteNumber(ref.globalStepIndex)
+        && isFiniteNumber(ref.timerPosition)
+        && isFiniteNumber(ref.scale) && ref.scale > 0;
+}
+
+/**
  * Owns every live cooking timer for the window. A port of the iOS app's
  * `TimerManager` plus `TimerStorage`
  * (`Packages/Timers/Sources/Timers/Core/`).
@@ -322,7 +341,10 @@ export class CookingTimerService implements Disposable {
                 dropped++;
                 continue;
             }
-            this.timers.set(record.id, isExpired(record, now) ? finish(record, now) : record);
+            const timer = record.recipeRef !== undefined && !isStoredRecipeRef(record.recipeRef)
+                ? { ...record, recipeRef: undefined }
+                : record;
+            this.timers.set(timer.id, isExpired(timer, now) ? finish(timer, now) : timer);
         }
         if (dropped > 0) {
             console.warn(`Dropped ${dropped} unreadable cooking timer(s) from storage`);

--- a/packages/cooklang/src/browser/cooking-timer-service.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.ts
@@ -18,6 +18,7 @@ import { StorageService } from '@theia/core/lib/browser/storage-service';
 import {
     ActiveTimer,
     TimerRecipeRef,
+    TimerState,
     addTime,
     createAndStart,
     finish,
@@ -29,6 +30,51 @@ import {
     restart,
     resume,
 } from '../common/cooking-timer';
+
+const TIMER_STATES: ReadonlySet<string> = new Set<TimerState>(['running', 'paused', 'finished']);
+
+function isFiniteNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Whether a record read back from storage is a timer this build can run.
+ *
+ * Persisted timers outlive the build that wrote them, so anything here may
+ * come from an older or newer version, or be corrupt. A record that fails
+ * this check is dropped rather than trusted: a non-finite duration would make
+ * a timer that can never expire, which in turn would hold the tick interval
+ * open for the life of the window.
+ */
+function isStoredTimer(value: unknown): value is ActiveTimer {
+    if (typeof value !== 'object' || !value) {
+        return false;
+    }
+    const timer = value as Partial<ActiveTimer>;
+    if (typeof timer.id !== 'string' || timer.id.length === 0) {
+        return false;
+    }
+    if (typeof timer.title !== 'string') {
+        return false;
+    }
+    if (!isFiniteNumber(timer.durationSeconds) || timer.durationSeconds <= 0) {
+        return false;
+    }
+    if (typeof timer.state !== 'string' || !TIMER_STATES.has(timer.state)) {
+        return false;
+    }
+    if (!isFiniteNumber(timer.updatedAtMs)) {
+        return false;
+    }
+    if (timer.startedAtMs !== undefined && !isFiniteNumber(timer.startedAtMs)) {
+        return false;
+    }
+    if (timer.pausedRemainingSeconds !== undefined && !isFiniteNumber(timer.pausedRemainingSeconds)) {
+        return false;
+    }
+    // A running timer with no anchor could never count down.
+    return timer.state !== 'running' || isFiniteNumber(timer.startedAtMs);
+}
 
 /**
  * Owns every live cooking timer for the window. A port of the iOS app's
@@ -143,6 +189,13 @@ export class CookingTimerService implements Disposable {
                     return resume(timer, now);
                 case 'finished':
                     return restart(timer, now);
+                default:
+                    // Unreachable through the public API once `isStoredTimer`
+                    // rejects any other state on restore; kept as defence in
+                    // depth so a corrupt state can never poison `persist()`
+                    // with `undefined` (which `JSON.stringify` writes as
+                    // `null`, wiping every timer on the next restore).
+                    return timer;
             }
         });
     }
@@ -187,6 +240,7 @@ export class CookingTimerService implements Disposable {
 
     dispose(): void {
         this.stopTicking();
+        this.timers.clear();
         this.onDidChangeTimersEmitter.dispose();
         this.onDidFinishTimerEmitter.dispose();
     }
@@ -250,10 +304,28 @@ export class CookingTimerService implements Disposable {
      * the alarm belongs to the moment it expired, not to startup.
      */
     protected async restore(): Promise<void> {
-        const stored = await this.storageService.getData<ActiveTimer[]>(CookingTimerService.STORAGE_KEY, []);
+        let stored: unknown;
+        try {
+            stored = await this.storageService.getData<unknown>(CookingTimerService.STORAGE_KEY, []);
+        } catch (e) {
+            console.warn('Could not read stored cooking timers', e);
+            stored = [];
+        }
+        if (!Array.isArray(stored)) {
+            console.warn('Stored cooking timers were not a list; ignoring them');
+            stored = [];
+        }
         const now = this.now();
-        for (const timer of stored ?? []) {
-            this.timers.set(timer.id, isExpired(timer, now) ? finish(timer, now) : timer);
+        let dropped = 0;
+        for (const record of stored as unknown[]) {
+            if (!isStoredTimer(record)) {
+                dropped++;
+                continue;
+            }
+            this.timers.set(record.id, isExpired(record, now) ? finish(record, now) : record);
+        }
+        if (dropped > 0) {
+            console.warn(`Dropped ${dropped} unreadable cooking timer(s) from storage`);
         }
         this.evictOldest();
         this.updateTicking();

--- a/packages/cooklang/src/browser/cooking-timer-service.ts
+++ b/packages/cooklang/src/browser/cooking-timer-service.ts
@@ -122,6 +122,15 @@ export class CookingTimerService implements Disposable {
     protected readonly onDidFinishTimerEmitter = new Emitter<ActiveTimer>();
     readonly onDidFinishTimer: Event<ActiveTimer> = this.onDidFinishTimerEmitter.event;
 
+    protected readonly onDidStartTimerEmitter = new Emitter<ActiveTimer>();
+    /**
+     * Fired only when a timer is deliberately started, never when persisted
+     * timers reload. Anything that should follow a user's action rather than
+     * a state change — asking for notification permission, say — belongs here
+     * rather than on `onDidChangeTimers`, which also fires on restore.
+     */
+    readonly onDidStartTimer: Event<ActiveTimer> = this.onDidStartTimerEmitter.event;
+
     protected tickHandle: ReturnType<typeof setInterval> | undefined;
 
     @postConstruct()
@@ -176,13 +185,13 @@ export class CookingTimerService implements Disposable {
     start(ref: TimerRecipeRef, title: string, durationSeconds: number): ActiveTimer {
         const now = this.now();
         const existing = this.find(ref);
-        if (existing) {
-            // Re-read title, duration and scale: the recipe may have been
-            // edited or re-scaled since this timer was first started.
-            const updated = { ...existing, title, durationSeconds, recipeRef: ref };
-            return this.replace(restart(updated, now));
-        }
-        return this.replace(createAndStart(this.newId(), title, durationSeconds, now, ref));
+        // Re-read title, duration and scale: the recipe may have been edited
+        // or re-scaled since this timer was first started.
+        const started = existing
+            ? this.replace(restart({ ...existing, title, durationSeconds, recipeRef: ref }, now))
+            : this.replace(createAndStart(this.newId(), title, durationSeconds, now, ref));
+        this.onDidStartTimerEmitter.fire(started);
+        return started;
     }
 
     pause(id: string): void {
@@ -262,6 +271,7 @@ export class CookingTimerService implements Disposable {
         this.timers.clear();
         this.onDidChangeTimersEmitter.dispose();
         this.onDidFinishTimerEmitter.dispose();
+        this.onDidStartTimerEmitter.dispose();
     }
 
     // --- Internals ---

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -78,8 +78,9 @@ export default new ContainerModule(bind => {
             createRecipePreviewWidget(ctx.container, new URI(options.uri)),
     })).inSingletonScope();
 
-    // Cooking timer state, shared by the recipe preview's timer badges and
-    // (in a later task) the Timers panel.
+    // Cooking timer state, shared by the recipe preview's timer badges and the
+    // Timers panel. Bound here rather than with the other timer bindings below
+    // because the preview widget injects it, and a preview cannot open without.
     bind(CookingTimerService).toSelf().inSingletonScope();
 
     // Recipe preview commands, keybindings, toolbar, and context menu
@@ -158,9 +159,7 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(ShoppingListContribution);
     bind(TabBarToolbarContribution).toService(ShoppingListContribution);
 
-    // --- Timers ---
-    // CookingTimerService is already bound; Task 9 pulled it forward because
-    // the preview widget injects it and every preview threw without it.
+    // --- Timers --- (CookingTimerService is bound above, with the preview.)
     bind(TimerChime).toSelf().inSingletonScope();
     bind(TimerAlarmService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(TimerAlarmService);

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -29,6 +29,7 @@ import { CooklangGrammarContribution } from './cooklang-grammar-contribution';
 import { CooklangLanguageClientContribution } from './cooklang-language-client-contribution';
 import { CooklangLanguageService, CooklangLanguageServicePath } from '../common/cooklang-language-service';
 import { RECIPE_PREVIEW_WIDGET_ID, createRecipePreviewWidget } from './recipe-preview-widget';
+import { CookingTimerService } from './cooking-timer-service';
 import { RecipePreviewContribution } from './recipe-preview-contribution';
 import { ShoppingListWidget, SHOPPING_LIST_WIDGET_ID } from './shopping-list-widget';
 import { ShoppingListService } from './shopping-list-service';
@@ -72,6 +73,10 @@ export default new ContainerModule(bind => {
         createWidget: (options: { uri: string }) =>
             createRecipePreviewWidget(ctx.container, new URI(options.uri)),
     })).inSingletonScope();
+
+    // Cooking timer state, shared by the recipe preview's timer badges and
+    // (in a later task) the Timers panel.
+    bind(CookingTimerService).toSelf().inSingletonScope();
 
     // Recipe preview commands, keybindings, toolbar, and context menu
     bind(RecipePreviewContribution).toSelf().inSingletonScope();

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -35,6 +35,10 @@ import { ShoppingListWidget, SHOPPING_LIST_WIDGET_ID } from './shopping-list-wid
 import { ShoppingListService } from './shopping-list-service';
 import { RecipeReferenceResolver } from './recipe-reference-resolver';
 import { ShoppingListContribution } from './shopping-list-contribution';
+import { TimerChime } from './timer-chime';
+import { TimerAlarmService } from './timer-alarm-service';
+import { TimersWidget, TIMERS_WIDGET_ID } from './timers-widget';
+import { TimersViewContribution } from './timers-view-contribution';
 import { MENU_PREVIEW_WIDGET_ID, createMenuPreviewWidget } from './menu-preview-widget';
 import { MenuPreviewContribution } from './menu-preview-contribution';
 import { REPORT_WIDGET_ID, ReportWidgetOptions, createReportWidget } from './report-widget';
@@ -153,4 +157,19 @@ export default new ContainerModule(bind => {
     bindViewContribution(bind, ShoppingListContribution);
     bind(FrontendApplicationContribution).toService(ShoppingListContribution);
     bind(TabBarToolbarContribution).toService(ShoppingListContribution);
+
+    // --- Timers ---
+    // CookingTimerService is already bound; Task 9 pulled it forward because
+    // the preview widget injects it and every preview threw without it.
+    bind(TimerChime).toSelf().inSingletonScope();
+    bind(TimerAlarmService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(TimerAlarmService);
+
+    bind(TimersWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: TIMERS_WIDGET_ID,
+        createWidget: () => ctx.container.get<TimersWidget>(TimersWidget),
+    })).inSingletonScope();
+
+    bindViewContribution(bind, TimersViewContribution);
 });

--- a/packages/cooklang/src/browser/recipe-preview-components.spec.ts
+++ b/packages/cooklang/src/browser/recipe-preview-components.spec.ts
@@ -11,12 +11,15 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+/* eslint-disable no-null/no-null */
+
 import { expect } from 'chai';
 import * as React from '@theia/core/shared/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { Section } from '../common/recipe-types';
 import { ResolvedRecipeImages } from '../common/recipe-images';
 import { InstructionsPanel } from './recipe-preview-components';
+import { TimerBindingProvider } from './timer-components';
 
 /** A step whose only content is `text`, so it is identifiable in the markup. */
 function step(text: string, number: number): Section['content'][number] {
@@ -89,5 +92,76 @@ describe('InstructionsPanel step image indices', () => {
         const markup = render(withNote, { steps: { '0': { '1': 'second.jpg' } } });
         expect(imageForStep(markup, 'two')).to.equal('second.jpg');
         expect(imageForStep(markup, 'one')).to.be.undefined;
+    });
+});
+
+describe('InstructionsPanel timer positions', () => {
+
+    it('numbers timers within their step and steps across sections', () => {
+        const sections: Section[] = [
+            {
+                name: null,
+                content: [
+                    {
+                        type: 'step',
+                        value: {
+                            number: 1,
+                            items: [
+                                { type: 'timer', index: 0 },
+                                { type: 'text', value: ' then ' },
+                                { type: 'timer', index: 1 },
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                name: null,
+                content: [
+                    { type: 'step', value: { number: 1, items: [{ type: 'timer', index: 2 }] } },
+                ],
+            },
+        ];
+        const seen: Array<[number, number]> = [];
+        const markup = renderToStaticMarkup(
+            React.createElement(
+                TimerBindingProvider,
+                {
+                    value: {
+                        ref: (globalStepIndex: number, timerPosition: number) => {
+                            seen.push([globalStepIndex, timerPosition]);
+                            return {
+                                recipePath: 'file:///a.cook',
+                                recipeName: 'a',
+                                globalStepIndex,
+                                timerPosition,
+                                scale: 1,
+                            };
+                        },
+                        find: () => undefined,
+                        start: () => undefined,
+                        toggle: () => undefined,
+                        reset: () => undefined,
+                        addTime: () => undefined,
+                        nowMs: () => 0,
+                    },
+                },
+                React.createElement(InstructionsPanel, {
+                    sections,
+                    ingredients: [],
+                    cookware: [],
+                    timers: [
+                        { name: null, quantity: { value: { type: 'number', value: { type: 'regular', value: 5 } }, unit: 'minutes', scalable: true } },
+                        { name: null, quantity: { value: { type: 'number', value: { type: 'regular', value: 6 } }, unit: 'minutes', scalable: true } },
+                        { name: null, quantity: { value: { type: 'number', value: { type: 'regular', value: 7 } }, unit: 'minutes', scalable: true } },
+                    ],
+                    inlineQuantities: [],
+                    images: { steps: {} },
+                })
+            )
+        );
+        expect(seen).to.deep.equal([[0, 0], [0, 1], [1, 0]]);
+        expect(markup).to.contain('5 minutes');
+        expect(markup).to.contain('7 minutes');
     });
 });

--- a/packages/cooklang/src/browser/recipe-preview-components.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-components.tsx
@@ -35,6 +35,7 @@ import {
     scaleRecipe,
 } from '../common/recipe-types';
 import { ResolvedRecipeImages, lookupStepImage } from '../common/recipe-images';
+import { linkify } from '../common/recipe-links';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -109,6 +110,56 @@ function buildReferencePath(ref: RecipeReference): string {
 }
 
 // ---------------------------------------------------------------------------
+// Links
+// ---------------------------------------------------------------------------
+
+/** Opens a URL outside the preview. Supplied by the widget. */
+export type LinkOpener = (url: string) => void;
+
+const LinkOpenerContext = React.createContext<LinkOpener | undefined>(undefined);
+
+/** Wraps a subtree so the links inside it open through `value`. */
+export const LinkOpenerProvider = LinkOpenerContext.Provider;
+
+interface LinkedTextProps {
+    text: string;
+}
+
+/**
+ * Recipe text with any URLs in it turned into links. Without a
+ * {@link LinkOpenerProvider} above it the anchors still render with their
+ * `href`, they just have no click behaviour — which is what keeps this
+ * component renderable in tests.
+ */
+export const LinkedText = ({ text }: LinkedTextProps): React.ReactElement => {
+    const openLink = React.useContext(LinkOpenerContext);
+    const tokens = linkify(text);
+    if (tokens.length === 0) {
+        return <></>;
+    }
+    if (tokens.length === 1 && tokens[0].type === 'text') {
+        return <React.Fragment>{text}</React.Fragment>;
+    }
+    return (
+        <React.Fragment>
+            {tokens.map((token, idx) => token.type === 'text' ? (
+                <React.Fragment key={idx}>{token.value}</React.Fragment>
+            ) : (
+                <a key={idx} className='recipe-link' href={token.href}
+                    onClick={e => {
+                        if (openLink) {
+                            e.preventDefault();
+                            openLink(token.href);
+                        }
+                    }}>
+                    {token.value}
+                </a>
+            ))}
+        </React.Fragment>
+    );
+};
+
+// ---------------------------------------------------------------------------
 // StepItemView
 // ---------------------------------------------------------------------------
 
@@ -123,7 +174,7 @@ interface StepItemViewProps {
 const StepItemView = ({ item, ingredients, cookware, timers, inlineQuantities }: StepItemViewProps): React.ReactElement => {
     switch (item.type) {
         case 'text':
-            return <React.Fragment>{item.value}</React.Fragment>;
+            return <LinkedText text={item.value} />;
 
         case 'ingredient': {
             const ing = ingredients[item.index];
@@ -234,7 +285,7 @@ const SectionContentView = ({
     imageSrc,
 }: SectionContentViewProps): React.ReactElement => {
     if (content.type === 'text') {
-        return <div className='note-item'>{content.value}</div>;
+        return <div className='note-item'><LinkedText text={content.value} /></div>;
     }
 
     const { items, number } = content.value;
@@ -477,7 +528,7 @@ export const MetadataPills = ({ meta }: MetadataPillsProps): React.ReactElement 
         <div className='recipe-metadata'>
             {pills.map((pill, idx) => (
                 <span key={idx} className='metadata-pill'>
-                    <strong>{pill.label}:</strong> {pill.value}
+                    <strong>{pill.label}:</strong> <LinkedText text={pill.value} />
                 </span>
             ))}
         </div>

--- a/packages/cooklang/src/browser/recipe-preview-components.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-components.tsx
@@ -133,7 +133,7 @@ interface LinkedTextProps {
  */
 export const LinkedText = ({ text }: LinkedTextProps): React.ReactElement => {
     const openLink = React.useContext(LinkOpenerContext);
-    const tokens = linkify(text);
+    const tokens = React.useMemo(() => linkify(text), [text]);
     if (tokens.length === 0) {
         return <></>;
     }
@@ -619,7 +619,7 @@ export const RecipeView = ({ recipe, fileName, images, onShowSource, onAddToShop
             )}
 
             {description && (
-                <p className='recipe-description'>{description}</p>
+                <p className='recipe-description'><LinkedText text={description} /></p>
             )}
 
             <MetadataPills meta={meta} />

--- a/packages/cooklang/src/browser/recipe-preview-components.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-components.tsx
@@ -36,6 +36,7 @@ import {
 } from '../common/recipe-types';
 import { ResolvedRecipeImages, lookupStepImage } from '../common/recipe-images';
 import { linkify } from '../common/recipe-links';
+import { TimerBadge } from './timer-components';
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -83,20 +84,6 @@ function ingredientIndicesForSection(section: Section): number[] {
         }
     }
     return result;
-}
-
-/**
- * Format a timer for display. Uses the timer name when present, falls back to
- * the formatted quantity, and ultimately to an empty string.
- */
-function formatTimer(timer: Timer): string {
-    if (timer.name) {
-        return timer.name;
-    }
-    if (timer.quantity !== null) {
-        return formatQuantity(timer.quantity);
-    }
-    return '';
 }
 
 /**
@@ -169,9 +156,20 @@ interface StepItemViewProps {
     cookware: Cookware[];
     timers: Timer[];
     inlineQuantities: InlineQuantity[];
+    globalStepIndex: number;
+    /** Index of this item among the timer items of its step. */
+    timerPosition: number;
 }
 
-const StepItemView = ({ item, ingredients, cookware, timers, inlineQuantities }: StepItemViewProps): React.ReactElement => {
+const StepItemView = ({
+    item,
+    ingredients,
+    cookware,
+    timers,
+    inlineQuantities,
+    globalStepIndex,
+    timerPosition,
+}: StepItemViewProps): React.ReactElement => {
     switch (item.type) {
         case 'text':
             return <LinkedText text={item.value} />;
@@ -190,8 +188,12 @@ const StepItemView = ({ item, ingredients, cookware, timers, inlineQuantities }:
 
         case 'timer': {
             const timer = timers[item.index];
-            const displayText = timer ? formatTimer(timer) : `timer[${item.index}]`;
-            return <span className='timer-badge'>{displayText}</span>;
+            if (!timer) {
+                return <span className='timer-badge'>{`timer[${item.index}]`}</span>;
+            }
+            return (
+                <TimerBadge timer={timer} globalStepIndex={globalStepIndex} timerPosition={timerPosition} />
+            );
         }
 
         case 'inlineQuantity': {
@@ -274,6 +276,7 @@ interface SectionContentViewProps {
     timers: Timer[];
     inlineQuantities: InlineQuantity[];
     imageSrc?: string;
+    globalStepIndex: number;
 }
 
 const SectionContentView = ({
@@ -283,6 +286,7 @@ const SectionContentView = ({
     timers,
     inlineQuantities,
     imageSrc,
+    globalStepIndex,
 }: SectionContentViewProps): React.ReactElement => {
     if (content.type === 'text') {
         return <div className='note-item'><LinkedText text={content.value} /></div>;
@@ -293,16 +297,24 @@ const SectionContentView = ({
         <div className='step-item'>
             <div className='step-number'>{number}</div>
             <div className='step-content'>
-                {items.map((item, idx) => (
-                    <StepItemView
-                        key={idx}
-                        item={item}
-                        ingredients={ingredients}
-                        cookware={cookware}
-                        timers={timers}
-                        inlineQuantities={inlineQuantities}
-                    />
-                ))}
+                {(() => {
+                    let timerPosition = 0;
+                    return items.map((item, idx) => {
+                        const position = item.type === 'timer' ? timerPosition++ : 0;
+                        return (
+                            <StepItemView
+                                key={idx}
+                                item={item}
+                                ingredients={ingredients}
+                                cookware={cookware}
+                                timers={timers}
+                                inlineQuantities={inlineQuantities}
+                                globalStepIndex={globalStepIndex}
+                                timerPosition={position}
+                            />
+                        );
+                    });
+                })()}
                 <StepIngredientsSummary items={items} ingredients={ingredients} />
                 {imageSrc && (
                     <RecipeImage className='step-image' src={imageSrc} alt={`Step ${number}`} />
@@ -349,6 +361,7 @@ export const InstructionsPanel = ({
                         )}
                         {section.content.map((content, cIdx) => {
                             let imageSrc: string | undefined;
+                            const stepIndex = globalStepIndex;
                             if (content.type === 'step') {
                                 if (images) {
                                     imageSrc = lookupStepImage(images, sIdx, stepInSection, globalStepIndex);
@@ -365,6 +378,7 @@ export const InstructionsPanel = ({
                                     timers={timers}
                                     inlineQuantities={inlineQuantities}
                                     imageSrc={imageSrc}
+                                    globalStepIndex={stepIndex}
                                 />
                             );
                         })}
@@ -543,13 +557,23 @@ export interface RecipeViewProps {
     recipe: Recipe;
     fileName: string;
     images?: ResolvedRecipeImages;
+    scale: number;
+    onScaleChange: (scale: number) => void;
     onShowSource?: () => void;
     onAddToShoppingList?: (scale: number) => void;
     onNavigateToRecipe?: (referencePath: string) => void;
 }
 
-export const RecipeView = ({ recipe, fileName, images, onShowSource, onAddToShoppingList, onNavigateToRecipe }: RecipeViewProps): React.ReactElement => {
-    const [scale, setScale] = React.useState(1);
+export const RecipeView = ({
+    recipe,
+    fileName,
+    images,
+    scale,
+    onScaleChange,
+    onShowSource,
+    onAddToShoppingList,
+    onNavigateToRecipe,
+}: RecipeViewProps): React.ReactElement => {
     const meta = recipe.metadata.map;
 
     // Derive title from metadata or strip the .cook extension from the filename.
@@ -588,7 +612,7 @@ export const RecipeView = ({ recipe, fileName, images, onShowSource, onAddToShop
                             onChange={e => {
                                 const val = parseFloat(e.target.value);
                                 if (Number.isFinite(val) && val > 0) {
-                                    setScale(val);
+                                    onScaleChange(val);
                                 }
                             }}
                             title='Scale factor'

--- a/packages/cooklang/src/browser/recipe-preview-contribution.ts
+++ b/packages/cooklang/src/browser/recipe-preview-contribution.ts
@@ -51,6 +51,10 @@ export namespace CooklangPreviewCommands {
         label: 'Cooklang: Open Source',
         iconClass: 'codicon codicon-go-to-file'
     };
+    export const OPEN_PREVIEW_AT_SCALE: Command = {
+        id: 'cooklang.openPreviewAtScale',
+        label: 'Cooklang: Open Preview at Scale',
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -111,6 +115,11 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
                 isEnabled: uri => CooklangUri.isRecipe(uri),
             })
         );
+        commands.registerCommand(CooklangPreviewCommands.OPEN_PREVIEW_AT_SCALE, {
+            execute: (uri: URI | string, scale: number) => this.openPreviewAtScale(uri, scale),
+            // Invoked from the Timers panel, never from the command palette.
+            isVisible: () => false,
+        });
     }
 
     // --- TabBarToolbarContribution ---
@@ -232,6 +241,21 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
         }
 
         const preview = await this.getOrCreatePreview(uri);
+        await this.shell.addWidget(preview, { area: 'main' });
+        this.shell.activateWidget(preview.id);
+    }
+
+    /**
+     * Open (or reveal) the preview for `uri` and set its scale — the way back
+     * from a timer in the Timers panel to the recipe it came from.
+     */
+    protected async openPreviewAtScale(uri: URI | string, scale: number): Promise<void> {
+        const target = typeof uri === 'string' ? new URI(uri) : uri;
+        if (!CooklangUri.isRecipe(target)) {
+            return;
+        }
+        const preview = await this.getOrCreatePreview(target);
+        preview.setScale(scale);
         await this.shell.addWidget(preview, { area: 'main' });
         this.shell.activateWidget(preview.id);
     }

--- a/packages/cooklang/src/browser/recipe-preview-links.spec.ts
+++ b/packages/cooklang/src/browser/recipe-preview-links.spec.ts
@@ -112,6 +112,8 @@ describe('RecipeView link wiring', () => {
             React.createElement(RecipeView, {
                 recipe: recipeWith({ description: 'Adapted from https://cook.md/original' }),
                 fileName: 'Soup.cook',
+                scale: 1,
+                onScaleChange: () => undefined,
             })
         );
         expect(markup).to.contain('class="recipe-description"');

--- a/packages/cooklang/src/browser/recipe-preview-links.spec.ts
+++ b/packages/cooklang/src/browser/recipe-preview-links.spec.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MetadataPills, LinkedText } from './recipe-preview-components';
+
+describe('LinkedText', () => {
+
+    it('renders plain text unchanged', () => {
+        const markup = renderToStaticMarkup(React.createElement(LinkedText, { text: 'Simmer gently.' }));
+        expect(markup).to.equal('Simmer gently.');
+    });
+
+    it('renders an anchor for a url in step text', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(LinkedText, { text: 'Method from https://cook.md/x here' })
+        );
+        expect(markup).to.contain('<a class="recipe-link" href="https://cook.md/x">https://cook.md/x</a>');
+        expect(markup).to.contain('Method from ');
+        expect(markup).to.contain(' here');
+    });
+});
+
+describe('MetadataPills', () => {
+
+    it('links a url in a metadata value', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(MetadataPills, { meta: { source: 'https://cook.md/recipes/soup' } })
+        );
+        expect(markup).to.contain('href="https://cook.md/recipes/soup"');
+    });
+
+    it('leaves a non-url metadata value alone', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(MetadataPills, { meta: { servings: '4' } })
+        );
+        expect(markup).to.not.contain('<a');
+        expect(markup).to.contain('4');
+    });
+});

--- a/packages/cooklang/src/browser/recipe-preview-links.spec.ts
+++ b/packages/cooklang/src/browser/recipe-preview-links.spec.ts
@@ -16,8 +16,8 @@
 import { expect } from 'chai';
 import * as React from '@theia/core/shared/react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { Section } from '../common/recipe-types';
-import { MetadataPills, LinkedText, InstructionsPanel } from './recipe-preview-components';
+import { Recipe, Section } from '../common/recipe-types';
+import { MetadataPills, LinkedText, InstructionsPanel, RecipeView } from './recipe-preview-components';
 
 describe('LinkedText', () => {
 
@@ -42,13 +42,6 @@ describe('LinkedText', () => {
         expect(markup).to.contain('href="https://one.example"');
         expect(markup).to.contain('href="https://two.example"');
         expect(markup.indexOf('https://one.example')).to.be.lessThan(markup.indexOf('https://two.example'));
-    });
-
-    it('links a url in the recipe description', () => {
-        const markup = renderToStaticMarkup(
-            React.createElement(LinkedText, { text: 'Adapted from https://cook.md/original' })
-        );
-        expect(markup).to.contain('href="https://cook.md/original"');
     });
 });
 
@@ -98,5 +91,30 @@ describe('InstructionsPanel link wiring', () => {
         ]);
         expect(markup).to.contain('class="note-item"');
         expect(markup).to.contain('href="https://cook.md/notes"');
+    });
+});
+
+describe('RecipeView link wiring', () => {
+
+    function recipeWith(meta: Record<string, unknown>): Recipe {
+        return {
+            metadata: { map: meta },
+            sections: [],
+            ingredients: [],
+            cookware: [],
+            timers: [],
+            inline_quantities: [],
+        };
+    }
+
+    it('links a url in the recipe description', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(RecipeView, {
+                recipe: recipeWith({ description: 'Adapted from https://cook.md/original' }),
+                fileName: 'Soup.cook',
+            })
+        );
+        expect(markup).to.contain('class="recipe-description"');
+        expect(markup).to.contain('href="https://cook.md/original"');
     });
 });

--- a/packages/cooklang/src/browser/recipe-preview-links.spec.ts
+++ b/packages/cooklang/src/browser/recipe-preview-links.spec.ts
@@ -11,10 +11,13 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+/* eslint-disable no-null/no-null */
+
 import { expect } from 'chai';
 import * as React from '@theia/core/shared/react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { MetadataPills, LinkedText } from './recipe-preview-components';
+import { Section } from '../common/recipe-types';
+import { MetadataPills, LinkedText, InstructionsPanel } from './recipe-preview-components';
 
 describe('LinkedText', () => {
 
@@ -30,6 +33,22 @@ describe('LinkedText', () => {
         expect(markup).to.contain('<a class="recipe-link" href="https://cook.md/x">https://cook.md/x</a>');
         expect(markup).to.contain('Method from ');
         expect(markup).to.contain(' here');
+    });
+
+    it('renders every link in a string with distinct anchors', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(LinkedText, { text: 'a https://one.example b https://two.example c' })
+        );
+        expect(markup).to.contain('href="https://one.example"');
+        expect(markup).to.contain('href="https://two.example"');
+        expect(markup.indexOf('https://one.example')).to.be.lessThan(markup.indexOf('https://two.example'));
+    });
+
+    it('links a url in the recipe description', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(LinkedText, { text: 'Adapted from https://cook.md/original' })
+        );
+        expect(markup).to.contain('href="https://cook.md/original"');
     });
 });
 
@@ -48,5 +67,36 @@ describe('MetadataPills', () => {
         );
         expect(markup).to.not.contain('<a');
         expect(markup).to.contain('4');
+    });
+});
+
+describe('InstructionsPanel link wiring', () => {
+
+    function render(content: Section['content']): string {
+        return renderToStaticMarkup(
+            React.createElement(InstructionsPanel, {
+                sections: [{ name: null, content }],
+                ingredients: [],
+                cookware: [],
+                timers: [],
+                inlineQuantities: [],
+            })
+        );
+    }
+
+    it('links a url in step text', () => {
+        const markup = render([
+            { type: 'step', value: { number: 1, items: [{ type: 'text', value: 'See https://cook.md/x now' }] } },
+        ]);
+        expect(markup).to.contain('href="https://cook.md/x"');
+        expect(markup).to.contain('class="recipe-link"');
+    });
+
+    it('links a url in a note block', () => {
+        const markup = render([
+            { type: 'text', value: 'More at https://cook.md/notes' },
+        ]);
+        expect(markup).to.contain('class="note-item"');
+        expect(markup).to.contain('href="https://cook.md/notes"');
     });
 });

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -34,6 +34,9 @@ import {
 } from '../common/recipe-images';
 import { RecipeImageService } from './recipe-image-service';
 import { RecipeView, LinkOpenerProvider } from './recipe-preview-components';
+import { TimerRecipeRef } from '../common/cooking-timer';
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerBinding, TimerBindingProvider } from './timer-components';
 
 import '../../src/browser/style/recipe-preview.css';
 
@@ -84,6 +87,9 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     @inject(WindowService)
     protected readonly windowService: WindowService;
 
+    @inject(CookingTimerService)
+    protected readonly timerService: CookingTimerService;
+
     protected uri: URI;
     protected recipe: Recipe | undefined;
     protected scale = 1;
@@ -105,6 +111,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
             minScrollbarLength: 35,
         };
         this.listenToDocumentChanges();
+        this.toDispose.push(this.timerService.onDidChangeTimers(() => this.update()));
     }
 
     protected override onActivateRequest(msg: Message): void {
@@ -349,6 +356,17 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         this.update();
     };
 
+    /**
+     * Set the displayed scale from outside the React tree — used when opening a
+     * recipe from a timer that was started at a different scale.
+     */
+    setScale(scale: number): void {
+        if (Number.isFinite(scale) && scale > 0 && scale !== this.scale) {
+            this.scale = scale;
+            this.update();
+        }
+    }
+
     protected handleShowSource = (): void => {
         if (this.uri) {
             this.editorManager.open(this.uri);
@@ -373,21 +391,48 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         this.windowService.openNewWindow(url, { external: true });
     };
 
+    /** The recipe's display name, used to label timers in the Timers panel. */
+    protected recipeName(): string {
+        const name = this.recipe?.metadata.map['name'];
+        if (name !== undefined && name !== '') {
+            return String(name);
+        }
+        return (this.uri?.path.base ?? '').replace(/\.cook$/i, '');
+    }
+
+    protected readonly timerBinding: TimerBinding = {
+        ref: (globalStepIndex: number, timerPosition: number): TimerRecipeRef => ({
+            recipePath: this.uri?.toString() ?? '',
+            recipeName: this.recipeName(),
+            globalStepIndex,
+            timerPosition,
+            scale: this.scale,
+        }),
+        find: ref => this.timerService.find(ref),
+        start: (ref, title, durationSeconds) => this.timerService.start(ref, title, durationSeconds),
+        toggle: id => this.timerService.toggle(id),
+        reset: id => this.timerService.reset(id),
+        addTime: (id, seconds) => this.timerService.addTime(id, seconds),
+        nowMs: () => this.timerService.nowMs(),
+    };
+
     protected render(): React.ReactNode {
         if (this.recipe) {
             return (
-                <LinkOpenerProvider value={this.handleOpenLink}>
-                    <RecipeView
-                        recipe={this.recipe}
-                        fileName={this.uri?.path.base ?? ''}
-                        images={this.images}
-                        scale={this.scale}
-                        onScaleChange={this.handleScaleChange}
-                        onShowSource={this.handleShowSource}
-                        onAddToShoppingList={this.handleAddToShoppingList}
-                        onNavigateToRecipe={this.handleNavigateToRecipe}
-                    />
-                </LinkOpenerProvider>
+                <TimerBindingProvider value={this.timerBinding}>
+                    <LinkOpenerProvider value={this.handleOpenLink}>
+                        <RecipeView
+                            recipe={this.recipe}
+                            fileName={this.uri?.path.base ?? ''}
+                            images={this.images}
+                            scale={this.scale}
+                            onScaleChange={this.handleScaleChange}
+                            onShowSource={this.handleShowSource}
+                            onAddToShoppingList={this.handleAddToShoppingList}
+                            onNavigateToRecipe={this.handleNavigateToRecipe}
+                        />
+                    </LinkOpenerProvider>
+                </TimerBindingProvider>
             );
         }
 

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -111,12 +111,32 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
             minScrollbarLength: 35,
         };
         this.listenToDocumentChanges();
-        this.toDispose.push(this.timerService.onDidChangeTimers(() => this.update()));
+        this.toDispose.push(this.timerService.onDidChangeTimers(() => {
+            // A tick is only interesting to this preview if one of its own
+            // timers is in it. Ticks fire for every timer in the window, and a
+            // full re-render of a long recipe once a second is not free.
+            if (this.isVisible && this.hasOwnTimer()) {
+                this.update();
+            }
+        }));
     }
 
     protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.node.focus();
+    }
+
+    protected override onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        // Ticks were ignored while hidden, so the countdown may be stale.
+        this.update();
+    }
+
+    /** Whether any live timer belongs to the recipe this preview shows. */
+    protected hasOwnTimer(): boolean {
+        const path = this.uri?.toString();
+        return path !== undefined
+            && this.timerService.list().some(timer => timer.recipeRef?.recipePath === path);
     }
 
     /**
@@ -400,6 +420,11 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         return (this.uri?.path.base ?? '').replace(/\.cook$/i, '');
     }
 
+    // A property initializer, not a method: its arrow functions close over
+    // `this` but only dereference `this.timerService` when invoked, by which
+    // point property injection has run. Binding eagerly instead — e.g.
+    // `find: this.timerService.find` — would read `this.timerService` at
+    // construction time, before injection, and throw on `undefined`.
     protected readonly timerBinding: TimerBinding = {
         ref: (globalStepIndex: number, timerPosition: number): TimerRecipeRef => ({
             recipePath: this.uri?.toString() ?? '',

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -17,6 +17,7 @@ import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -32,7 +33,7 @@ import {
     RECIPE_IMAGE_EXTENSIONS,
 } from '../common/recipe-images';
 import { RecipeImageService } from './recipe-image-service';
-import { RecipeView } from './recipe-preview-components';
+import { RecipeView, LinkOpenerProvider } from './recipe-preview-components';
 
 import '../../src/browser/style/recipe-preview.css';
 
@@ -79,6 +80,9 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
 
     @inject(RecipeImageService)
     protected readonly imageService: RecipeImageService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
 
     protected uri: URI;
     protected recipe: Recipe | undefined;
@@ -359,17 +363,23 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
         open(this.openerService, targetUri);
     };
 
+    protected handleOpenLink = (url: string): void => {
+        this.windowService.openNewWindow(url, { external: true });
+    };
+
     protected render(): React.ReactNode {
         if (this.recipe) {
             return (
-                <RecipeView
-                    recipe={this.recipe}
-                    fileName={this.uri?.path.base ?? ''}
-                    images={this.images}
-                    onShowSource={this.handleShowSource}
-                    onAddToShoppingList={this.handleAddToShoppingList}
-                    onNavigateToRecipe={this.handleNavigateToRecipe}
-                />
+                <LinkOpenerProvider value={this.handleOpenLink}>
+                    <RecipeView
+                        recipe={this.recipe}
+                        fileName={this.uri?.path.base ?? ''}
+                        images={this.images}
+                        onShowSource={this.handleShowSource}
+                        onAddToShoppingList={this.handleAddToShoppingList}
+                        onNavigateToRecipe={this.handleNavigateToRecipe}
+                    />
+                </LinkOpenerProvider>
             );
         }
 

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -86,6 +86,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
 
     protected uri: URI;
     protected recipe: Recipe | undefined;
+    protected scale = 1;
     protected parseErrors: string[] = [];
     protected debounceTimer: ReturnType<typeof setTimeout> | undefined;
     protected parseSequence = 0;
@@ -343,6 +344,11 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
 
     // --- Rendering ---
 
+    protected handleScaleChange = (scale: number): void => {
+        this.scale = scale;
+        this.update();
+    };
+
     protected handleShowSource = (): void => {
         if (this.uri) {
             this.editorManager.open(this.uri);
@@ -375,6 +381,8 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
                         recipe={this.recipe}
                         fileName={this.uri?.path.base ?? ''}
                         images={this.images}
+                        scale={this.scale}
+                        onScaleChange={this.handleScaleChange}
                         onShowSource={this.handleShowSource}
                         onAddToShoppingList={this.handleAddToShoppingList}
                         onNavigateToRecipe={this.handleNavigateToRecipe}

--- a/packages/cooklang/src/browser/style/recipe-preview.css
+++ b/packages/cooklang/src/browser/style/recipe-preview.css
@@ -386,9 +386,13 @@
 }
 
 .theia-recipe-preview .timer-badge-finished {
-    background: var(--theia-editorWarning-foreground);
-    border-color: var(--theia-editorWarning-foreground);
-    color: var(--theia-editor-background);
+    /* The inputValidation warning pair is designed as background-plus-text and
+       stays legible in both themes. Using editorWarning-foreground as a
+       background instead only reached ~3.1:1 against editor-background in the
+       light theme, under the 4.5:1 needed for text this size. */
+    background: var(--theia-inputValidation-warningBackground);
+    border-color: var(--theia-inputValidation-warningBorder, var(--theia-editorWarning-foreground));
+    color: var(--theia-foreground);
 }
 
 /* Note block — styled as blockquote */

--- a/packages/cooklang/src/browser/style/recipe-preview.css
+++ b/packages/cooklang/src/browser/style/recipe-preview.css
@@ -410,3 +410,15 @@
     border-radius: 6px;
     box-shadow: 0 1px 4px var(--theia-widget-shadow);
 }
+
+/* Links found in metadata values, step text and notes */
+.theia-recipe-preview .recipe-link {
+    color: var(--theia-textLink-foreground);
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.theia-recipe-preview .recipe-link:hover {
+    color: var(--theia-textLink-activeForeground);
+    text-decoration: underline;
+}

--- a/packages/cooklang/src/browser/style/recipe-preview.css
+++ b/packages/cooklang/src/browser/style/recipe-preview.css
@@ -353,6 +353,44 @@
     white-space: nowrap;
 }
 
+.theia-recipe-preview .timer-badge-icon {
+    margin-right: 3px;
+    font-size: 0.9em;
+    vertical-align: baseline;
+}
+
+.theia-recipe-preview .timer-badge-clock {
+    font-family: var(--theia-editor-font-family, monospace);
+}
+
+.theia-recipe-preview .timer-badge-idle,
+.theia-recipe-preview .timer-badge-running,
+.theia-recipe-preview .timer-badge-paused,
+.theia-recipe-preview .timer-badge-finished {
+    cursor: pointer;
+}
+
+.theia-recipe-preview .timer-badge-idle:hover {
+    border-color: var(--theia-focusBorder);
+}
+
+.theia-recipe-preview .timer-badge-running {
+    background: var(--theia-editorInfo-foreground);
+    border-color: var(--theia-editorInfo-foreground);
+    color: var(--theia-editor-background);
+}
+
+.theia-recipe-preview .timer-badge-paused {
+    opacity: 0.7;
+    border-style: dashed;
+}
+
+.theia-recipe-preview .timer-badge-finished {
+    background: var(--theia-editorWarning-foreground);
+    border-color: var(--theia-editorWarning-foreground);
+    color: var(--theia-editor-background);
+}
+
 /* Note block — styled as blockquote */
 .theia-recipe-preview .note-item {
     padding: 8px 16px;

--- a/packages/cooklang/src/browser/style/timers.css
+++ b/packages/cooklang/src/browser/style/timers.css
@@ -40,6 +40,10 @@
     opacity: 0.75;
 }
 
+.theia-cooklang-timers .timer-row-main {
+    min-width: 0;
+}
+
 .theia-cooklang-timers .timer-row-clock {
     font-family: var(--theia-editor-font-family, monospace);
     font-size: 1.8em;
@@ -58,6 +62,8 @@
     display: inline-flex;
     align-items: center;
     gap: 4px;
+    max-width: 100%;
+    min-width: 0;
     /* A real button for keyboard and assistive tech, styled as a link. */
     background: none;
     border: none;
@@ -75,6 +81,13 @@
 
 .theia-cooklang-timers .timer-row-recipe:hover {
     text-decoration: underline;
+}
+
+.theia-cooklang-timers .timer-row-recipe-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
 }
 
 .theia-cooklang-timers .timer-row-scale {

--- a/packages/cooklang/src/browser/style/timers.css
+++ b/packages/cooklang/src/browser/style/timers.css
@@ -1,0 +1,114 @@
+.theia-cooklang-timers {
+    padding: 8px;
+    color: var(--theia-foreground);
+    font-size: var(--theia-ui-font-size1);
+}
+
+.theia-cooklang-timers .timers-empty {
+    padding: 16px 8px;
+    color: var(--theia-descriptionForeground);
+    line-height: 1.5;
+}
+
+.theia-cooklang-timers .timers-header {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.theia-cooklang-timers .timers-header-action {
+    background: none;
+    border: none;
+    color: var(--theia-textLink-foreground);
+    cursor: pointer;
+    padding: 2px 4px;
+}
+
+.theia-cooklang-timers .timer-row {
+    border: 1px solid var(--theia-panel-border);
+    border-radius: 4px;
+    padding: 8px;
+    margin-bottom: 8px;
+}
+
+.theia-cooklang-timers .timer-row-finished {
+    border-color: var(--theia-editorWarning-foreground);
+}
+
+.theia-cooklang-timers .timer-row-paused {
+    opacity: 0.75;
+}
+
+.theia-cooklang-timers .timer-row-clock {
+    font-family: var(--theia-editor-font-family, monospace);
+    font-size: 1.8em;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.theia-cooklang-timers .timer-row-title {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.theia-cooklang-timers .timer-row-recipe {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    /* A real button for keyboard and assistive tech, styled as a link. */
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--theia-textLink-foreground);
+    cursor: pointer;
+    font-size: 0.92em;
+    font-family: inherit;
+}
+
+.theia-cooklang-timers .timer-row-recipe:focus-visible {
+    outline: 1px solid var(--theia-focusBorder);
+    outline-offset: 2px;
+}
+
+.theia-cooklang-timers .timer-row-recipe:hover {
+    text-decoration: underline;
+}
+
+.theia-cooklang-timers .timer-row-scale {
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-cooklang-timers .timer-row-progress {
+    height: 3px;
+    background: var(--theia-panel-border);
+    border-radius: 2px;
+    margin: 8px 0;
+    overflow: hidden;
+}
+
+.theia-cooklang-timers .timer-row-progress-fill {
+    height: 100%;
+    background: var(--theia-progressBar-background);
+}
+
+.theia-cooklang-timers .timer-row-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.theia-cooklang-timers .timer-row-action {
+    background: none;
+    border: 1px solid var(--theia-panel-border);
+    border-radius: 3px;
+    color: var(--theia-foreground);
+    cursor: pointer;
+    padding: 2px 6px;
+}
+
+.theia-cooklang-timers .timer-row-action:hover {
+    border-color: var(--theia-focusBorder);
+}

--- a/packages/cooklang/src/browser/timer-alarm-service.ts
+++ b/packages/cooklang/src/browser/timer-alarm-service.ts
@@ -48,13 +48,15 @@ export class TimerAlarmService implements FrontendApplicationContribution {
 
     onStart(): void {
         this.timerService.onDidFinishTimer(timer => this.alarm(timer));
-        // Ask for notification permission the first time a timer exists, not at
-        // startup: nobody wants a permission prompt for opening a recipe.
-        this.timerService.onDidChangeTimers(() => this.ensurePermission());
+        // Ask for notification permission the first time the user deliberately
+        // starts a timer — not at startup, and not when persisted timers merely
+        // reload from storage — since that is the natural moment for it and
+        // nobody wants a permission prompt for opening a recipe.
+        this.timerService.onDidStartTimer(() => this.ensurePermission());
     }
 
     protected ensurePermission(): void {
-        if (this.permissionRequested || this.timerService.list().length === 0) {
+        if (this.permissionRequested) {
             return;
         }
         this.permissionRequested = true;
@@ -74,9 +76,14 @@ export class TimerAlarmService implements FrontendApplicationContribution {
                 body: timer.recipeRef?.recipeName,
                 requireInteraction: true,
                 tag: `cooklang-timer-${timer.id}`,
+                // The chime is our sound. When it is on, the OS notification
+                // sound would just layer on top of it; when it is off, the
+                // user wants silence. Either way, `silent: true` is right.
+                silent: true,
             },
             () => {
-                this.commands.executeCommand(TimersCommands.TOGGLE_VIEW.id);
+                this.commands.executeCommand(TimersCommands.TOGGLE_VIEW.id)
+                    .catch(e => console.warn('Could not reveal the Timers view', e));
             }
         );
     }

--- a/packages/cooklang/src/browser/timer-alarm-service.ts
+++ b/packages/cooklang/src/browser/timer-alarm-service.ts
@@ -12,14 +12,13 @@
 // *****************************************************************************
 
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { CommandRegistry } from '@theia/core/lib/common/command';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application-contribution';
 import { OSNotificationService } from '@theia/ai-core/lib/browser/os-notification-service';
 import { ActiveTimer } from '../common/cooking-timer';
 import { CooklangPreferences } from '../common/cooklang-preferences';
 import { CookingTimerService } from './cooking-timer-service';
 import { TimerChime } from './timer-chime';
-import { TimersCommands } from './timers-commands';
+import { TimersViewContribution } from './timers-view-contribution';
 
 /**
  * Turns a finished timer into something you notice from the other side of the
@@ -41,8 +40,8 @@ export class TimerAlarmService implements FrontendApplicationContribution {
     @inject(CooklangPreferences)
     protected readonly preferences: CooklangPreferences;
 
-    @inject(CommandRegistry)
-    protected readonly commands: CommandRegistry;
+    @inject(TimersViewContribution)
+    protected readonly timersView: TimersViewContribution;
 
     protected permissionRequested = false;
 
@@ -82,7 +81,11 @@ export class TimerAlarmService implements FrontendApplicationContribution {
                 silent: true,
             },
             () => {
-                this.commands.executeCommand(TimersCommands.TOGGLE_VIEW.id)
+                // Reveal, never toggle. The toggle command collapses the panel
+                // when the view is already the active tab — which is exactly
+                // where a cook watching a countdown is — so it would hide the
+                // thing the notification is pointing at.
+                this.timersView.openView({ activate: true })
                     .catch(e => console.warn('Could not reveal the Timers view', e));
             }
         );

--- a/packages/cooklang/src/browser/timer-alarm-service.ts
+++ b/packages/cooklang/src/browser/timer-alarm-service.ts
@@ -1,0 +1,83 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject } from '@theia/core/shared/inversify';
+import { CommandRegistry } from '@theia/core/lib/common/command';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application-contribution';
+import { OSNotificationService } from '@theia/ai-core/lib/browser/os-notification-service';
+import { ActiveTimer } from '../common/cooking-timer';
+import { CooklangPreferences } from '../common/cooklang-preferences';
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerChime } from './timer-chime';
+import { TimersCommands } from './timers-commands';
+
+/**
+ * Turns a finished timer into something you notice from the other side of the
+ * kitchen: a system notification (so it lands even when the window is in the
+ * background) and a chime.
+ */
+@injectable()
+export class TimerAlarmService implements FrontendApplicationContribution {
+
+    @inject(CookingTimerService)
+    protected readonly timerService: CookingTimerService;
+
+    @inject(OSNotificationService)
+    protected readonly notificationService: OSNotificationService;
+
+    @inject(TimerChime)
+    protected readonly chime: TimerChime;
+
+    @inject(CooklangPreferences)
+    protected readonly preferences: CooklangPreferences;
+
+    @inject(CommandRegistry)
+    protected readonly commands: CommandRegistry;
+
+    protected permissionRequested = false;
+
+    onStart(): void {
+        this.timerService.onDidFinishTimer(timer => this.alarm(timer));
+        // Ask for notification permission the first time a timer exists, not at
+        // startup: nobody wants a permission prompt for opening a recipe.
+        this.timerService.onDidChangeTimers(() => this.ensurePermission());
+    }
+
+    protected ensurePermission(): void {
+        if (this.permissionRequested || this.timerService.list().length === 0) {
+            return;
+        }
+        this.permissionRequested = true;
+        this.notificationService.requestPermission();
+    }
+
+    protected alarm(timer: ActiveTimer): void {
+        if (this.preferences['cooklang.timers.sound']) {
+            this.chime.play();
+        }
+        if (!this.preferences['cooklang.timers.notifications']) {
+            return;
+        }
+        this.notificationService.showNotification(
+            `${timer.title} — done`,
+            {
+                body: timer.recipeRef?.recipeName,
+                requireInteraction: true,
+                tag: `cooklang-timer-${timer.id}`,
+            },
+            () => {
+                this.commands.executeCommand(TimersCommands.TOGGLE_VIEW.id);
+            }
+        );
+    }
+}

--- a/packages/cooklang/src/browser/timer-chime.ts
+++ b/packages/cooklang/src/browser/timer-chime.ts
@@ -1,0 +1,79 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+
+/** Frequency in Hz and relative level for each partial of one bell strike. */
+const PARTIALS: ReadonlyArray<readonly [number, number]> = [
+    [880, 1],
+    [1320, 0.4],
+    [1760, 0.2],
+];
+
+const STRIKES = 3;
+const STRIKE_SPACING_SECONDS = 0.45;
+const STRIKE_LENGTH_SECONDS = 0.4;
+
+/**
+ * The sound a finished timer makes. Synthesized rather than shipped as an
+ * audio file: the generated webpack config has no rule for audio assets, so a
+ * `.wav` import would silently fail to bundle.
+ */
+@injectable()
+export class TimerChime {
+
+    protected context: AudioContext | undefined;
+
+    play(): void {
+        try {
+            const context = this.audioContext();
+            // A context created before any user gesture starts suspended.
+            context.resume();
+            for (let i = 0; i < STRIKES; i++) {
+                this.strike(context, context.currentTime + i * STRIKE_SPACING_SECONDS);
+            }
+        } catch (e) {
+            console.debug('Could not play the timer chime', e);
+        }
+    }
+
+    protected audioContext(): AudioContext {
+        if (!this.context) {
+            this.context = new AudioContext();
+        }
+        return this.context;
+    }
+
+    /** One bell strike: a struck-metal spectrum under an exponential decay. */
+    protected strike(context: AudioContext, at: number): void {
+        const envelope = context.createGain();
+        envelope.gain.setValueAtTime(0.0001, at);
+        envelope.gain.exponentialRampToValueAtTime(0.3, at + 0.01);
+        envelope.gain.exponentialRampToValueAtTime(0.0001, at + STRIKE_LENGTH_SECONDS);
+        envelope.connect(context.destination);
+
+        for (const [frequency, level] of PARTIALS) {
+            const oscillator = context.createOscillator();
+            oscillator.type = 'sine';
+            oscillator.frequency.setValueAtTime(frequency, at);
+
+            const partialGain = context.createGain();
+            partialGain.gain.setValueAtTime(level, at);
+
+            oscillator.connect(partialGain);
+            partialGain.connect(envelope);
+            oscillator.start(at);
+            oscillator.stop(at + STRIKE_SPACING_SECONDS);
+        }
+    }
+}

--- a/packages/cooklang/src/browser/timer-chime.ts
+++ b/packages/cooklang/src/browser/timer-chime.ts
@@ -33,14 +33,16 @@ const STRIKE_LENGTH_SECONDS = 0.4;
 export class TimerChime {
 
     protected context: AudioContext | undefined;
+    protected master: AudioNode | undefined;
 
     play(): void {
         try {
             const context = this.audioContext();
             // A context created before any user gesture starts suspended.
-            context.resume();
+            context.resume().catch(() => { /* a context that will not resume simply stays silent */ });
+            const master = this.masterOutput(context);
             for (let i = 0; i < STRIKES; i++) {
-                this.strike(context, context.currentTime + i * STRIKE_SPACING_SECONDS);
+                this.strike(context, master, context.currentTime + i * STRIKE_SPACING_SECONDS);
             }
         } catch (e) {
             console.debug('Could not play the timer chime', e);
@@ -54,13 +56,27 @@ export class TimerChime {
         return this.context;
     }
 
+    /**
+     * A compressor between the strikes and the speakers. Several timers can
+     * finish in the same second and each strike schedules three oscillators,
+     * so without this the summed gain clips into distortion.
+     */
+    protected masterOutput(context: AudioContext): AudioNode {
+        if (!this.master) {
+            const compressor = context.createDynamicsCompressor();
+            compressor.connect(context.destination);
+            this.master = compressor;
+        }
+        return this.master;
+    }
+
     /** One bell strike: a struck-metal spectrum under an exponential decay. */
-    protected strike(context: AudioContext, at: number): void {
+    protected strike(context: AudioContext, master: AudioNode, at: number): void {
         const envelope = context.createGain();
         envelope.gain.setValueAtTime(0.0001, at);
         envelope.gain.exponentialRampToValueAtTime(0.3, at + 0.01);
         envelope.gain.exponentialRampToValueAtTime(0.0001, at + STRIKE_LENGTH_SECONDS);
-        envelope.connect(context.destination);
+        envelope.connect(master);
 
         for (const [frequency, level] of PARTIALS) {
             const oscillator = context.createOscillator();

--- a/packages/cooklang/src/browser/timer-components.spec.ts
+++ b/packages/cooklang/src/browser/timer-components.spec.ts
@@ -1,0 +1,152 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/* eslint-disable no-null/no-null */
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ActiveTimer, TimerRecipeRef, createAndStart, finish, pause } from '../common/cooking-timer';
+import { Timer } from '../common/recipe-types';
+import { TimerBadge, TimerBinding, TimerBindingProvider, TimerRow } from './timer-components';
+
+const T0 = 1_700_000_000_000;
+
+function ref(): TimerRecipeRef {
+    return {
+        recipePath: 'file:///recipes/Soup.cook',
+        recipeName: 'Soup',
+        globalStepIndex: 2,
+        timerPosition: 0,
+        scale: 1,
+    };
+}
+
+function minuteTimer(minutes: number, name: string | null = null): Timer {
+    return {
+        name,
+        quantity: {
+            value: { type: 'number', value: { type: 'regular', value: minutes } },
+            unit: 'minutes',
+            scalable: true,
+        },
+    };
+}
+
+function binding(active: ActiveTimer | undefined): TimerBinding {
+    return {
+        ref: () => ref(),
+        find: () => active,
+        start: () => undefined,
+        toggle: () => undefined,
+        reset: () => undefined,
+        addTime: () => undefined,
+        nowMs: () => T0,
+    };
+}
+
+function renderBadge(timer: Timer, active: ActiveTimer | undefined): string {
+    return renderToStaticMarkup(
+        React.createElement(
+            TimerBindingProvider,
+            { value: binding(active) },
+            React.createElement(TimerBadge, { timer, globalStepIndex: 2, timerPosition: 0 })
+        )
+    );
+}
+
+describe('TimerBadge', () => {
+
+    it('renders a plain badge with no binding above it', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(TimerBadge, { timer: minuteTimer(10), globalStepIndex: 2, timerPosition: 0 })
+        );
+        expect(markup).to.contain('class="timer-badge"');
+        expect(markup).to.contain('10 minutes');
+    });
+
+    it('renders a startable badge when the timer has a duration', () => {
+        const markup = renderBadge(minuteTimer(10), undefined);
+        expect(markup).to.contain('timer-badge-idle');
+        expect(markup).to.contain('10 minutes');
+    });
+
+    it('shows the name alongside the duration', () => {
+        const markup = renderBadge(minuteTimer(10, 'sauce'), undefined);
+        expect(markup).to.contain('sauce');
+        expect(markup).to.contain('10 minutes');
+    });
+
+    it('stays a plain badge when the timer has no runnable duration', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: { value: { type: 'text', value: 'until golden' }, unit: null, scalable: false },
+        };
+        const markup = renderBadge(timer, undefined);
+        expect(markup).to.equal('<span class="timer-badge">until golden</span>');
+    });
+
+    it('shows a running countdown', () => {
+        const active = createAndStart('t1', 'sauce', 600, T0 - 90_000, ref());
+        const markup = renderBadge(minuteTimer(10, 'sauce'), active);
+        expect(markup).to.contain('timer-badge-running');
+        expect(markup).to.contain('08:30');
+    });
+
+    it('marks a paused timer', () => {
+        const active = pause(createAndStart('t1', 'sauce', 600, T0 - 90_000, ref()), T0);
+        expect(renderBadge(minuteTimer(10, 'sauce'), active)).to.contain('timer-badge-paused');
+    });
+
+    it('marks a finished timer at zero', () => {
+        const active = finish(createAndStart('t1', 'sauce', 600, T0 - 600_000, ref()), T0);
+        const markup = renderBadge(minuteTimer(10, 'sauce'), active);
+        expect(markup).to.contain('timer-badge-finished');
+        expect(markup).to.contain('00:00');
+    });
+});
+
+describe('TimerRow', () => {
+
+    function renderRow(active: ActiveTimer): string {
+        return renderToStaticMarkup(
+            React.createElement(TimerRow, {
+                timer: active,
+                nowMs: T0,
+                onToggle: () => undefined,
+                onReset: () => undefined,
+                onAddTime: () => undefined,
+                onRemove: () => undefined,
+                onOpenRecipe: () => undefined,
+            })
+        );
+    }
+
+    it('shows the countdown, the title and the recipe', () => {
+        const markup = renderRow(createAndStart('t1', 'simmer sauce', 600, T0 - 90_000, ref()));
+        expect(markup).to.contain('08:30');
+        expect(markup).to.contain('simmer sauce');
+        expect(markup).to.contain('Soup');
+    });
+
+    it('carries its state as a class', () => {
+        expect(renderRow(createAndStart('t1', 'a', 600, T0, ref()))).to.contain('timer-row-running');
+        expect(renderRow(finish(createAndStart('t1', 'a', 600, T0 - 600_000, ref()), T0)))
+            .to.contain('timer-row-finished');
+    });
+
+    it('omits the recipe link for a timer with no recipe', () => {
+        const orphan: ActiveTimer = { ...createAndStart('t1', 'a', 600, T0, ref()), recipeRef: undefined };
+        expect(renderRow(orphan)).to.not.contain('timer-row-recipe');
+    });
+});

--- a/packages/cooklang/src/browser/timer-components.spec.ts
+++ b/packages/cooklang/src/browser/timer-components.spec.ts
@@ -18,7 +18,7 @@ import * as React from '@theia/core/shared/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ActiveTimer, TimerRecipeRef, createAndStart, finish, pause } from '../common/cooking-timer';
 import { Timer } from '../common/recipe-types';
-import { TimerBadge, TimerBinding, TimerBindingProvider, TimerRow } from './timer-components';
+import { TimerBadge, TimerBinding, TimerBindingProvider, TimerRow, timerBadgeLabel } from './timer-components';
 
 const T0 = 1_700_000_000_000;
 
@@ -87,6 +87,15 @@ describe('TimerBadge', () => {
         expect(markup).to.contain('10 minutes');
     });
 
+    it('falls back to the duration when the name is empty', () => {
+        expect(timerBadgeLabel(minuteTimer(10, ''))).to.equal('10 minutes');
+        expect(renderBadge(minuteTimer(10, ''), undefined)).to.contain('10 minutes');
+    });
+
+    it('shows a bare named timer with no duration', () => {
+        expect(timerBadgeLabel({ name: 'sauce', quantity: null })).to.equal('sauce');
+    });
+
     it('stays a plain badge when the timer has no runnable duration', () => {
         const timer: Timer = {
             name: null,
@@ -108,11 +117,22 @@ describe('TimerBadge', () => {
         expect(renderBadge(minuteTimer(10, 'sauce'), active)).to.contain('timer-badge-paused');
     });
 
+    it('shows the frozen clock on a paused timer', () => {
+        const active = pause(createAndStart('t1', 'sauce', 600, T0 - 90_000, ref()), T0);
+        expect(renderBadge(minuteTimer(10, 'sauce'), active)).to.contain('08:30');
+    });
+
     it('marks a finished timer at zero', () => {
         const active = finish(createAndStart('t1', 'sauce', 600, T0 - 600_000, ref()), T0);
         const markup = renderBadge(minuteTimer(10, 'sauce'), active);
         expect(markup).to.contain('timer-badge-finished');
         expect(markup).to.contain('00:00');
+    });
+
+    it('escapes user-authored text rather than rendering it as markup', () => {
+        const markup = renderBadge(minuteTimer(10, '<img src=x onerror=alert(1)>'), undefined);
+        expect(markup).to.not.contain('<img');
+        expect(markup).to.contain('&lt;img');
     });
 });
 
@@ -148,5 +168,25 @@ describe('TimerRow', () => {
     it('omits the recipe link for a timer with no recipe', () => {
         const orphan: ActiveTimer = { ...createAndStart('t1', 'a', 600, T0, ref()), recipeRef: undefined };
         expect(renderRow(orphan)).to.not.contain('timer-row-recipe');
+    });
+
+    it('shows the scale when the recipe was not at 1x', () => {
+        const scaled: TimerRecipeRef = { ...ref(), scale: 2 };
+        const timer: ActiveTimer = { ...createAndStart('t1', 'a', 600, T0, scaled) };
+        expect(renderRow(timer)).to.contain('×2');
+    });
+
+    it('omits the recipe control when there is no handler for it', () => {
+        const markup = renderToStaticMarkup(
+            React.createElement(TimerRow, {
+                timer: createAndStart('t1', 'a', 600, T0, ref()),
+                nowMs: T0,
+                onToggle: () => undefined,
+                onReset: () => undefined,
+                onAddTime: () => undefined,
+                onRemove: () => undefined,
+            })
+        );
+        expect(markup).to.not.contain('timer-row-recipe');
     });
 });

--- a/packages/cooklang/src/browser/timer-components.tsx
+++ b/packages/cooklang/src/browser/timer-components.tsx
@@ -1,0 +1,194 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/* eslint-disable no-null/no-null */
+
+import * as React from '@theia/core/shared/react';
+import { ActiveTimer, TimerRecipeRef, remainingSeconds } from '../common/cooking-timer';
+import { Timer, formatQuantity } from '../common/recipe-types';
+import { formatClock, formatDuration, timerDurationSeconds } from '../common/timer-duration';
+
+// ---------------------------------------------------------------------------
+// Binding
+// ---------------------------------------------------------------------------
+
+/**
+ * Everything a timer badge needs from the outside world. `RecipePreviewWidget`
+ * supplies one; without it the badges render as inert decoration, which is what
+ * keeps this module testable and `recipe-preview-components.tsx` service-free.
+ */
+export interface TimerBinding {
+    /** Build the identity of the timer at this position in the open recipe. */
+    ref(globalStepIndex: number, timerPosition: number): TimerRecipeRef;
+    /** The live timer at `ref`, if one has been started. */
+    find(ref: TimerRecipeRef): ActiveTimer | undefined;
+    /** Start a new timer at `ref` with the given title and duration. */
+    start(ref: TimerRecipeRef, title: string, durationSeconds: number): void;
+    /** Pause a running timer, or resume/restart a paused or finished one. */
+    toggle(id: string): void;
+    /** Reset a timer back to its full duration, paused. */
+    reset(id: string): void;
+    /** Extend (or shorten, with a negative value) a timer's remaining time. */
+    addTime(id: string, seconds: number): void;
+    /** The current wall-clock time, in milliseconds. */
+    nowMs(): number;
+}
+
+const TimerBindingContext = React.createContext<TimerBinding | undefined>(undefined);
+
+/** Wraps a subtree so the timer badges inside it are backed by `value`. */
+export const TimerBindingProvider = TimerBindingContext.Provider;
+
+// ---------------------------------------------------------------------------
+// TimerBadge
+// ---------------------------------------------------------------------------
+
+/**
+ * The text shown on a badge that has not been started: the name and the
+ * duration together, so `~sauce{10%minutes}` reads `sauce 10 minutes` rather
+ * than hiding the duration behind the name.
+ */
+export function timerBadgeLabel(timer: Timer): string {
+    const quantity = timer.quantity ? formatQuantity(timer.quantity) : '';
+    if (timer.name && quantity) {
+        return `${timer.name} ${quantity}`;
+    }
+    return timer.name ?? quantity;
+}
+
+/** Props for {@link TimerBadge}. */
+export interface TimerBadgeProps {
+    timer: Timer;
+    globalStepIndex: number;
+    timerPosition: number;
+}
+
+/**
+ * The inline `~timer` badge in a recipe step. Renders as today's plain,
+ * unclickable `<span className='timer-badge'>` when there is no
+ * {@link TimerBindingProvider} above it, or when the timer has no runnable
+ * duration (`~{until golden}`, bare `~sauce`). Otherwise it is clickable:
+ * idle badges start the timer, and running/paused/finished badges toggle it.
+ */
+export const TimerBadge = ({ timer, globalStepIndex, timerPosition }: TimerBadgeProps): React.ReactElement => {
+    const binding = React.useContext(TimerBindingContext);
+    const label = timerBadgeLabel(timer);
+    const duration = timerDurationSeconds(timer);
+
+    if (!binding || duration === undefined) {
+        return <span className='timer-badge'>{label}</span>;
+    }
+
+    const ref = binding.ref(globalStepIndex, timerPosition);
+    const active = binding.find(ref);
+
+    if (!active) {
+        return (
+            <span className='timer-badge timer-badge-idle' role='button' tabIndex={0}
+                title={`Start a ${formatDuration(duration)} timer`}
+                onClick={() => binding.start(ref, timer.name ?? label, duration)}>
+                <span className='codicon codicon-watch timer-badge-icon'></span>
+                {label}
+            </span>
+        );
+    }
+
+    const titles: Record<string, string> = {
+        running: 'Pause timer',
+        paused: 'Resume timer',
+        finished: 'Restart timer',
+    };
+
+    return (
+        <span className={`timer-badge timer-badge-${active.state}`} role='button' tabIndex={0}
+            title={titles[active.state]}
+            onClick={() => binding.toggle(active.id)}>
+            <span className='codicon codicon-watch timer-badge-icon'></span>
+            <span className='timer-badge-clock'>{formatClock(remainingSeconds(active, binding.nowMs()))}</span>
+        </span>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// TimerRow  (one entry in the Timers panel)
+// ---------------------------------------------------------------------------
+
+/** Props for {@link TimerRow}. */
+export interface TimerRowProps {
+    timer: ActiveTimer;
+    nowMs: number;
+    onToggle: (id: string) => void;
+    onReset: (id: string) => void;
+    onAddTime: (id: string, seconds: number) => void;
+    onRemove: (id: string) => void;
+    onOpenRecipe?: (ref: TimerRecipeRef) => void;
+}
+
+/**
+ * One row of the Timers panel: the countdown, the timer's title, a link back
+ * to the recipe it came from (when it has one), a progress bar, and the
+ * add-time/toggle/reset/remove controls.
+ */
+export const TimerRow = ({
+    timer,
+    nowMs,
+    onToggle,
+    onReset,
+    onAddTime,
+    onRemove,
+    onOpenRecipe,
+}: TimerRowProps): React.ReactElement => {
+    const remaining = remainingSeconds(timer, nowMs);
+    const elapsedFraction = timer.durationSeconds > 0
+        ? Math.min(1, Math.max(0, 1 - remaining / timer.durationSeconds))
+        : 0;
+    const toggleIcon = timer.state === 'running' ? 'codicon-debug-pause' : 'codicon-play';
+    const toggleTitle = timer.state === 'running'
+        ? 'Pause'
+        : timer.state === 'paused' ? 'Resume' : 'Restart';
+
+    return (
+        <div className={`timer-row timer-row-${timer.state}`}>
+            <div className='timer-row-main'>
+                <div className='timer-row-clock'>{formatClock(remaining)}</div>
+                <div className='timer-row-title'>{timer.title}</div>
+                {timer.recipeRef && onOpenRecipe && (
+                    <a className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
+                        onClick={() => onOpenRecipe(timer.recipeRef!)}>
+                        <span className='codicon codicon-go-to-file'></span>
+                        {timer.recipeRef.recipeName}
+                        {timer.recipeRef.scale !== 1 && (
+                            <span className='timer-row-scale'>×{timer.recipeRef.scale}</span>
+                        )}
+                    </a>
+                )}
+            </div>
+            <div className='timer-row-progress'>
+                <div className='timer-row-progress-fill' style={{ width: `${elapsedFraction * 100}%` }}></div>
+            </div>
+            <div className='timer-row-actions'>
+                <button className='timer-row-action' title='Add one minute'
+                    onClick={() => onAddTime(timer.id, 60)}>+1 min</button>
+                <button className='timer-row-action' title={toggleTitle} onClick={() => onToggle(timer.id)}>
+                    <span className={`codicon ${toggleIcon}`}></span>
+                </button>
+                <button className='timer-row-action' title='Reset' onClick={() => onReset(timer.id)}>
+                    <span className='codicon codicon-debug-restart'></span>
+                </button>
+                <button className='timer-row-action' title='Delete' onClick={() => onRemove(timer.id)}>
+                    <span className='codicon codicon-trash'></span>
+                </button>
+            </div>
+        </div>
+    );
+};

--- a/packages/cooklang/src/browser/timer-components.tsx
+++ b/packages/cooklang/src/browser/timer-components.tsx
@@ -179,7 +179,7 @@ export const TimerRow = ({
                 <div className='timer-row-clock'>{formatClock(remaining)}</div>
                 <div className='timer-row-title'>{timer.title}</div>
                 {timer.recipeRef && onOpenRecipe && (
-                    <button className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
+                    <button type='button' className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
                         onClick={() => onOpenRecipe(timer.recipeRef!)}>
                         <span className='codicon codicon-go-to-file'></span>
                         {timer.recipeRef.recipeName}
@@ -193,16 +193,16 @@ export const TimerRow = ({
                 <div className='timer-row-progress-fill' style={{ width: `${(elapsedFraction * 100).toFixed(2)}%` }}></div>
             </div>
             <div className='timer-row-actions'>
-                <button className='timer-row-action' title='Add one minute'
+                <button type='button' className='timer-row-action' title='Add one minute'
                     onClick={() => onAddTime(timer.id, 60)}>+1 min</button>
-                <button className='timer-row-action' title={toggleTitle} aria-label={toggleTitle}
+                <button type='button' className='timer-row-action' title={toggleTitle} aria-label={toggleTitle}
                     onClick={() => onToggle(timer.id)}>
                     <span className={`codicon ${toggleIcon}`}></span>
                 </button>
-                <button className='timer-row-action' title='Reset' aria-label='Reset' onClick={() => onReset(timer.id)}>
+                <button type='button' className='timer-row-action' title='Reset' aria-label='Reset' onClick={() => onReset(timer.id)}>
                     <span className='codicon codicon-debug-restart'></span>
                 </button>
-                <button className='timer-row-action' title='Delete' aria-label='Delete' onClick={() => onRemove(timer.id)}>
+                <button type='button' className='timer-row-action' title='Delete' aria-label='Delete' onClick={() => onRemove(timer.id)}>
                     <span className='codicon codicon-trash'></span>
                 </button>
             </div>

--- a/packages/cooklang/src/browser/timer-components.tsx
+++ b/packages/cooklang/src/browser/timer-components.tsx
@@ -11,8 +11,6 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
-/* eslint-disable no-null/no-null */
-
 import * as React from '@theia/core/shared/react';
 import { ActiveTimer, TimerRecipeRef, remainingSeconds } from '../common/cooking-timer';
 import { Timer, formatQuantity } from '../common/recipe-types';
@@ -63,8 +61,29 @@ export function timerBadgeLabel(timer: Timer): string {
     if (timer.name && quantity) {
         return `${timer.name} ${quantity}`;
     }
-    return timer.name ?? quantity;
+    return timer.name || quantity;
 }
+
+/**
+ * Enter and Space activate a `role='button'` element. The browser does this
+ * for a real `<button>` but not for a span, so we have to.
+ */
+function activateOnKey(activate: () => void): (event: React.KeyboardEvent) => void {
+    return event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            // Space would otherwise scroll the preview.
+            event.preventDefault();
+            activate();
+        }
+    };
+}
+
+/** Tooltip shown on a started badge, per lifecycle state. */
+const BADGE_TITLES: Record<string, string> = {
+    running: 'Pause timer',
+    paused: 'Resume timer',
+    finished: 'Restart timer',
+};
 
 /** Props for {@link TimerBadge}. */
 export interface TimerBadgeProps {
@@ -93,26 +112,23 @@ export const TimerBadge = ({ timer, globalStepIndex, timerPosition }: TimerBadge
     const active = binding.find(ref);
 
     if (!active) {
+        const start = (): void => binding.start(ref, timer.name || label, duration);
         return (
             <span className='timer-badge timer-badge-idle' role='button' tabIndex={0}
                 title={`Start a ${formatDuration(duration)} timer`}
-                onClick={() => binding.start(ref, timer.name ?? label, duration)}>
+                onClick={start} onKeyDown={activateOnKey(start)}>
                 <span className='codicon codicon-watch timer-badge-icon'></span>
                 {label}
             </span>
         );
     }
 
-    const titles: Record<string, string> = {
-        running: 'Pause timer',
-        paused: 'Resume timer',
-        finished: 'Restart timer',
-    };
+    const toggle = (): void => binding.toggle(active.id);
 
     return (
         <span className={`timer-badge timer-badge-${active.state}`} role='button' tabIndex={0}
-            title={titles[active.state]}
-            onClick={() => binding.toggle(active.id)}>
+            title={BADGE_TITLES[active.state]}
+            onClick={toggle} onKeyDown={activateOnKey(toggle)}>
             <span className='codicon codicon-watch timer-badge-icon'></span>
             <span className='timer-badge-clock'>{formatClock(remainingSeconds(active, binding.nowMs()))}</span>
         </span>
@@ -163,29 +179,30 @@ export const TimerRow = ({
                 <div className='timer-row-clock'>{formatClock(remaining)}</div>
                 <div className='timer-row-title'>{timer.title}</div>
                 {timer.recipeRef && onOpenRecipe && (
-                    <a className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
+                    <button className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
                         onClick={() => onOpenRecipe(timer.recipeRef!)}>
                         <span className='codicon codicon-go-to-file'></span>
                         {timer.recipeRef.recipeName}
                         {timer.recipeRef.scale !== 1 && (
                             <span className='timer-row-scale'>×{timer.recipeRef.scale}</span>
                         )}
-                    </a>
+                    </button>
                 )}
             </div>
             <div className='timer-row-progress'>
-                <div className='timer-row-progress-fill' style={{ width: `${elapsedFraction * 100}%` }}></div>
+                <div className='timer-row-progress-fill' style={{ width: `${(elapsedFraction * 100).toFixed(2)}%` }}></div>
             </div>
             <div className='timer-row-actions'>
                 <button className='timer-row-action' title='Add one minute'
                     onClick={() => onAddTime(timer.id, 60)}>+1 min</button>
-                <button className='timer-row-action' title={toggleTitle} onClick={() => onToggle(timer.id)}>
+                <button className='timer-row-action' title={toggleTitle} aria-label={toggleTitle}
+                    onClick={() => onToggle(timer.id)}>
                     <span className={`codicon ${toggleIcon}`}></span>
                 </button>
-                <button className='timer-row-action' title='Reset' onClick={() => onReset(timer.id)}>
+                <button className='timer-row-action' title='Reset' aria-label='Reset' onClick={() => onReset(timer.id)}>
                     <span className='codicon codicon-debug-restart'></span>
                 </button>
-                <button className='timer-row-action' title='Delete' onClick={() => onRemove(timer.id)}>
+                <button className='timer-row-action' title='Delete' aria-label='Delete' onClick={() => onRemove(timer.id)}>
                     <span className='codicon codicon-trash'></span>
                 </button>
             </div>

--- a/packages/cooklang/src/browser/timer-components.tsx
+++ b/packages/cooklang/src/browser/timer-components.tsx
@@ -182,7 +182,7 @@ export const TimerRow = ({
                     <button type='button' className='timer-row-recipe' title={`Open ${timer.recipeRef.recipeName}`}
                         onClick={() => onOpenRecipe(timer.recipeRef!)}>
                         <span className='codicon codicon-go-to-file'></span>
-                        {timer.recipeRef.recipeName}
+                        <span className='timer-row-recipe-name'>{timer.recipeRef.recipeName}</span>
                         {timer.recipeRef.scale !== 1 && (
                             <span className='timer-row-scale'>×{timer.recipeRef.scale}</span>
                         )}

--- a/packages/cooklang/src/browser/timers-commands.ts
+++ b/packages/cooklang/src/browser/timers-commands.ts
@@ -1,0 +1,26 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { Command } from '@theia/core/lib/common/command';
+
+/**
+ * Commands contributed by the Timers panel. Kept in their own module so
+ * other Cooklang browser code (like the alarm service) can reference them
+ * without depending on the panel's implementation.
+ */
+export namespace TimersCommands {
+    export const TOGGLE_VIEW: Command = {
+        id: 'cooklang.toggleTimers',
+        label: 'Cooklang: Toggle Timers',
+    };
+}

--- a/packages/cooklang/src/browser/timers-view-contribution.ts
+++ b/packages/cooklang/src/browser/timers-view-contribution.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { TimersWidget, TIMERS_WIDGET_ID } from './timers-widget';
+import { TimersCommands } from './timers-commands';
+
+/**
+ * Registers the Timers panel as a view, contributing the toggle command and
+ * quick-open entry that `AbstractViewContribution` provides for free.
+ */
+@injectable()
+export class TimersViewContribution extends AbstractViewContribution<TimersWidget> {
+
+    constructor() {
+        super({
+            widgetId: TIMERS_WIDGET_ID,
+            widgetName: TimersWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'right',
+            },
+            toggleCommandId: TimersCommands.TOGGLE_VIEW.id,
+        });
+    }
+}

--- a/packages/cooklang/src/browser/timers-widget.tsx
+++ b/packages/cooklang/src/browser/timers-widget.tsx
@@ -13,6 +13,7 @@
 
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import * as React from '@theia/core/shared/react';
 import { TimerRecipeRef } from '../common/cooking-timer';
@@ -61,7 +62,32 @@ export class TimersWidget extends ReactWidget {
     protected handleAddTime = (id: string, seconds: number): void => this.timerService.addTime(id, seconds);
     protected handleRemove = (id: string): void => this.timerService.remove(id);
     protected handleRemoveFinished = (): void => this.timerService.removeFinished();
-    protected handleRemoveAll = (): void => this.timerService.removeAll();
+
+    protected handleRemoveAll = (): void => {
+        this.confirmRemoveAll().catch(e => console.warn('Could not clear the timers', e));
+    };
+
+    /**
+     * Clearing finished timers is harmless, but a running one represents
+     * something actually cooking, so ask before throwing those away.
+     */
+    protected async confirmRemoveAll(): Promise<void> {
+        const running = this.timerService.list().filter(timer => timer.state === 'running').length;
+        if (running > 0) {
+            const confirmed = await new ConfirmDialog({
+                title: 'Clear all timers',
+                msg: running === 1
+                    ? 'One timer is still running. Clearing it cannot be undone.'
+                    : `${running} timers are still running. Clearing them cannot be undone.`,
+                ok: 'Clear all',
+                cancel: 'Cancel',
+            }).open();
+            if (!confirmed) {
+                return;
+            }
+        }
+        this.timerService.removeAll();
+    }
 
     protected handleOpenRecipe = (ref: TimerRecipeRef): void => {
         this.commandRegistry.executeCommand('cooklang.openPreviewAtScale', ref.recipePath, ref.scale)

--- a/packages/cooklang/src/browser/timers-widget.tsx
+++ b/packages/cooklang/src/browser/timers-widget.tsx
@@ -112,11 +112,11 @@ export class TimersWidget extends ReactWidget {
             <div className='timers-body'>
                 <div className='timers-header'>
                     {hasFinished && (
-                        <button className='timers-header-action' onClick={this.handleRemoveFinished}>
+                        <button type='button' className='timers-header-action' onClick={this.handleRemoveFinished}>
                             Clear finished
                         </button>
                     )}
-                    <button className='timers-header-action' onClick={this.handleRemoveAll}>
+                    <button type='button' className='timers-header-action' onClick={this.handleRemoveAll}>
                         Clear all
                     </button>
                 </div>

--- a/packages/cooklang/src/browser/timers-widget.tsx
+++ b/packages/cooklang/src/browser/timers-widget.tsx
@@ -1,0 +1,109 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { CommandRegistry } from '@theia/core/lib/common/command';
+import * as React from '@theia/core/shared/react';
+import { TimerRecipeRef } from '../common/cooking-timer';
+import { CookingTimerService } from './cooking-timer-service';
+import { TimerRow } from './timer-components';
+
+import '../../src/browser/style/timers.css';
+
+export const TIMERS_WIDGET_ID = 'cooklang-timers';
+
+/**
+ * Lists every started timer across every recipe, so a timer stays visible after
+ * you scroll past its step or close its preview. A port of the iOS app's
+ * `TimersView`.
+ */
+@injectable()
+export class TimersWidget extends ReactWidget {
+
+    static readonly ID = TIMERS_WIDGET_ID;
+    static readonly LABEL = 'Timers';
+
+    @inject(CookingTimerService)
+    protected readonly timerService: CookingTimerService;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = TIMERS_WIDGET_ID;
+        this.title.label = TimersWidget.LABEL;
+        this.title.caption = TimersWidget.LABEL;
+        this.title.iconClass = 'codicon codicon-watch';
+        this.title.closable = true;
+        this.addClass('theia-cooklang-timers');
+        this.scrollOptions = {
+            suppressScrollX: true,
+            minScrollbarLength: 35,
+        };
+        this.toDispose.push(this.timerService.onDidChangeTimers(() => this.update()));
+        this.update();
+    }
+
+    protected handleToggle = (id: string): void => this.timerService.toggle(id);
+    protected handleReset = (id: string): void => this.timerService.reset(id);
+    protected handleAddTime = (id: string, seconds: number): void => this.timerService.addTime(id, seconds);
+    protected handleRemove = (id: string): void => this.timerService.remove(id);
+    protected handleRemoveFinished = (): void => this.timerService.removeFinished();
+    protected handleRemoveAll = (): void => this.timerService.removeAll();
+
+    protected handleOpenRecipe = (ref: TimerRecipeRef): void => {
+        this.commandRegistry.executeCommand('cooklang.openPreviewAtScale', ref.recipePath, ref.scale)
+            .catch(e => console.warn('Could not open recipe from timer:', e));
+    };
+
+    protected render(): React.ReactNode {
+        const timers = CookingTimerService.sortForDisplay(this.timerService.list());
+        if (timers.length === 0) {
+            return (
+                <div className='timers-empty'>
+                    No timers yet. Click a time in a recipe step to start one.
+                </div>
+            );
+        }
+        const hasFinished = timers.some(timer => timer.state === 'finished');
+        const nowMs = this.timerService.nowMs();
+        return (
+            <div className='timers-body'>
+                <div className='timers-header'>
+                    {hasFinished && (
+                        <button className='timers-header-action' onClick={this.handleRemoveFinished}>
+                            Clear finished
+                        </button>
+                    )}
+                    <button className='timers-header-action' onClick={this.handleRemoveAll}>
+                        Clear all
+                    </button>
+                </div>
+                {timers.map(timer => (
+                    <TimerRow
+                        key={timer.id}
+                        timer={timer}
+                        nowMs={nowMs}
+                        onToggle={this.handleToggle}
+                        onReset={this.handleReset}
+                        onAddTime={this.handleAddTime}
+                        onRemove={this.handleRemove}
+                        onOpenRecipe={this.handleOpenRecipe}
+                    />
+                ))}
+            </div>
+        );
+    }
+}

--- a/packages/cooklang/src/browser/timers-widget.tsx
+++ b/packages/cooklang/src/browser/timers-widget.tsx
@@ -72,13 +72,16 @@ export class TimersWidget extends ReactWidget {
      * something actually cooking, so ask before throwing those away.
      */
     protected async confirmRemoveAll(): Promise<void> {
-        const running = this.timerService.list().filter(timer => timer.state === 'running').length;
-        if (running > 0) {
+        // A paused timer is state the cook deliberately kept, so it deserves the
+        // same protection as a running one. Only an all-finished list clears
+        // without asking, because that throws nothing away.
+        const unfinished = this.timerService.list().filter(timer => timer.state !== 'finished').length;
+        if (unfinished > 0) {
             const confirmed = await new ConfirmDialog({
                 title: 'Clear all timers',
-                msg: running === 1
-                    ? 'One timer is still running. Clearing it cannot be undone.'
-                    : `${running} timers are still running. Clearing them cannot be undone.`,
+                msg: unfinished === 1
+                    ? 'One timer has not finished. Clearing it cannot be undone.'
+                    : `${unfinished} timers have not finished. Clearing them cannot be undone.`,
                 ok: 'Clear all',
                 cancel: 'Cancel',
             }).open();

--- a/packages/cooklang/src/common/cooking-timer.spec.ts
+++ b/packages/cooklang/src/common/cooking-timer.spec.ts
@@ -137,6 +137,13 @@ describe('addTime', () => {
         expect(timer.state).to.equal('paused');
         expect(remainingSeconds(timer, T0 + 700_000)).to.equal(60);
     });
+
+    it('never lets the remaining time go below zero', () => {
+        const shortened = addTime(pause(started(), T0 + 60_000), -1000, T0 + 60_000);
+        expect(remainingSeconds(shortened, T0 + 60_000)).to.equal(0);
+        const revived = addTime(finish(started(), T0 + 600_000), -60, T0 + 700_000);
+        expect(remainingSeconds(revived, T0 + 700_000)).to.equal(0);
+    });
 });
 
 describe('isExpired and fireAtMs', () => {

--- a/packages/cooklang/src/common/cooking-timer.spec.ts
+++ b/packages/cooklang/src/common/cooking-timer.spec.ts
@@ -1,0 +1,173 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import {
+    ActiveTimer,
+    TimerRecipeRef,
+    addTime,
+    createAndStart,
+    finish,
+    fireAtMs,
+    isExpired,
+    matchesRef,
+    pause,
+    remainingSeconds,
+    reset,
+    restart,
+    resume,
+} from './cooking-timer';
+
+const T0 = 1_700_000_000_000;
+
+function ref(overrides: Partial<TimerRecipeRef> = {}): TimerRecipeRef {
+    return {
+        recipePath: 'file:///recipes/Soup.cook',
+        recipeName: 'Soup',
+        globalStepIndex: 2,
+        timerPosition: 0,
+        scale: 1,
+        ...overrides,
+    };
+}
+
+function started(): ActiveTimer {
+    return createAndStart('id-1', 'simmer', 600, T0, ref());
+}
+
+describe('createAndStart', () => {
+
+    it('produces a running timer anchored to now', () => {
+        const timer = started();
+        expect(timer.state).to.equal('running');
+        expect(timer.startedAtMs).to.equal(T0);
+        expect(timer.pausedRemainingSeconds).to.equal(undefined);
+        expect(timer.durationSeconds).to.equal(600);
+        expect(timer.updatedAtMs).to.equal(T0);
+        expect(timer.recipeRef?.recipeName).to.equal('Soup');
+    });
+});
+
+describe('remainingSeconds', () => {
+
+    it('counts down while running', () => {
+        expect(remainingSeconds(started(), T0)).to.equal(600);
+        expect(remainingSeconds(started(), T0 + 90_000)).to.equal(510);
+    });
+
+    it('never goes below zero', () => {
+        expect(remainingSeconds(started(), T0 + 999_000)).to.equal(0);
+    });
+
+    it('freezes while paused', () => {
+        const paused = pause(started(), T0 + 90_000);
+        expect(remainingSeconds(paused, T0 + 90_000)).to.equal(510);
+        expect(remainingSeconds(paused, T0 + 900_000)).to.equal(510);
+    });
+
+    it('is zero once finished', () => {
+        expect(remainingSeconds(finish(started(), T0 + 600_000), T0 + 700_000)).to.equal(0);
+    });
+});
+
+describe('pause and resume', () => {
+
+    it('does not drift across repeated cycles', () => {
+        let timer = started();
+        // run 100s, pause 1000s, run 100s, pause 1000s
+        timer = pause(timer, T0 + 100_000);
+        timer = resume(timer, T0 + 1_100_000);
+        timer = pause(timer, T0 + 1_200_000);
+        timer = resume(timer, T0 + 2_200_000);
+        // 200 seconds of running have elapsed in total
+        expect(remainingSeconds(timer, T0 + 2_200_000)).to.equal(400);
+    });
+
+    it('ignores a pause on an already paused timer', () => {
+        const paused = pause(started(), T0 + 60_000);
+        expect(pause(paused, T0 + 300_000)).to.deep.equal(paused);
+    });
+
+    it('ignores a resume on a running timer', () => {
+        const running = started();
+        expect(resume(running, T0 + 60_000)).to.deep.equal(running);
+    });
+});
+
+describe('reset and restart', () => {
+
+    it('reset returns a paused timer at full duration', () => {
+        const timer = reset(pause(started(), T0 + 60_000), T0 + 70_000);
+        expect(timer.state).to.equal('paused');
+        expect(remainingSeconds(timer, T0 + 70_000)).to.equal(600);
+    });
+
+    it('restart returns a running timer at full duration', () => {
+        const timer = restart(finish(started(), T0 + 600_000), T0 + 700_000);
+        expect(timer.state).to.equal('running');
+        expect(remainingSeconds(timer, T0 + 700_000)).to.equal(600);
+        expect(remainingSeconds(timer, T0 + 760_000)).to.equal(540);
+    });
+});
+
+describe('addTime', () => {
+
+    it('extends a running timer', () => {
+        const timer = addTime(started(), 60, T0 + 60_000);
+        expect(remainingSeconds(timer, T0 + 60_000)).to.equal(600);
+    });
+
+    it('extends a paused timer', () => {
+        const timer = addTime(pause(started(), T0 + 60_000), 60, T0 + 60_000);
+        expect(remainingSeconds(timer, T0 + 60_000)).to.equal(600);
+    });
+
+    it('revives a finished timer as paused with just the added time', () => {
+        const timer = addTime(finish(started(), T0 + 600_000), 60, T0 + 700_000);
+        expect(timer.state).to.equal('paused');
+        expect(remainingSeconds(timer, T0 + 700_000)).to.equal(60);
+    });
+});
+
+describe('isExpired and fireAtMs', () => {
+
+    it('expires exactly at the end of the duration', () => {
+        expect(isExpired(started(), T0 + 599_000)).to.equal(false);
+        expect(isExpired(started(), T0 + 600_000)).to.equal(true);
+    });
+
+    it('does not expire while paused', () => {
+        expect(isExpired(pause(started(), T0 + 60_000), T0 + 10_000_000)).to.equal(false);
+    });
+
+    it('reports when a running timer will fire', () => {
+        expect(fireAtMs(started())).to.equal(T0 + 600_000);
+        expect(fireAtMs(pause(started(), T0 + 60_000))).to.equal(undefined);
+    });
+});
+
+describe('matchesRef', () => {
+
+    it('matches on recipe, step and position, ignoring scale', () => {
+        const timer = started();
+        expect(matchesRef(timer, ref({ scale: 4 }))).to.equal(true);
+        expect(matchesRef(timer, ref({ timerPosition: 1 }))).to.equal(false);
+        expect(matchesRef(timer, ref({ globalStepIndex: 3 }))).to.equal(false);
+        expect(matchesRef(timer, ref({ recipePath: 'file:///other.cook' }))).to.equal(false);
+    });
+
+    it('never matches a timer with no recipe', () => {
+        const orphan: ActiveTimer = { ...started(), recipeRef: undefined };
+        expect(matchesRef(orphan, ref())).to.equal(false);
+    });
+});

--- a/packages/cooklang/src/common/cooking-timer.ts
+++ b/packages/cooklang/src/common/cooking-timer.ts
@@ -26,7 +26,11 @@ export type TimerState = 'running' | 'paused' | 'finished';
 
 /** Where a timer came from, and how to get back there. */
 export interface TimerRecipeRef {
-    /** Full URI string of the `.cook` file. */
+    /**
+     * Full URI string of the `.cook` file, captured when the timer started.
+     * A snapshot, not a live pointer: renaming or moving the file afterwards
+     * orphans the timer from its badge, by design.
+     */
     recipePath: string;
     /** Display name of the recipe, for the panel row. */
     recipeName: string;

--- a/packages/cooklang/src/common/cooking-timer.ts
+++ b/packages/cooklang/src/common/cooking-timer.ts
@@ -1,0 +1,220 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * The live state of a cooking timer. This is a port of the iOS app's
+ * `ActiveTimer` (`Packages/Timers/Sources/Timers/Models/ActiveTimer.swift`),
+ * minus its `idle` state: here a record only exists once the timer has been
+ * started, because the Timers panel lists started timers only.
+ *
+ * Every function is pure and takes the current time as an argument, so the
+ * whole state machine is testable with a fake clock.
+ */
+
+export type TimerState = 'running' | 'paused' | 'finished';
+
+/** Where a timer came from, and how to get back there. */
+export interface TimerRecipeRef {
+    /** Full URI string of the `.cook` file. */
+    recipePath: string;
+    /** Display name of the recipe, for the panel row. */
+    recipeName: string;
+    /** Index of the step across the whole recipe, 0-based. */
+    globalStepIndex: number;
+    /** Index of this timer among the timers of that step, 0-based. */
+    timerPosition: number;
+    /** Recipe scale factor in force when the timer was started. */
+    scale: number;
+}
+
+export interface ActiveTimer {
+    id: string;
+    title: string;
+    durationSeconds: number;
+    state: TimerState;
+    /**
+     * When the timer's countdown is anchored. While running this may be in the
+     * past by more than the elapsed wall time: `resume` back-dates it so that
+     * `remainingSeconds` stays a pure function of the clock.
+     */
+    startedAtMs?: number;
+    /** Frozen remaining time; set while paused. */
+    pausedRemainingSeconds?: number;
+    recipeRef?: TimerRecipeRef;
+    updatedAtMs: number;
+}
+
+/**
+ * Creates a new timer, already running, anchored to `nowMs`.
+ */
+export function createAndStart(
+    id: string,
+    title: string,
+    durationSeconds: number,
+    nowMs: number,
+    recipeRef?: TimerRecipeRef
+): ActiveTimer {
+    return {
+        id,
+        title,
+        durationSeconds,
+        state: 'running',
+        startedAtMs: nowMs,
+        recipeRef,
+        updatedAtMs: nowMs,
+    };
+}
+
+/**
+ * The time left on `timer` at `nowMs`, in seconds. Never negative.
+ */
+export function remainingSeconds(timer: ActiveTimer, nowMs: number): number {
+    switch (timer.state) {
+        case 'running': {
+            if (timer.startedAtMs === undefined) {
+                return timer.durationSeconds;
+            }
+            const elapsed = (nowMs - timer.startedAtMs) / 1000;
+            return Math.max(0, timer.durationSeconds - elapsed);
+        }
+        case 'paused':
+            return timer.pausedRemainingSeconds ?? timer.durationSeconds;
+        case 'finished':
+            return 0;
+    }
+}
+
+/** When a running timer will fire, or `undefined` if it is not running. */
+export function fireAtMs(timer: ActiveTimer): number | undefined {
+    if (timer.state !== 'running' || timer.startedAtMs === undefined) {
+        return undefined;
+    }
+    return timer.startedAtMs + timer.durationSeconds * 1000;
+}
+
+/**
+ * Whether a running `timer` has counted all the way down by `nowMs`.
+ */
+export function isExpired(timer: ActiveTimer, nowMs: number): boolean {
+    return timer.state === 'running' && remainingSeconds(timer, nowMs) <= 0;
+}
+
+/**
+ * Freezes a running timer's remaining time. A no-op on a timer that is not
+ * running.
+ */
+export function pause(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    if (timer.state !== 'running') {
+        return timer;
+    }
+    return {
+        ...timer,
+        state: 'paused',
+        pausedRemainingSeconds: remainingSeconds(timer, nowMs),
+        startedAtMs: undefined,
+        updatedAtMs: nowMs,
+    };
+}
+
+/**
+ * Continues a paused (or finished) timer from where it left off. A no-op on
+ * a timer that is already running.
+ */
+export function resume(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    if (timer.state === 'running') {
+        return timer;
+    }
+    const remaining = timer.state === 'paused'
+        ? (timer.pausedRemainingSeconds ?? timer.durationSeconds)
+        : timer.durationSeconds;
+    // Back-date the anchor by the portion already spent, so that
+    // `remainingSeconds` needs nothing but the clock.
+    return {
+        ...timer,
+        state: 'running',
+        startedAtMs: nowMs - (timer.durationSeconds - remaining) * 1000,
+        pausedRemainingSeconds: undefined,
+        updatedAtMs: nowMs,
+    };
+}
+
+/**
+ * Marks `timer` as expired, with no time remaining.
+ */
+export function finish(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    return {
+        ...timer,
+        state: 'finished',
+        startedAtMs: undefined,
+        pausedRemainingSeconds: 0,
+        updatedAtMs: nowMs,
+    };
+}
+
+/** Back to the full duration, paused. */
+export function reset(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    return {
+        ...timer,
+        state: 'paused',
+        startedAtMs: undefined,
+        pausedRemainingSeconds: timer.durationSeconds,
+        updatedAtMs: nowMs,
+    };
+}
+
+/** Back to the full duration, running. */
+export function restart(timer: ActiveTimer, nowMs: number): ActiveTimer {
+    return resume(reset(timer, nowMs), nowMs);
+}
+
+/**
+ * Extends `timer` by `seconds`. Extending a finished timer revives it as
+ * paused, holding just the added time.
+ */
+export function addTime(timer: ActiveTimer, seconds: number, nowMs: number): ActiveTimer {
+    switch (timer.state) {
+        case 'running':
+            return {
+                ...timer,
+                startedAtMs: (timer.startedAtMs ?? nowMs) + seconds * 1000,
+                updatedAtMs: nowMs,
+            };
+        case 'paused':
+            return {
+                ...timer,
+                pausedRemainingSeconds: (timer.pausedRemainingSeconds ?? timer.durationSeconds) + seconds,
+                updatedAtMs: nowMs,
+            };
+        case 'finished':
+            return {
+                ...timer,
+                state: 'paused',
+                pausedRemainingSeconds: seconds,
+                updatedAtMs: nowMs,
+            };
+    }
+}
+
+/**
+ * Whether `timer` is the timer at `ref`'s position. The scale is deliberately
+ * ignored: re-scaling the preview must not lose a running timer.
+ */
+export function matchesRef(timer: ActiveTimer, ref: TimerRecipeRef): boolean {
+    const own = timer.recipeRef;
+    if (!own) {
+        return false;
+    }
+    return own.recipePath === ref.recipePath
+        && own.globalStepIndex === ref.globalStepIndex
+        && own.timerPosition === ref.timerPosition;
+}

--- a/packages/cooklang/src/common/cooking-timer.ts
+++ b/packages/cooklang/src/common/cooking-timer.ts
@@ -21,6 +21,7 @@
  * whole state machine is testable with a fake clock.
  */
 
+/** The phase of a started timer's lifecycle. */
 export type TimerState = 'running' | 'paused' | 'finished';
 
 /** Where a timer came from, and how to get back there. */
@@ -37,6 +38,7 @@ export interface TimerRecipeRef {
     scale: number;
 }
 
+/** The live state of a single started timer. */
 export interface ActiveTimer {
     id: string;
     title: string;
@@ -178,8 +180,9 @@ export function restart(timer: ActiveTimer, nowMs: number): ActiveTimer {
 }
 
 /**
- * Extends `timer` by `seconds`. Extending a finished timer revives it as
- * paused, holding just the added time.
+ * Extends `timer` by `seconds`, which may be negative to shorten it.
+ * Extending a finished timer revives it as paused, holding just the added
+ * time. The remaining time never goes below zero, whatever `seconds` is.
  */
 export function addTime(timer: ActiveTimer, seconds: number, nowMs: number): ActiveTimer {
     switch (timer.state) {
@@ -192,14 +195,14 @@ export function addTime(timer: ActiveTimer, seconds: number, nowMs: number): Act
         case 'paused':
             return {
                 ...timer,
-                pausedRemainingSeconds: (timer.pausedRemainingSeconds ?? timer.durationSeconds) + seconds,
+                pausedRemainingSeconds: Math.max(0, (timer.pausedRemainingSeconds ?? timer.durationSeconds) + seconds),
                 updatedAtMs: nowMs,
             };
         case 'finished':
             return {
                 ...timer,
                 state: 'paused',
-                pausedRemainingSeconds: seconds,
+                pausedRemainingSeconds: Math.max(0, seconds),
                 updatedAtMs: nowMs,
             };
     }

--- a/packages/cooklang/src/common/cooklang-preferences.ts
+++ b/packages/cooklang/src/common/cooklang-preferences.ts
@@ -31,6 +31,16 @@ export const cooklangPreferencesSchema: PreferenceSchema = {
             'type': 'string',
             'description': 'Base URL of the Cooklang nutrition service used by report templates.',
             'default': 'https://nutrition.cook.md'
+        },
+        'cooklang.timers.notifications': {
+            'type': 'boolean',
+            'description': 'Show a system notification when a recipe timer finishes.',
+            'default': true
+        },
+        'cooklang.timers.sound': {
+            'type': 'boolean',
+            'description': 'Play a sound when a recipe timer finishes.',
+            'default': true
         }
     }
 };
@@ -38,6 +48,8 @@ export const cooklangPreferencesSchema: PreferenceSchema = {
 export interface CooklangConfiguration {
     'cooklang.openInPreviewMode': boolean;
     'cooklang.nutrition.serviceUrl': string;
+    'cooklang.timers.notifications': boolean;
+    'cooklang.timers.sound': boolean;
 }
 
 export const CooklangPreferenceContribution = Symbol('CooklangPreferenceContribution');

--- a/packages/cooklang/src/common/index.ts
+++ b/packages/cooklang/src/common/index.ts
@@ -23,3 +23,6 @@ export { CooklangPreferences, bindCooklangPreferences } from './cooklang-prefere
 export * from './shopping-list-types';
 export * from './menu-types';
 export * from './report-templates';
+export * from './cooking-timer';
+export * from './timer-duration';
+export * from './recipe-links';

--- a/packages/cooklang/src/common/recipe-links.spec.ts
+++ b/packages/cooklang/src/common/recipe-links.spec.ts
@@ -1,0 +1,96 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { linkify } from './recipe-links';
+
+describe('linkify', () => {
+
+    it('returns a single text token when there is no link', () => {
+        expect(linkify('Simmer for a while.')).to.deep.equal([
+            { type: 'text', value: 'Simmer for a while.' },
+        ]);
+    });
+
+    it('returns an empty array for empty text', () => {
+        expect(linkify('')).to.deep.equal([]);
+    });
+
+    it('splits text around an http url', () => {
+        expect(linkify('See https://cooklang.org/spec now')).to.deep.equal([
+            { type: 'text', value: 'See ' },
+            { type: 'link', value: 'https://cooklang.org/spec', href: 'https://cooklang.org/spec' },
+            { type: 'text', value: ' now' },
+        ]);
+    });
+
+    it('upgrades a bare www host to https', () => {
+        expect(linkify('www.cook.md')).to.deep.equal([
+            { type: 'link', value: 'www.cook.md', href: 'https://www.cook.md' },
+        ]);
+    });
+
+    it('links a bare email address through mailto', () => {
+        expect(linkify('ask chef@cook.md')).to.deep.equal([
+            { type: 'text', value: 'ask ' },
+            { type: 'link', value: 'chef@cook.md', href: 'mailto:chef@cook.md' },
+        ]);
+    });
+
+    it('keeps an explicit mailto scheme', () => {
+        expect(linkify('mailto:chef@cook.md')).to.deep.equal([
+            { type: 'link', value: 'mailto:chef@cook.md', href: 'mailto:chef@cook.md' },
+        ]);
+    });
+
+    it('leaves trailing sentence punctuation outside the link', () => {
+        expect(linkify('Source: https://cook.md/x.')).to.deep.equal([
+            { type: 'text', value: 'Source: ' },
+            { type: 'link', value: 'https://cook.md/x', href: 'https://cook.md/x' },
+            { type: 'text', value: '.' },
+        ]);
+    });
+
+    it('leaves an unbalanced closing paren outside the link', () => {
+        expect(linkify('(see https://cook.md/x)')).to.deep.equal([
+            { type: 'text', value: '(see ' },
+            { type: 'link', value: 'https://cook.md/x', href: 'https://cook.md/x' },
+            { type: 'text', value: ')' },
+        ]);
+    });
+
+    it('keeps a balanced paren inside the link', () => {
+        expect(linkify('https://en.wikipedia.org/wiki/Roux_(cooking)')).to.deep.equal([
+            {
+                type: 'link',
+                value: 'https://en.wikipedia.org/wiki/Roux_(cooking)',
+                href: 'https://en.wikipedia.org/wiki/Roux_(cooking)',
+            },
+        ]);
+    });
+
+    it('finds several links in one run of text', () => {
+        const tokens = linkify('a https://one.example b https://two.example c');
+        expect(tokens.filter(t => t.type === 'link').map(t => t.value)).to.deep.equal([
+            'https://one.example',
+            'https://two.example',
+        ]);
+        expect(tokens).to.have.length(5);
+    });
+
+    it('does not mistake a plain colon or a decimal for a link', () => {
+        expect(linkify('Cook: 1.5 hours')).to.deep.equal([
+            { type: 'text', value: 'Cook: 1.5 hours' },
+        ]);
+    });
+});

--- a/packages/cooklang/src/common/recipe-links.spec.ts
+++ b/packages/cooklang/src/common/recipe-links.spec.ts
@@ -93,4 +93,49 @@ describe('linkify', () => {
             { type: 'text', value: 'Cook: 1.5 hours' },
         ]);
     });
+
+    it('does not emit a link when trimming eats the scheme', () => {
+        expect(linkify('mailto:.')).to.deep.equal([{ type: 'text', value: 'mailto:.' }]);
+        expect(linkify('www..')).to.deep.equal([{ type: 'text', value: 'www..' }]);
+        expect(linkify('Check www.: it works')).to.deep.equal([
+            { type: 'text', value: 'Check www.: it works' },
+        ]);
+    });
+
+    it('reproduces the input exactly, whatever the tokens', () => {
+        const inputs = [
+            '',
+            '.',
+            'www.',
+            'mailto:.',
+            'https://',
+            'https://a.example',
+            'a https://b.example',
+            'https://a.example b',
+            'https://a.example https://a.example',
+            'Boil at 100°C — see https://a.example/√ for why.',
+            'no links at all',
+            'bare @ sign and a lone www without a dot',
+        ];
+        for (const input of inputs) {
+            const rebuilt = linkify(input).map(token => token.value).join('');
+            expect(rebuilt, `round trip of ${JSON.stringify(input)}`).to.equal(input);
+        }
+    });
+
+    it('stays linear on long input without links', function (): void {
+        this.timeout(5000);
+        const haystack = `${'a.'.repeat(100_000)} end`;
+        const started = Date.now();
+        expect(linkify(haystack)).to.have.length(1);
+        expect(Date.now() - started, 'linkify should not backtrack quadratically').to.be.lessThan(1000);
+    });
+
+    it('stays linear when trimming a long run of brackets', function (): void {
+        this.timeout(5000);
+        const haystack = `https://a.example${')'.repeat(50_000)}`;
+        const started = Date.now();
+        linkify(haystack);
+        expect(Date.now() - started, 'trimTrailing should not rescan per character').to.be.lessThan(1000);
+    });
 });

--- a/packages/cooklang/src/common/recipe-links.ts
+++ b/packages/cooklang/src/common/recipe-links.ts
@@ -11,11 +11,13 @@
 // See LICENSE-AGPL for the full license text.
 // *****************************************************************************
 
+/** A run of plain, non-link text. */
 export interface TextToken {
     type: 'text';
     value: string;
 }
 
+/** A run of text that should be rendered as a clickable link. */
 export interface LinkToken {
     type: 'link';
     /** The text as written in the recipe. */
@@ -24,18 +26,32 @@ export interface LinkToken {
     href: string;
 }
 
+/** One token produced by {@link linkify}: either plain text or a link. */
 export type LinkifyToken = TextToken | LinkToken;
 
 /**
  * Matches, in order: an explicit http(s) URL, a bare `www.` host, an explicit
  * `mailto:`, and a bare email address. Deliberately greedy up to whitespace or
  * a quote/angle bracket; trailing punctuation is trimmed afterwards.
+ *
+ * Two adjacent links with no separating whitespace collapse into a single
+ * token (e.g. the greedy `https?://` alternative swallows a `www.` host that
+ * immediately follows it). That is a known and accepted ambiguity, not an
+ * oversight.
+ *
+ * The `(?<!...)` lookbehind on the bare-email alternative is purely a
+ * performance guard, not a semantic requirement: without it, a long run of
+ * local-part characters with no `@` (a hash, a base64 paste, a run-on word)
+ * makes the engine retry the greedy character class from every offset inside
+ * the run, which is quadratic in the run's length. The lookbehind stops a
+ * match attempt from starting partway through such a run, so only the run's
+ * first offset does real backtracking work.
  */
 const LINK_PATTERN = new RegExp([
     'https?://[^\\s<>"\']+',
     'www\\.[^\\s<>"\']+',
     'mailto:[^\\s<>"\']+',
-    '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
+    '(?<![A-Za-z0-9._%+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
 ].join('|'), 'g');
 
 const TRAILING_PUNCTUATION = '.,;:!?';
@@ -53,30 +69,35 @@ function count(text: string, character: string): number {
 /**
  * Drop characters a writer meant as prose rather than as part of the URL: a
  * full stop that ends the sentence, or a closing bracket that was never opened
- * inside the URL itself.
+ * inside the URL itself. Counts brackets once up front and adjusts
+ * incrementally rather than rescanning the shrinking value on every
+ * character, which keeps this linear in the length of `match`.
  */
 function trimTrailing(match: string): string {
-    let value = match;
-    for (;;) {
-        const last = value.charAt(value.length - 1);
-        if (last === '') {
-            break;
-        }
+    let end = match.length;
+    const openParens = count(match, '(');
+    let closeParens = count(match, ')');
+    const openBrackets = count(match, '[');
+    let closeBrackets = count(match, ']');
+    while (end > 0) {
+        const last = match.charAt(end - 1);
         if (TRAILING_PUNCTUATION.includes(last)) {
-            value = value.slice(0, -1);
+            end--;
             continue;
         }
-        if (last === ')' && count(value, ')') > count(value, '(')) {
-            value = value.slice(0, -1);
+        if (last === ')' && closeParens > openParens) {
+            closeParens--;
+            end--;
             continue;
         }
-        if (last === ']' && count(value, ']') > count(value, '[')) {
-            value = value.slice(0, -1);
+        if (last === ']' && closeBrackets > openBrackets) {
+            closeBrackets--;
+            end--;
             continue;
         }
         break;
     }
-    return value;
+    return match.substring(0, end);
 }
 
 function hrefFor(value: string): string {
@@ -87,6 +108,23 @@ function hrefFor(value: string): string {
         return `https://${value}`;
     }
     return `mailto:${value}`;
+}
+
+/**
+ * Whether a match still looks like a link after {@link trimTrailing} has had
+ * its way with it. Trimming can eat a scheme down to nothing meaningful —
+ * `mailto:.` becomes `mailto`, `www..` becomes `www` — and those must render
+ * as plain text rather than as an anchor pointing somewhere nonsensical.
+ */
+function isUsableLink(value: string): boolean {
+    if (/^https?:\/\//i.test(value)) {
+        return value.replace(/^https?:\/\//i, '').length > 0;
+    }
+    if (/^www\./i.test(value)) {
+        return value.length > 'www.'.length;
+    }
+    const address = /^mailto:/i.test(value) ? value.substring('mailto:'.length) : value;
+    return /^[^@\s]+@[^@\s]+\.[^@\s.]+$/.test(address);
 }
 
 /**
@@ -104,7 +142,7 @@ export function linkify(text: string): LinkifyToken[] {
     while (match) {
         const start = match.index;
         const value = trimTrailing(match[0]);
-        if (value.length > 0) {
+        if (isUsableLink(value)) {
             if (start > cursor) {
                 tokens.push({ type: 'text', value: text.substring(cursor, start) });
             }

--- a/packages/cooklang/src/common/recipe-links.ts
+++ b/packages/cooklang/src/common/recipe-links.ts
@@ -1,0 +1,121 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+export interface TextToken {
+    type: 'text';
+    value: string;
+}
+
+export interface LinkToken {
+    type: 'link';
+    /** The text as written in the recipe. */
+    value: string;
+    /** The absolute URL to open. */
+    href: string;
+}
+
+export type LinkifyToken = TextToken | LinkToken;
+
+/**
+ * Matches, in order: an explicit http(s) URL, a bare `www.` host, an explicit
+ * `mailto:`, and a bare email address. Deliberately greedy up to whitespace or
+ * a quote/angle bracket; trailing punctuation is trimmed afterwards.
+ */
+const LINK_PATTERN = new RegExp([
+    'https?://[^\\s<>"\']+',
+    'www\\.[^\\s<>"\']+',
+    'mailto:[^\\s<>"\']+',
+    '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
+].join('|'), 'g');
+
+const TRAILING_PUNCTUATION = '.,;:!?';
+
+function count(text: string, character: string): number {
+    let total = 0;
+    for (const c of text) {
+        if (c === character) {
+            total++;
+        }
+    }
+    return total;
+}
+
+/**
+ * Drop characters a writer meant as prose rather than as part of the URL: a
+ * full stop that ends the sentence, or a closing bracket that was never opened
+ * inside the URL itself.
+ */
+function trimTrailing(match: string): string {
+    let value = match;
+    for (;;) {
+        const last = value.charAt(value.length - 1);
+        if (last === '') {
+            break;
+        }
+        if (TRAILING_PUNCTUATION.includes(last)) {
+            value = value.slice(0, -1);
+            continue;
+        }
+        if (last === ')' && count(value, ')') > count(value, '(')) {
+            value = value.slice(0, -1);
+            continue;
+        }
+        if (last === ']' && count(value, ']') > count(value, '[')) {
+            value = value.slice(0, -1);
+            continue;
+        }
+        break;
+    }
+    return value;
+}
+
+function hrefFor(value: string): string {
+    if (/^https?:\/\//i.test(value) || /^mailto:/i.test(value)) {
+        return value;
+    }
+    if (/^www\./i.test(value)) {
+        return `https://${value}`;
+    }
+    return `mailto:${value}`;
+}
+
+/**
+ * Split `text` into plain runs and links. Text with no links yields a single
+ * text token; empty text yields no tokens at all.
+ */
+export function linkify(text: string): LinkifyToken[] {
+    if (text.length === 0) {
+        return [];
+    }
+    const tokens: LinkifyToken[] = [];
+    let cursor = 0;
+    LINK_PATTERN.lastIndex = 0;
+    let match = LINK_PATTERN.exec(text);
+    while (match) {
+        const start = match.index;
+        const value = trimTrailing(match[0]);
+        if (value.length > 0) {
+            if (start > cursor) {
+                tokens.push({ type: 'text', value: text.substring(cursor, start) });
+            }
+            tokens.push({ type: 'link', value, href: hrefFor(value) });
+            cursor = start + value.length;
+            LINK_PATTERN.lastIndex = cursor;
+        }
+        match = LINK_PATTERN.exec(text);
+    }
+    if (cursor < text.length) {
+        tokens.push({ type: 'text', value: text.substring(cursor) });
+    }
+    return tokens;
+}

--- a/packages/cooklang/src/common/timer-duration.spec.ts
+++ b/packages/cooklang/src/common/timer-duration.spec.ts
@@ -124,6 +124,12 @@ describe('formatClock', () => {
     it('clamps negatives to zero', () => {
         expect(formatClock(-5)).to.equal('00:00');
     });
+
+    it('treats non-finite input as zero', () => {
+        expect(formatClock(NaN)).to.equal('00:00');
+        expect(formatClock(Infinity)).to.equal('00:00');
+        expect(formatClock(-Infinity)).to.equal('00:00');
+    });
 });
 
 describe('formatDuration', () => {
@@ -137,5 +143,10 @@ describe('formatDuration', () => {
 
     it('renders zero explicitly', () => {
         expect(formatDuration(0)).to.equal('0 sec');
+    });
+
+    it('treats non-finite input as zero', () => {
+        expect(formatDuration(NaN)).to.equal('0 sec');
+        expect(formatDuration(Infinity)).to.equal('0 sec');
     });
 });

--- a/packages/cooklang/src/common/timer-duration.spec.ts
+++ b/packages/cooklang/src/common/timer-duration.spec.ts
@@ -1,0 +1,141 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/* eslint-disable no-null/no-null */
+
+import { expect } from 'chai';
+import { Timer } from './recipe-types';
+import { timerDurationSeconds, formatClock, formatDuration } from './timer-duration';
+
+/** A timer with a plain numeric quantity, e.g. `~name{value%unit}`. */
+function numberTimer(value: number, unit: string | null, name: string | null = null): Timer {
+    return {
+        name,
+        quantity: {
+            value: { type: 'number', value: { type: 'regular', value } },
+            unit,
+            scalable: true,
+        },
+    };
+}
+
+describe('timerDurationSeconds', () => {
+
+    it('reads the unit from its first character', () => {
+        expect(timerDurationSeconds(numberTimer(30, 'seconds'))).to.equal(30);
+        expect(timerDurationSeconds(numberTimer(10, 'minutes'))).to.equal(600);
+        expect(timerDurationSeconds(numberTimer(2, 'hours'))).to.equal(7200);
+        expect(timerDurationSeconds(numberTimer(3, 'days'))).to.equal(259200);
+    });
+
+    it('accepts abbreviated and capitalised units', () => {
+        expect(timerDurationSeconds(numberTimer(10, 'min'))).to.equal(600);
+        expect(timerDurationSeconds(numberTimer(10, 'M'))).to.equal(600);
+        expect(timerDurationSeconds(numberTimer(1, 'hr'))).to.equal(3600);
+    });
+
+    it('keeps fractional values', () => {
+        expect(timerDurationSeconds(numberTimer(1.5, 'hours'))).to.equal(5400);
+    });
+
+    it('resolves fractions', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: {
+                value: { type: 'number', value: { type: 'fraction', value: { whole: 1, num: 1, den: 2, err: 0 } } },
+                unit: 'hours',
+                scalable: true,
+            },
+        };
+        expect(timerDurationSeconds(timer)).to.equal(5400);
+    });
+
+    it('uses the start of a range', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: {
+                value: {
+                    type: 'range',
+                    value: {
+                        start: { type: 'regular', value: 50 },
+                        end: { type: 'regular', value: 60 },
+                    },
+                },
+                unit: 'minutes',
+                scalable: true,
+            },
+        };
+        expect(timerDurationSeconds(timer)).to.equal(3000);
+    });
+
+    it('uses the first number of a text quantity, which is how the parser returns ranges', () => {
+        const timer: Timer = {
+            name: null,
+            quantity: { value: { type: 'text', value: '50-60' }, unit: 'minutes', scalable: false },
+        };
+        expect(timerDurationSeconds(timer)).to.equal(3000);
+    });
+
+    it('returns undefined when the timer cannot be run', () => {
+        // ~{until golden}: text quantity, no unit
+        expect(timerDurationSeconds({
+            name: null,
+            quantity: { value: { type: 'text', value: 'until golden' }, unit: null, scalable: false },
+        })).to.equal(undefined);
+        // ~sauce: a name and nothing else
+        expect(timerDurationSeconds({ name: 'sauce', quantity: null })).to.equal(undefined);
+        // an unrecognised unit
+        expect(timerDurationSeconds(numberTimer(10, 'cups'))).to.equal(undefined);
+        // a zero or negative duration is not a timer
+        expect(timerDurationSeconds(numberTimer(0, 'minutes'))).to.equal(undefined);
+    });
+});
+
+describe('formatClock', () => {
+
+    it('shows minutes and seconds by default', () => {
+        expect(formatClock(0)).to.equal('00:00');
+        expect(formatClock(62)).to.equal('01:02');
+        expect(formatClock(600)).to.equal('10:00');
+    });
+
+    it('adds hours only when there are hours', () => {
+        expect(formatClock(3930)).to.equal('01:05:30');
+    });
+
+    it('adds days at 24 hours and above', () => {
+        expect(formatClock(4 * 86400 + 8 * 3600 + 5 * 60 + 30)).to.equal('4d 08:05:30');
+    });
+
+    it('rounds up, so a countdown never shows a value it has not reached', () => {
+        expect(formatClock(0.2)).to.equal('00:01');
+    });
+
+    it('clamps negatives to zero', () => {
+        expect(formatClock(-5)).to.equal('00:00');
+    });
+});
+
+describe('formatDuration', () => {
+
+    it('renders the largest units first and skips empty ones', () => {
+        expect(formatDuration(600)).to.equal('10 min');
+        expect(formatDuration(330)).to.equal('5 min 30 sec');
+        expect(formatDuration(3900)).to.equal('1 hour 5 min');
+        expect(formatDuration(4 * 86400 + 8 * 3600)).to.equal('4 day 8 hour');
+    });
+
+    it('renders zero explicitly', () => {
+        expect(formatDuration(0)).to.equal('0 sec');
+    });
+});

--- a/packages/cooklang/src/common/timer-duration.ts
+++ b/packages/cooklang/src/common/timer-duration.ts
@@ -1,0 +1,153 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/* eslint-disable no-null/no-null */
+
+import { NumberValue, Quantity, QuantityValue, Timer } from './recipe-types';
+
+/**
+ * Seconds per unit, keyed by the unit's first character. This mirrors the iOS
+ * app's `CookingTimerUnit`, which also matches on the first character so that
+ * `m`, `min` and `minutes` all mean the same thing.
+ */
+const UNIT_SECONDS: Record<string, number> = {
+    s: 1,
+    m: 60,
+    h: 3600,
+    d: 86400,
+};
+
+function unitSeconds(unit: string | null): number | undefined {
+    if (!unit) {
+        return undefined;
+    }
+    const first = unit.trim().charAt(0).toLowerCase();
+    return UNIT_SECONDS[first];
+}
+
+function numberValueToNumber(value: NumberValue): number {
+    switch (value.type) {
+        case 'regular':
+            return value.value;
+        case 'fraction': {
+            const { whole, num, den } = value.value;
+            return den === 0 ? whole : whole + num / den;
+        }
+    }
+}
+
+/**
+ * The first number in `text`. The parser hands ranges written as
+ * `~{50-60%minutes}` back as the text `'50-60'`, and the iOS app takes the
+ * first value; we do the same so both apps start the same timer.
+ */
+function firstNumberInText(text: string): number | undefined {
+    const match = /\d+(?:\.\d+)?/.exec(text);
+    return match ? parseFloat(match[0]) : undefined;
+}
+
+function quantityValueToNumber(value: QuantityValue): number | undefined {
+    switch (value.type) {
+        case 'number':
+            return numberValueToNumber(value.value);
+        case 'range':
+            return numberValueToNumber(value.value.start);
+        case 'text':
+            return firstNumberInText(value.value);
+    }
+}
+
+/**
+ * The runnable duration of `quantity` in whole seconds, or `undefined` when it
+ * does not describe a duration (no unit, no number, or a non-time unit).
+ */
+export function quantityDurationSeconds(quantity: Quantity | null): number | undefined {
+    if (quantity === null || quantity === undefined) {
+        return undefined;
+    }
+    const multiplier = unitSeconds(quantity.unit);
+    if (multiplier === undefined) {
+        return undefined;
+    }
+    const value = quantityValueToNumber(quantity.value);
+    if (value === undefined || !Number.isFinite(value) || value <= 0) {
+        return undefined;
+    }
+    return Math.round(value * multiplier);
+}
+
+/**
+ * The runnable duration of `timer`, or `undefined` when the timer cannot be
+ * run — `~{until golden}` and bare named timers like `~sauce` have no duration
+ * and stay as plain decoration in the preview.
+ */
+export function timerDurationSeconds(timer: Timer): number | undefined {
+    return quantityDurationSeconds(timer.quantity);
+}
+
+interface DurationParts {
+    days: number;
+    hours: number;
+    minutes: number;
+    seconds: number;
+}
+
+function splitDuration(totalSeconds: number): DurationParts {
+    const total = Math.max(0, totalSeconds);
+    return {
+        days: Math.floor(total / 86400),
+        hours: Math.floor((total % 86400) / 3600),
+        minutes: Math.floor((total % 3600) / 60),
+        seconds: total % 60,
+    };
+}
+
+function pad(value: number): string {
+    return String(value).padStart(2, '0');
+}
+
+/**
+ * A countdown clock: `10:00`, `01:05:30`, `4d 08:05:30`. Rounds up, so a
+ * counter started at 10 minutes reads `10:00` rather than `09:59`.
+ */
+export function formatClock(totalSeconds: number): string {
+    const { days, hours, minutes, seconds } = splitDuration(Math.ceil(totalSeconds));
+    if (days > 0) {
+        return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    if (hours > 0) {
+        return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    return `${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * A human-readable duration: `10 min`, `5 min 30 sec`, `1 hour 5 min`.
+ */
+export function formatDuration(totalSeconds: number): string {
+    const { days, hours, minutes, seconds } = splitDuration(Math.round(totalSeconds));
+    const parts: string[] = [];
+    if (days > 0) {
+        parts.push(`${days} day`);
+    }
+    if (hours > 0) {
+        parts.push(`${hours} hour`);
+    }
+    if (minutes > 0) {
+        parts.push(`${minutes} min`);
+    }
+    if (seconds > 0) {
+        parts.push(`${seconds} sec`);
+    }
+    return parts.length === 0 ? '0 sec' : parts.join(' ');
+}

--- a/packages/cooklang/src/common/timer-duration.ts
+++ b/packages/cooklang/src/common/timer-duration.ts
@@ -103,7 +103,7 @@ interface DurationParts {
 }
 
 function splitDuration(totalSeconds: number): DurationParts {
-    const total = Math.max(0, totalSeconds);
+    const total = Number.isFinite(totalSeconds) ? Math.max(0, totalSeconds) : 0;
     return {
         days: Math.floor(total / 86400),
         hours: Math.floor((total % 86400) / 3600),
@@ -119,6 +119,7 @@ function pad(value: number): string {
 /**
  * A countdown clock: `10:00`, `01:05:30`, `4d 08:05:30`. Rounds up, so a
  * counter started at 10 minutes reads `10:00` rather than `09:59`.
+ * Non-finite input (`NaN`, `Infinity`) is treated as zero.
  */
 export function formatClock(totalSeconds: number): string {
     const { days, hours, minutes, seconds } = splitDuration(Math.ceil(totalSeconds));
@@ -133,6 +134,7 @@ export function formatClock(totalSeconds: number): string {
 
 /**
  * A human-readable duration: `10 min`, `5 min 30 sec`, `1 hour 5 min`.
+ * Non-finite input (`NaN`, `Infinity`) is treated as zero.
  */
 export function formatDuration(totalSeconds: number): string {
     const { days, hours, minutes, seconds } = splitDuration(Math.round(totalSeconds));


### PR DESCRIPTION
Closes #95.

From a trialing user: *"Taking inspiration from the Obsidian Cooklang plugin, could you make the urls clickable, and timers that actually work"*. The preview was built assuming people cook from the mobile app; this makes it possible to cook from the editor.

## Summary

- **Clickable URLs** in metadata pill values, step text, note blocks and the recipe description, opening in the system browser.
- **Runnable timers**: click a `~timer` badge in a step to start it, click again to pause, resume or restart. Timers with no numeric duration (`~{until golden}`) stay inert, as before.
- **Timers panel** in the right sidebar listing every started timer across recipes, each with a link back to its recipe *at the scale it was started at*, plus `+1 min`, play/pause, reset and delete.
- **Persistence** across reloads and restarts. A timer that expired while the app was closed comes back finished, without replaying its alarm.
- **OS notification and a chime** when a timer finishes, so it lands with the window backgrounded. Both are individually switchable via `cooklang.timers.sound` and `cooklang.timers.notifications`.

The design is a deliberate port of the iOS app's `Packages/Timers` (`ActiveTimer`, `TimerManager`, `TimerStorage`, `DurationFormatter`, `TimerCellView`), so both apps start the same timer from the same recipe and behave the same way.

Design: `docs/superpowers/specs/2026-09-01-recipe-preview-timers-and-links-design.md`
Plan: `docs/superpowers/plans/2026-09-01-recipe-preview-timers-and-links.md`

## Notable decisions

- `recipe-preview-components.tsx` and `timer-components.tsx` stay free of dependency injection — timer behaviour and the link opener arrive through React context. That keeps them renderable with `renderToStaticMarkup`, which is the only way they can be tested: a spec that transitively reaches `@theia/monaco` aborts the whole mocha run with a `.css` ESM error.
- The chime is synthesized with the Web Audio API rather than shipped as an audio file, because the generated webpack config has no audio asset rule.
- `restore()` validates every persisted record and drops what it cannot run. An unvalidated non-finite duration produced a timer that could never expire and an interval that never stopped.
- The finish notification *reveals* the Timers view rather than toggling it — the toggle collapses the panel when it is already the active tab, which is exactly where someone watching a countdown is.

## Test plan

`281 passing` in `@theia/cooklang`; compile and lint clean; the Electron app bundles and the new stylesheets reach the frontend bundle.

Manually verified in the running app:

- [x] Metadata `source` URL and `author` email are links and open the system browser
- [x] URLs in step text, notes and the description are links
- [x] `~{10%seconds}` and `~dough{15%seconds}` are clickable; `~{until thick}` is not
- [x] `~{50-60%minutes}` shows the range and starts a 50-minute timer
- [x] Click to start, pause, resume; badge states readable in light and dark themes
- [x] Enter and Space activate a focused badge; panel row controls are keyboard reachable
- [x] Panel lists running timers with recipe name and all four controls; truncates cleanly at a narrow sidebar
- [x] "Clear all" confirms when a timer is running or paused, clears instantly when all are finished
- [x] Scale 2, start a timer, click its recipe link — preview opens at scale 2
- [x] Timer finishes with the window backgrounded: notification and chime; clicking the notification reveals the panel rather than collapsing it
- [x] Reload mid-countdown keeps the timer; quit and relaunch past the deadline returns it finished with no replayed alarm
- [x] `cooklang.timers.sound` off notifies silently

## Note

`app/proto/cookbot.proto` is included as a separate commit. It was picked up by the proto sync during `npm run bundle` and is unrelated to this feature.

https://claude.ai/code/session_017FjxPhqHLqfLniqfFZjZHP