### PR TITLE
fix: six Sentry issues from alpha.38-.42

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.spec.ts
@@ -14,8 +14,21 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import 'reflect-metadata';
+
 import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { ReactNode } from '@theia/core/shared/react';
+import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
+import { ToolCallResult } from '@theia/ai-core';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
+import { ToolCallPartRenderer } from './toolcall-part-renderer';
+
+disableJSDOM();
 
 describe('condenseArguments', () => {
 
@@ -271,6 +284,55 @@ describe('formatArgsForTooltip', () => {
         const result = formatArgsForTooltip(args);
         expect(result.value).to.contain('\\[0\\]');
         expect(result.value).to.contain('\\[1\\]');
+    });
+
+});
+
+describe('ToolCallPartRenderer.renderResult', () => {
+
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    class TestRenderer extends ToolCallPartRenderer {
+        renderFor(result: ToolCallResult): ReactNode {
+            return this.renderResult({ result } as ToolCallChatResponseContent);
+        }
+    }
+
+    const renderer = new TestRenderer();
+
+    const asElement = (node: ReactNode): React.ReactElement => node as React.ReactElement;
+
+    it('renders a plain object whose "content" is a string as JSON, not as content parts', () => {
+        // The shape returned by the cookbot `fetchUrl` tool: a legal `object`
+        // ToolCallResult that happens to use `content` for something that is
+        // not a list of ToolCallContentResult.
+        const result = { content: 'the page text', title: 'A Recipe' };
+
+        const node = asElement(renderer.renderFor(result));
+
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('renders a JSON *string* whose parsed "content" is a string as JSON', () => {
+        // Tool handlers hand back strings; `renderResult` parses them first.
+        const result = { content: 'the page text', title: 'A Recipe' };
+
+        const node = asElement(renderer.renderFor(JSON.stringify(result)));
+
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('still renders a real ToolCallContent result as content parts', () => {
+        const result = { content: [{ type: 'text', text: 'hello' }] };
+
+        const node = asElement(renderer.renderFor(result));
+
+        expect(node.type).to.equal('div');
+        expect(node.props.className).to.equal('theia-toolCall-response-content');
+        expect(node.props.children).to.have.length(1);
     });
 
 });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -25,7 +25,7 @@ import { ToolConfirmation, useToolConfirmationState } from './tool-confirmation'
 import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ResponseNode } from '../chat-tree-view';
 import { useMarkdownRendering } from './markdown-part-renderer';
-import { ToolCallResult, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
+import { isToolCallContent, ToolCallResult, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
 
@@ -80,7 +80,7 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
         if (typeof result !== 'object' || result === null) {
             return <pre>{String(result)}</pre>;
         }
-        if ('content' in result) {
+        if (isToolCallContent(result)) {
             return <div className='theia-toolCall-response-content'>
                 {result.content.map((content, idx) => {
                     switch (content.type) {

--- a/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
@@ -12,8 +12,8 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { LanguageModelStreamResponse, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core/lib/common';
-import { CookbotChatChunk, CookbotInitResult } from '../common/cookbot-protocol';
+import { LanguageModelMessage, LanguageModelStreamResponse, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core/lib/common';
+import { CookbotChatChunk, CookbotInitResult, CookbotMessageParam } from '../common/cookbot-protocol';
 import { CookbotLanguageModel } from './cookbot-language-model';
 import { CookbotSessionInitializer } from './cookbot-session-initializer';
 
@@ -462,4 +462,56 @@ describe('CookbotLanguageModel empty responses', () => {
         expect(thrown?.message).to.contain('too long');
         expect(thrown?.message).to.contain('new chat');
     });
+});
+
+describe('CookbotLanguageModel thinking blocks', () => {
+
+    function transform(messages: LanguageModelMessage[]): CookbotMessageParam[] {
+        const model = createModel(new FakeGrpcClient());
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (model as any).transformMessages(messages);
+    }
+
+    const thinking = (thought: string, signature: string): LanguageModelMessage =>
+        ({ actor: 'ai', type: 'thinking', thinking: thought, signature }) as LanguageModelMessage;
+
+    const text = (content: string): LanguageModelMessage =>
+        ({ actor: 'user', type: 'text', text: content }) as LanguageModelMessage;
+
+    it('keeps a signed thinking block', () => {
+        const raw = transform([thinking('weighing options', 'sig-abc')]);
+
+        expect(raw).to.have.length(1);
+        expect(raw[0].content[0]).to.deep.include({
+            type: 'thinking',
+            thinking: 'weighing options',
+            signature: 'sig-abc'
+        });
+    });
+
+    it('drops an unsigned thinking block rather than sending an empty signature', () => {
+        // Anthropic answers a blank signature with
+        // `messages.N.content.0: Invalid \`signature\` in \`thinking\` block`,
+        // and since the history is re-sent every turn that 400 is permanent.
+        const raw = transform([thinking('interrupted before the signature arrived', '')]);
+
+        expect(raw).to.be.empty;
+    });
+
+    it('drops a thinking block whose signature is missing entirely', () => {
+        const raw = transform([
+            { actor: 'ai', type: 'thinking', thinking: 'no signature field' } as LanguageModelMessage
+        ]);
+
+        expect(raw).to.be.empty;
+    });
+
+    it('keeps the rest of the turn when an unsigned thinking block is dropped', () => {
+        const raw = transform([thinking('unsigned', ''), text('what next?')]);
+
+        expect(raw).to.have.length(1);
+        expect(raw[0].role).to.equal('user');
+        expect(raw[0].content[0]).to.deep.include({ type: 'text', text: 'what next?' });
+    });
+
 });

--- a/packages/cooklang-ai/src/node/cookbot-language-model.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.ts
@@ -454,14 +454,24 @@ export class CookbotLanguageModel implements LanguageModel {
             }
 
             if (LanguageModelMessage.isThinkingMessage(msg)) {
-                raw.push({
-                    role: 'assistant',
-                    content: [{
-                        type: 'thinking',
-                        thinking: msg.thinking,
-                        signature: msg.signature || '',
-                    }],
-                });
+                // A thinking block is only replayable with the signature the
+                // model issued for it. A stream cut short before its
+                // `signature_delta` leaves one behind unsigned, and sending
+                // that with a blank signature earns
+                // `messages.N.content.0: Invalid \`signature\` in \`thinking\` block` -
+                // permanently, because the history is re-sent every turn. Drop
+                // it instead: losing the reasoning costs this turn's context,
+                // sending it costs the whole session.
+                if (msg.signature) {
+                    raw.push({
+                        role: 'assistant',
+                        content: [{
+                            type: 'thinking',
+                            thinking: msg.thinking,
+                            signature: msg.signature,
+                        }],
+                    });
+                }
                 continue;
             }
 

--- a/packages/cooklang-native/index.d.ts
+++ b/packages/cooklang-native/index.d.ts
@@ -62,6 +62,17 @@ export declare function checkedSet(entriesJson: string): Array<string>
  */
 export declare function findRecipe(baseDir: string, name: string): string | null
 /**
+ * Resolve a recipe by name (with or without extension) inside `base_dir` using
+ * `cooklang-find`'s lookup rules — the same rules `findRecipe` uses to read the
+ * content, so a reference that renders in the preview resolves to the very file
+ * the preview read. Returns the absolute path, or `null` if nothing matches.
+ *
+ * Callers must not reconstruct this path themselves: `cooklang-find` decides the
+ * search order, which extensions to try (`.cook` then `.menu`) and how a bare
+ * name maps onto the tree, and those rules are not reproducible from a name.
+ */
+export declare function findRecipePath(baseDir: string, name: string): string | null
+/**
  * Title and step images for the recipe at `recipe_path`, discovered with
  * `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
  *

--- a/packages/cooklang-native/index.js
+++ b/packages/cooklang-native/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, recipeImages, compactChecked, searchRecipes, parsePantry, checkPantry, renderReport } = nativeBinding
+const { parse, generateShoppingList, parseMenu, LspServer, startSync, stopSync, getSyncStatus, onSyncStatusChanged, parseShoppingList, writeShoppingList, parseChecked, writeCheckEntry, checkedSet, findRecipe, findRecipePath, recipeImages, compactChecked, searchRecipes, parsePantry, checkPantry, renderReport } = nativeBinding
 
 module.exports.parse = parse
 module.exports.generateShoppingList = generateShoppingList
@@ -326,6 +326,7 @@ module.exports.parseChecked = parseChecked
 module.exports.writeCheckEntry = writeCheckEntry
 module.exports.checkedSet = checkedSet
 module.exports.findRecipe = findRecipe
+module.exports.findRecipePath = findRecipePath
 module.exports.recipeImages = recipeImages
 module.exports.compactChecked = compactChecked
 module.exports.searchRecipes = searchRecipes

--- a/packages/cooklang-native/src/lib.rs
+++ b/packages/cooklang-native/src/lib.rs
@@ -949,6 +949,25 @@ pub fn napi_find_recipe(base_dir: String, name: String) -> napi::Result<Option<S
     }
 }
 
+/// Resolve a recipe by name (with or without extension) inside `base_dir` using
+/// `cooklang-find`'s lookup rules — the same rules `findRecipe` uses to read the
+/// content, so a reference that renders in the preview resolves to the very file
+/// the preview read. Returns the absolute path, or `null` if nothing matches.
+///
+/// Callers must not reconstruct this path themselves: `cooklang-find` decides the
+/// search order, which extensions to try (`.cook` then `.menu`) and how a bare
+/// name maps onto the tree, and those rules are not reproducible from a name.
+#[napi(js_name = "findRecipePath")]
+pub fn napi_find_recipe_path(base_dir: String, name: String) -> napi::Result<Option<String>> {
+    let base = Utf8PathBuf::from(base_dir);
+    let recipe_name = Utf8PathBuf::from(name);
+    match cooklang_find::get_recipe([base], recipe_name) {
+        Ok(entry) => Ok(entry.path().map(|path| path.to_string())),
+        Err(cooklang_find::fetcher::FetchError::InvalidPath(_)) => Ok(None),
+        Err(e) => Err(napi::Error::from_reason(format!("findRecipePath: {e}"))),
+    }
+}
+
 /// Title and step images for the recipe at `recipe_path`, discovered with
 /// `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
 ///
@@ -1389,6 +1408,61 @@ mod workspace_tools_tests {
         );
         ws.write("Week.menu", "= Monday\n@./Pancakes{2}\n");
         ws
+    }
+
+    #[test]
+    fn find_recipe_path_resolves_a_top_level_recipe_by_bare_name() {
+        let ws = temp_workspace();
+        let path = napi_find_recipe_path(ws.base_dir(), "Pancakes".to_string()).unwrap();
+        assert!(
+            path.as_deref().is_some_and(|p| p.ends_with("Pancakes.cook")),
+            "expected Pancakes.cook, got {path:?}"
+        );
+    }
+
+    #[test]
+    fn find_recipe_path_resolves_a_recipe_in_a_subdirectory() {
+        // The case the preview widgets got wrong by resolving against the
+        // workspace root: the reference names a nested recipe.
+        let ws = temp_workspace();
+        let path = napi_find_recipe_path(ws.base_dir(), "Dinner/Salmon Bowl".to_string()).unwrap();
+        assert!(
+            path.as_deref()
+                .is_some_and(|p| p.ends_with("Dinner/Salmon Bowl.cook")),
+            "expected Dinner/Salmon Bowl.cook, got {path:?}"
+        );
+    }
+
+    #[test]
+    fn find_recipe_path_resolves_a_menu_not_just_cook() {
+        // A hardcoded `+ '.cook'` in the caller can never reach this file.
+        let ws = temp_workspace();
+        let path = napi_find_recipe_path(ws.base_dir(), "Week".to_string()).unwrap();
+        assert!(
+            path.as_deref().is_some_and(|p| p.ends_with("Week.menu")),
+            "expected Week.menu, got {path:?}"
+        );
+    }
+
+    #[test]
+    fn find_recipe_path_returns_none_for_a_missing_recipe() {
+        let ws = temp_workspace();
+        let path = napi_find_recipe_path(ws.base_dir(), "No Such Recipe".to_string()).unwrap();
+        assert_eq!(path, None);
+    }
+
+    #[test]
+    fn find_recipe_path_agrees_with_find_recipe() {
+        // The path and the content must come from the same file, or the preview
+        // would render one recipe and navigate to another.
+        let ws = temp_workspace();
+        let path = napi_find_recipe_path(ws.base_dir(), "Pancakes".to_string())
+            .unwrap()
+            .expect("path");
+        let content = napi_find_recipe(ws.base_dir(), "Pancakes".to_string())
+            .unwrap()
+            .expect("content");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), content);
     }
 
     fn search(ws: &TempWs, query: &str) -> Vec<serde_json::Value> {

--- a/packages/cooklang-telemetry/src/common/telemetry-options.spec.ts
+++ b/packages/cooklang-telemetry/src/common/telemetry-options.spec.ts
@@ -64,8 +64,14 @@ describe('buildOptions', () => {
             exception: { values: [{ value: 'failed at /Users/jane/Recipes/x.cook' }] },
             extra: { recipeContent: 'Add @salt{}' }
         });
-        expect(scrubbed.exception!.values![0].value).to.equal('failed at ~/Recipes/x.cook');
-        expect(scrubbed.extra).to.not.have.property('recipeContent');
+        expect(scrubbed!.exception!.values![0].value).to.equal('failed at ~/Recipes/x.cook');
+        expect(scrubbed!.extra).to.not.have.property('recipeContent');
+    });
+
+    it('drops unactionable events instead of reporting them', () => {
+        const options = buildOptions({ release: '0.0.0', packaged: true, homeDir: '/Users/jane' });
+        const dropped = options.beforeSend({ exception: { values: [{ value: 'write EIO' }] } });
+        expect(dropped).to.be.undefined;
     });
 
     it('scrubs breadcrumbs through beforeBreadcrumb', () => {

--- a/packages/cooklang-telemetry/src/common/telemetry-options.ts
+++ b/packages/cooklang-telemetry/src/common/telemetry-options.ts
@@ -12,6 +12,7 @@
 // *****************************************************************************
 
 import { ScrubbableBreadcrumb, ScrubbableEvent, scrubBreadcrumb, scrubEvent } from './scrub';
+import { isUnactionableError } from './unactionable-errors';
 
 /**
  * Sentry DSN for the Cook Editor project. A DSN is write-only and not a
@@ -51,7 +52,8 @@ export interface TelemetryOptions {
     release: string;
     environment: string;
     sendDefaultPii: false;
-    beforeSend(event: ScrubbableEvent): ScrubbableEvent;
+    /** Returns `undefined` to drop the event rather than report it. */
+    beforeSend(event: ScrubbableEvent): ScrubbableEvent | undefined;
     beforeBreadcrumb(breadcrumb: ScrubbableBreadcrumb): ScrubbableBreadcrumb;
 }
 
@@ -63,7 +65,7 @@ export function buildOptions(args: BuildOptionsArgs): TelemetryOptions {
         release: args.release,
         environment: args.packaged ? 'production' : 'development',
         sendDefaultPii: false,
-        beforeSend: event => scrubEvent(event, scrubOptions),
+        beforeSend: event => isUnactionableError(event) ? undefined : scrubEvent(event, scrubOptions),
         beforeBreadcrumb: breadcrumb => scrubBreadcrumb(breadcrumb, scrubOptions)
     };
 }

--- a/packages/cooklang-telemetry/src/common/unactionable-errors.spec.ts
+++ b/packages/cooklang-telemetry/src/common/unactionable-errors.spec.ts
@@ -1,0 +1,49 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ScrubbableEvent } from './scrub';
+import { isUnactionableError } from './unactionable-errors';
+
+const withException = (value: string): ScrubbableEvent => ({ exception: { values: [{ value }] } });
+
+describe('isUnactionableError', () => {
+
+    it('drops a broken stdout pipe reported through the console integration', () => {
+        expect(isUnactionableError(withException('write EIO'))).to.be.true;
+        expect(isUnactionableError(withException('write EPIPE'))).to.be.true;
+    });
+
+    it('keeps a real filesystem IO failure', () => {
+        // Node words a failed file write differently, and that one is ours to fix.
+        expect(isUnactionableError(withException("EIO: i/o error, write '/Volumes/x/a.cook'"))).to.be.false;
+        expect(isUnactionableError(withException('Unable to write file \'.shopping-list\''))).to.be.false;
+    });
+
+    it('keeps errors that merely mention the phrase', () => {
+        expect(isUnactionableError(withException('Failed to write EIO handler config'))).to.be.false;
+    });
+
+    it('keeps an event with no exception', () => {
+        expect(isUnactionableError({})).to.be.false;
+        expect(isUnactionableError({ exception: { values: [] } })).to.be.false;
+        expect(isUnactionableError({ exception: { values: [{}] } })).to.be.false;
+    });
+
+    it('drops when any exception in the chain is a broken pipe', () => {
+        expect(isUnactionableError({
+            exception: { values: [{ value: 'write EIO' }, { value: 'wrapper' }] }
+        })).to.be.true;
+    });
+
+});

--- a/packages/cooklang-telemetry/src/common/unactionable-errors.ts
+++ b/packages/cooklang-telemetry/src/common/unactionable-errors.ts
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { ScrubbableEvent } from './scrub';
+
+/**
+ * A write to a stdout/stderr pipe nothing is reading any more.
+ *
+ * Sentry wraps `console.*`, so once the pipe is gone every console call throws
+ * and is captured as an error - which is why these arrive attributed to
+ * `console.error` / `console.debug` inside Sentry's own bundle rather than to
+ * any code of ours. A packaged app whose launching terminal has closed produces
+ * them in bursts and there is nothing to fix in response.
+ *
+ * Anchored deliberately: this is the exact text Node gives a failed stream
+ * write. A real file-write failure reads `EIO: i/o error, write '<path>'` and
+ * must still be reported.
+ */
+const BROKEN_PIPE_WRITE = /^write E(IO|PIPE)$/;
+
+/**
+ * Whether `event` describes something no change to the app could prevent, and
+ * so should never reach Sentry.
+ *
+ * Keep this list short and each entry anchored. A filter that is too broad
+ * hides real regressions, and nothing tells you it happened.
+ */
+export function isUnactionableError(event: ScrubbableEvent): boolean {
+    const values = event.exception?.values;
+    if (!values) {
+        return false;
+    }
+    return values.some(({ value }) => value !== undefined && BROKEN_PIPE_WRITE.test(value));
+}

--- a/packages/cooklang-telemetry/src/electron-main/cooklang-telemetry-electron-main-module.ts
+++ b/packages/cooklang-telemetry/src/electron-main/cooklang-telemetry-electron-main-module.ts
@@ -37,8 +37,10 @@ if (shouldInitialize({
         release: options.release,
         environment: options.environment,
         sendDefaultPii: options.sendDefaultPii,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        beforeSend: event => options.beforeSend(event as any) as any,
+        // Sentry drops an event when `beforeSend` returns null; internally we use
+        // undefined for "no event", so translate at the boundary.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-null/no-null
+        beforeSend: event => (options.beforeSend(event as any) ?? null) as any,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         beforeBreadcrumb: breadcrumb => options.beforeBreadcrumb(breadcrumb as any) as any
     });

--- a/packages/cooklang-telemetry/src/node/cooklang-telemetry-backend-module.ts
+++ b/packages/cooklang-telemetry/src/node/cooklang-telemetry-backend-module.ts
@@ -47,8 +47,10 @@ if (shouldInitialize({
         release: options.release,
         environment: options.environment,
         sendDefaultPii: options.sendDefaultPii,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        beforeSend: event => options.beforeSend(event as any) as any,
+        // Sentry drops an event when `beforeSend` returns null; internally we use
+        // undefined for "no event", so translate at the boundary.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-null/no-null
+        beforeSend: event => (options.beforeSend(event as any) ?? null) as any,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         beforeBreadcrumb: breadcrumb => options.beforeBreadcrumb(breadcrumb as any) as any
     });

--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -34,6 +34,7 @@ import { RecipePreviewContribution } from './recipe-preview-contribution';
 import { ShoppingListWidget, SHOPPING_LIST_WIDGET_ID } from './shopping-list-widget';
 import { ShoppingListService } from './shopping-list-service';
 import { RecipeReferenceResolver } from './recipe-reference-resolver';
+import { RecipeNavigator } from './recipe-navigator';
 import { ShoppingListContribution } from './shopping-list-contribution';
 import { TimerChime } from './timer-chime';
 import { TimerAlarmService } from './timer-alarm-service';
@@ -147,6 +148,7 @@ export default new ContainerModule(bind => {
 
     // Shopping list
     bind(RecipeReferenceResolver).toSelf().inSingletonScope();
+    bind(RecipeNavigator).toSelf().inSingletonScope();
     bind(ShoppingListService).toSelf().inSingletonScope();
 
     bind(ShoppingListWidget).toSelf();

--- a/packages/cooklang/src/browser/menu-preview-widget.tsx
+++ b/packages/cooklang/src/browser/menu-preview-widget.tsx
@@ -16,16 +16,15 @@ import { Message } from '@theia/core/shared/@lumino/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { CommandRegistry } from '@theia/core/lib/common/command';
-import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import * as React from '@theia/core/shared/react';
 import { CooklangLanguageService, COOKLANG_LANGUAGE_ID } from '../common';
 import { MenuParseResult } from '../common/menu-types';
 import { MenuView } from './menu-preview-components';
+import { RecipeNavigator } from './recipe-navigator';
 
 import '../../src/browser/style/menu-preview.css';
 
@@ -61,14 +60,11 @@ export class MenuPreviewWidget extends ReactWidget implements Navigatable {
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
 
-    @inject(OpenerService)
-    protected readonly openerService: OpenerService;
-
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
 
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
+    @inject(RecipeNavigator)
+    protected readonly navigator: RecipeNavigator;
 
     protected uri: URI;
     protected menuResult: MenuParseResult | undefined;
@@ -206,7 +202,7 @@ export class MenuPreviewWidget extends ReactWidget implements Navigatable {
 
     protected handleShowSource = (): void => {
         if (this.uri) {
-            this.editorManager.open(this.uri);
+            this.navigator.openSource(this.uri);
         }
     };
 
@@ -220,16 +216,7 @@ export class MenuPreviewWidget extends ReactWidget implements Navigatable {
     };
 
     protected handleNavigateToRecipe = (referencePath: string): void => {
-        const root = this.workspaceService.tryGetRoots()[0];
-        if (!root) {
-            return;
-        }
-        const rootUri = new URI(root.resource.toString());
-        const cleanPath = referencePath.startsWith('./')
-            ? referencePath.slice(2)
-            : referencePath;
-        const targetUri = rootUri.resolve(cleanPath + '.cook');
-        open(this.openerService, targetUri);
+        this.navigator.navigate(referencePath);
     };
 
     protected render(): React.ReactNode {

--- a/packages/cooklang/src/browser/recipe-navigator.spec.ts
+++ b/packages/cooklang/src/browser/recipe-navigator.spec.ts
@@ -1,0 +1,154 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { RecipeNavigator } from './recipe-navigator';
+
+/** Records what the navigator asked of each collaborator. */
+class TestNavigator extends RecipeNavigator {
+
+    opened: string[] = [];
+    warnings: string[] = [];
+    lookups: Array<{ baseDir: string; name: string }> = [];
+
+    openError: Error | undefined;
+
+    constructor(
+        protected readonly resolveTo: (name: string) => string | undefined | Error,
+        root: string | false = '/ws'
+    ) {
+        super();
+        this.workspaceService = {
+            tryGetRoots: () => root === false ? [] : [{ resource: new URI(root).withScheme('file') }]
+        } as unknown as RecipeNavigator['workspaceService'];
+        this.languageService = {
+            findRecipePath: async (baseDir: string, name: string) => {
+                this.lookups.push({ baseDir, name });
+                const outcome = this.resolveTo(name);
+                if (outcome instanceof Error) {
+                    throw outcome;
+                }
+                return outcome;
+            }
+        } as unknown as RecipeNavigator['languageService'];
+        this.messageService = {
+            warn: (text: string) => { this.warnings.push(text); return Promise.resolve(undefined); }
+        } as unknown as RecipeNavigator['messageService'];
+    }
+
+    protected override async openUri(uri: URI): Promise<void> {
+        if (this.openError) {
+            throw this.openError;
+        }
+        this.opened.push(uri.toString());
+    }
+
+    protected override async openInEditor(uri: URI): Promise<void> {
+        if (this.openError) {
+            throw this.openError;
+        }
+        this.opened.push(`editor:${uri.toString()}`);
+    }
+}
+
+describe('RecipeNavigator', () => {
+
+    it('opens the path cooklang-find resolved, not one rebuilt from the reference', async () => {
+        const nav = new TestNavigator(() => '/ws/Dinner/Salmon Bowl.cook');
+
+        await nav.navigate('Salmon Bowl');
+
+        expect(nav.opened).to.have.length(1);
+        expect(new URI(nav.opened[0]).path.fsPath()).to.equal('/ws/Dinner/Salmon Bowl.cook');
+        expect(nav.warnings).to.be.empty;
+    });
+
+    it('passes the workspace root and the reference verbatim to the lookup', async () => {
+        // No './' stripping, no '.cook' appended: cooklang-find owns those rules.
+        const nav = new TestNavigator(() => '/ws/Pancakes.cook');
+
+        await nav.navigate('./Pancakes');
+
+        expect(nav.lookups).to.deep.equal([{ baseDir: '/ws', name: './Pancakes' }]);
+    });
+
+    it('opens a .menu target', async () => {
+        const nav = new TestNavigator(() => '/ws/Week.menu');
+
+        await nav.navigate('Week');
+
+        expect(new URI(nav.opened[0]).path.fsPath()).to.equal('/ws/Week.menu');
+    });
+
+    it('tells the user when the reference resolves to nothing, and opens nothing', async () => {
+        const nav = new TestNavigator(() => undefined);
+
+        await nav.navigate('No Such Recipe');
+
+        expect(nav.opened).to.be.empty;
+        expect(nav.warnings).to.have.length(1);
+        expect(nav.warnings[0]).to.contain('No Such Recipe');
+    });
+
+    it('reports a failing lookup instead of rejecting', async () => {
+        const nav = new TestNavigator(() => new Error('native boom'));
+
+        await nav.navigate('Pancakes');
+
+        expect(nav.opened).to.be.empty;
+        expect(nav.warnings).to.have.length(1);
+    });
+
+    it('reports a failing open instead of rejecting', async () => {
+        // The Sentry signature: the file vanished between resolve and open.
+        const nav = new TestNavigator(() => '/ws/Pancakes.cook');
+        nav.openError = new Error("'file:///ws/Pancakes.cook' is invalid");
+
+        await nav.navigate('Pancakes');
+
+        expect(nav.opened).to.be.empty;
+        expect(nav.warnings).to.have.length(1);
+        expect(nav.warnings[0]).to.contain('Pancakes');
+    });
+
+    it('opens the source in an editor, not through the default opener', async () => {
+        // The default opener for a .cook file is the preview this was invoked
+        // from, so opening the source must bypass it.
+        const nav = new TestNavigator(() => undefined);
+
+        await nav.openSource(new URI('/ws/Pancakes.cook').withScheme('file'));
+
+        expect(nav.opened).to.deep.equal(['editor:file:///ws/Pancakes.cook']);
+    });
+
+    it('reports a failing source open instead of rejecting', async () => {
+        const nav = new TestNavigator(() => undefined);
+        nav.openError = new Error("'file:///ws/Pancakes.cook' is invalid");
+
+        await nav.openSource(new URI('/ws/Pancakes.cook').withScheme('file'));
+
+        expect(nav.warnings).to.have.length(1);
+        expect(nav.warnings[0]).to.contain('Pancakes.cook');
+    });
+
+    it('does nothing without a workspace', async () => {
+        const nav = new TestNavigator(() => '/ws/Pancakes.cook', false);
+
+        await nav.navigate('Pancakes');
+
+        expect(nav.opened).to.be.empty;
+        expect(nav.lookups).to.be.empty;
+    });
+
+});

--- a/packages/cooklang/src/browser/recipe-navigator.ts
+++ b/packages/cooklang/src/browser/recipe-navigator.ts
@@ -1,0 +1,114 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { nls } from '@theia/core/lib/common/nls';
+import URI from '@theia/core/lib/common/uri';
+import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { EditorManager } from '@theia/editor/lib/browser';
+import { CooklangLanguageService } from '../common';
+import { CooklangUri } from '../common/cooklang-uri';
+
+/**
+ * Opens the recipe a preview link points at.
+ *
+ * Both previews used to rebuild the target path themselves
+ * (`workspaceRoot.resolve(reference + '.cook')`), which is wrong twice over: it
+ * can only ever reach `.cook` files in the shape the caller guessed, and the two
+ * previews did not even guess alike - the menu preview stripped a leading `./`
+ * and the recipe preview did not. `cooklang-find` owns the lookup rules, so ask
+ * it for the path and open exactly what it returns.
+ *
+ * Failures are reported to the user rather than thrown: these calls sit in React
+ * click handlers, so a rejected promise is a silent no-op for the user and an
+ * unhandled rejection in telemetry.
+ */
+@injectable()
+export class RecipeNavigator {
+
+    @inject(CooklangLanguageService)
+    protected languageService: CooklangLanguageService;
+
+    @inject(WorkspaceService)
+    protected workspaceService: WorkspaceService;
+
+    @inject(OpenerService)
+    protected openerService: OpenerService;
+
+    @inject(EditorManager)
+    protected editorManager: EditorManager;
+
+    @inject(MessageService)
+    protected messageService: MessageService;
+
+    /**
+     * Resolve `referencePath` against the workspace and open it. Never rejects.
+     */
+    async navigate(referencePath: string): Promise<void> {
+        const root = this.workspaceService.tryGetRoots()[0];
+        if (!root) {
+            return;
+        }
+        const baseDir = root.resource.path.fsPath();
+        let resolved: string | undefined;
+        try {
+            resolved = await this.languageService.findRecipePath(baseDir, referencePath);
+        } catch (e) {
+            console.warn(`[cooklang] findRecipePath failed for ${referencePath}:`, e);
+            this.warnNotOpened(referencePath);
+            return;
+        }
+        if (resolved === undefined) {
+            this.messageService.warn(
+                nls.localize('theia/cooklang/recipeNotFound', 'Recipe not found: {0}', referencePath)
+            );
+            return;
+        }
+        try {
+            await this.openUri(CooklangUri.fromNativePath(resolved));
+        } catch (e) {
+            console.warn(`[cooklang] failed to open ${resolved}:`, e);
+            this.warnNotOpened(referencePath);
+        }
+    }
+
+    /**
+     * Open `uri` in the text editor, reporting failures. Deliberately not the
+     * default opener: for a `.cook` file that is the preview this was invoked
+     * from, so `open()` here would reopen the preview instead of the source.
+     */
+    async openSource(uri: URI): Promise<void> {
+        try {
+            await this.openInEditor(uri);
+        } catch (e) {
+            console.warn(`[cooklang] failed to open ${uri.toString()} in an editor:`, e);
+            this.warnNotOpened(uri.path.base);
+        }
+    }
+
+    protected async openInEditor(uri: URI): Promise<void> {
+        await this.editorManager.open(uri);
+    }
+
+    protected warnNotOpened(referencePath: string): void {
+        this.messageService.warn(
+            nls.localize('theia/cooklang/recipeNotOpened', 'Could not open recipe: {0}', referencePath)
+        );
+    }
+
+    protected async openUri(uri: URI): Promise<void> {
+        await open(this.openerService, uri);
+    }
+}

--- a/packages/cooklang/src/browser/recipe-preview-widget.tsx
+++ b/packages/cooklang/src/browser/recipe-preview-widget.tsx
@@ -16,12 +16,10 @@ import { Message } from '@theia/core/shared/@lumino/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { Navigatable } from '@theia/core/lib/browser/navigatable-types';
 import { CommandRegistry } from '@theia/core/lib/common/command';
-import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import * as React from '@theia/core/shared/react';
 import { CooklangLanguageService, COOKLANG_LANGUAGE_ID } from '../common';
@@ -33,6 +31,7 @@ import {
     RECIPE_IMAGE_EXTENSIONS,
 } from '../common/recipe-images';
 import { RecipeImageService } from './recipe-image-service';
+import { RecipeNavigator } from './recipe-navigator';
 import { RecipeView, LinkOpenerProvider } from './recipe-preview-components';
 import { TimerRecipeRef } from '../common/cooking-timer';
 import { CookingTimerService } from './cooking-timer-service';
@@ -72,17 +71,14 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
 
-    @inject(OpenerService)
-    protected readonly openerService: OpenerService;
-
     @inject(EditorManager)
     protected readonly editorManager: EditorManager;
 
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-
     @inject(RecipeImageService)
     protected readonly imageService: RecipeImageService;
+
+    @inject(RecipeNavigator)
+    protected readonly navigator: RecipeNavigator;
 
     @inject(WindowService)
     protected readonly windowService: WindowService;
@@ -389,7 +385,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
 
     protected handleShowSource = (): void => {
         if (this.uri) {
-            this.editorManager.open(this.uri);
+            this.navigator.openSource(this.uri);
         }
     };
 
@@ -398,13 +394,7 @@ export class RecipePreviewWidget extends ReactWidget implements Navigatable {
     };
 
     protected handleNavigateToRecipe = (referencePath: string): void => {
-        const root = this.workspaceService.tryGetRoots()[0];
-        if (!root) {
-            return;
-        }
-        const rootUri = new URI(root.resource.toString());
-        const targetUri = rootUri.resolve(referencePath + '.cook');
-        open(this.openerService, targetUri);
+        this.navigator.navigate(referencePath);
     };
 
     protected handleOpenLink = (url: string): void => {

--- a/packages/cooklang/src/common/cooklang-language-service.ts
+++ b/packages/cooklang/src/common/cooklang-language-service.ts
@@ -67,6 +67,19 @@ export interface CooklangLanguageService {
     findRecipe(baseDir: string, name: string): Promise<string | undefined>;
 
     /**
+     * The absolute path of the recipe `findRecipe` would read for `name` inside
+     * `baseDir`, or `undefined` when nothing matches.
+     *
+     * Use this to navigate to a referenced recipe rather than rebuilding the path
+     * from the reference text: `cooklang-find` owns the lookup rules (search
+     * order, `.cook` vs `.menu`, how a bare name maps onto the tree) and they are
+     * not reproducible by appending an extension to a workspace-relative path.
+     *
+     * Same disk-access caveat as `findRecipe` (OS path, Electron-only).
+     */
+    findRecipePath(baseDir: string, name: string): Promise<string | undefined>;
+
+    /**
      * Title and step images for the recipe at `recipePath`, discovered with
      * `cooklang-find`'s naming rules (the same ones CookCLI's web server uses).
      *

--- a/packages/cooklang/src/common/cooklang-uri.ts
+++ b/packages/cooklang/src/common/cooklang-uri.ts
@@ -47,6 +47,16 @@ export namespace CooklangUri {
         return hasExtension(uri, MENU_EXTENSION);
     }
 
+    /**
+     * A URI for an absolute filesystem path returned by the native addon.
+     *
+     * `cooklang-find` reports OS paths, so Windows results arrive with `\`
+     * separators that `URI.fromFilePath` does not translate.
+     */
+    export function fromNativePath(path: string): URI {
+        return URI.fromFilePath(path.replace(/\\/g, '/'));
+    }
+
     /** Whether `uri` denotes any Cooklang file (recipe or menu). */
     export function isCooklang(uri: URI | undefined): boolean {
         return isRecipe(uri) || isMenu(uri);

--- a/packages/cooklang/src/node/cooklang-language-service-impl.ts
+++ b/packages/cooklang/src/node/cooklang-language-service-impl.ts
@@ -275,6 +275,12 @@ export class CooklangLanguageServiceImpl implements CooklangLanguageService {
         return result ?? undefined;
     }
 
+    async findRecipePath(baseDir: string, name: string): Promise<string | undefined> {
+        const native = require('@theia/cooklang-native');
+        const result = native.findRecipePath(baseDir, name);
+        return result ?? undefined;
+    }
+
     async recipeImages(recipePath: string): Promise<string> {
         const native = require('@theia/cooklang-native');
         return native.recipeImages(recipePath);

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -820,10 +820,17 @@ export class ElectronMainApplication {
         // the second instance passes it's original argument array as the fourth argument to this method
         // The `argv` second parameter is not usable for us since it is mangled by electron before being passed here
 
-        if (originalArgv.includes('--open-url')) {
-            this.openUrl(originalArgv[originalArgv.length - 1]);
+        // That fourth argument is the `additionalData` the second instance handed to
+        // `requestSingleInstanceLock`. An instance the OS starts on our behalf - a file
+        // association, a URL scheme handler - never reaches that call, so it arrives as
+        // null and any use of it throws, losing the activation entirely. Treat it as "no
+        // arguments", which still focuses the running window.
+        const argv = Array.isArray(originalArgv) ? originalArgv : [];
+
+        if (argv.includes('--open-url')) {
+            this.openUrl(argv[argv.length - 1]);
         } else {
-            createYargs(this.processArgv.getProcessArgvWithoutBin(originalArgv), cwd)
+            createYargs(this.processArgv.getProcessArgvWithoutBin(argv), cwd)
                 .help(false)
                 .command('$0 [file]', false,
                     cmd => cmd

--- a/packages/keymaps/src/browser/keymaps-service.ts
+++ b/packages/keymaps/src/browser/keymaps-service.ts
@@ -61,7 +61,17 @@ export class KeymapsService {
      */
     @postConstruct()
     protected init(): void {
-        this.doInit();
+        // Not awaited on purpose (`@postConstruct` must stay synchronous), so the rejection has
+        // to be handled here. Default keybindings still work without `keymaps.json`, but `open()`
+        // and `updateKeymap()` await `deferredModel`, so it has to be settled too - otherwise
+        // "Keyboard Shortcuts" hangs forever instead of reporting that it could not load.
+        this.doInit().catch(e => {
+            console.error(`Failed to initialize the keymaps from '${UserStorageUri.resolve('keymaps.json')}'.`, e);
+            this.deferredModel.reject(e);
+        });
+        // Nothing need be awaiting the deferred at the moment it rejects; keep that from
+        // surfacing as a second, unhandled rejection.
+        this.deferredModel.promise.catch(() => { /* reported above, re-thrown to awaiting callers */ });
     }
 
     protected async doInit(): Promise<void> {


### PR DESCRIPTION
Six issues from the editor's Sentry project, each traced to a root cause before
being changed. Two turned out to need no work and are noted at the bottom.

## EDITOR-P — chat view crashes on a tool result (31 events in 11 minutes)

`ToolCallResult` is `undefined | object | string | ToolCallContent`, so a tool
may legally return an arbitrary object, and `renderResult` has a
`JSON.stringify` fallback for exactly that. But it discriminated the
`ToolCallContent` variant with a bare `'content' in result`, omitting the
`Array.isArray` half that every other discrimination site uses —
`isToolCallContent` in ai-core, and the three checks in ai-chat/chat-model.ts.
That one line was the only outlier.

In production the trigger was `fetchUrl`, whose `CookbotFetchResult` is
`{ content: string, title: string }`. The throw happened inside a React render,
so it took the chat view down and React retried it in a loop.

Upstream fixed the sibling primitive-result case in 28b86459e; this is the
remaining object variant.

## EDITOR-E — preview recipe links open the wrong path, silently

Both previews rebuilt the target themselves —
`workspaceRoot.resolve(reference + '.cook')` — which is wrong twice over. A
hardcoded `.cook` can never reach a `.menu` target, and the two previews did not
even guess alike: the menu preview stripped a leading `./`, the recipe preview
did not. `cooklang-find` owns those lookup rules.

Adds `findRecipePath` to the native addon (the same `get_recipe` call
`findRecipe` already makes, returning the entry's path instead of its content,
so a link opens the very file the preview read) and routes both previews through
a shared `RecipeNavigator`.

The opens were also floating promises in React click handlers, so a missing
target was a silent no-op for the user and an unhandled rejection in telemetry —
one user clicked the same dead link seven times in six seconds, then tried
renaming a file to make it work. `RecipeNavigator` never rejects; it reports
"Recipe not found" or "Could not open recipe".

## EDITOR-G — a blank thinking signature wedges the session

`transformMessages` replayed thinking blocks as `signature: msg.signature || ''`.
A thinking block is only replayable with the signature the model issued, so a
blank one earns ``messages.N.content.0: Invalid `signature` in `thinking` block``
— permanently, because the history is re-sent every turn. An unsigned block is
what a stream cut short before its `signature_delta` leaves behind. Skip those:
losing the reasoning costs this turn's context, sending it costs the session.

## EDITOR-3 — keymaps.json failure hangs Keyboard Shortcuts

Same floating `@postConstruct` → async `doInit()` shape 4f2a2620e fixed for the
toolbar, still live on alpha.42. The toolbar could just log and fall back to
defaults; here `open()` and `updateKeymap()` both await `deferredModel`, so
logging alone leaves those hanging forever. Rejects the deferred too, with a
no-op handler so a rejection nobody awaits yet is not a second unhandled one.

## EDITOR-7 — null argv loses a second-instance activation

The fourth argument to `onSecondInstance` is the `additionalData` the second
instance handed to `requestSingleInstanceLock`. An instance the OS starts on our
behalf — a file association, a URL scheme handler — never reaches that call, so
it arrives as null and every use of it throws. Treated as "no arguments", which
still focuses the running window.

## EDITOR-C/A/B — 68 events of broken-pipe noise

Sentry wraps `console.*`, so once the stdout/stderr pipe is gone every console
call throws and is captured — which is why these arrive attributed to
`console.error` inside Sentry's own bundle rather than to any code of ours.
Nothing to fix in response, so they are filtered in `beforeSend`.
`isUnactionableError` is anchored to the exact text Node gives a failed stream
write; a real file failure reads `EIO: i/o error, write '<path>'` and is still
reported, with a test pinning that distinction.

## Testing

- 5 new Rust tests (`cargo test`: 49 passing). `find_recipe_path_resolves_a_menu_not_just_cook` is the concrete proof the old `+ '.cook'` rule was unreachable for some targets.
- 16 new TS tests across ai-chat-ui, cooklang, cooklang-ai and cooklang-telemetry.
- `lerna run test`: 44 projects passing. `lerna run compile`: 47 projects. Lint clean.
- Native binding smoke-tested after rebuild: nested → `Dinner/Salmon Bowl.cook`, `Week` → `Week.menu`, missing → `null`.

## Caveats

- **Extended thinking + tool_use.** Anthropic wants thinking blocks preserved alongside a `tool_use` in the same assistant turn. Dropping an unsigned one from such a turn could fail a different way. It is still strictly better than a blank signature, which is a guaranteed 400 — but if an "expected thinking block" error appears after this ships, that is where it comes from.
- **Two changes ship unit-untested.** `electron-main` has no test harness (it imports electron directly), and `keymaps-service` imports `MonacoTextModelService`, which a browser spec cannot pull in under the current mocha setup.
- **EDITOR-E was never reproduced locally.** The diagnosis rests on the code plus four Sentry events, with the `.menu` test as proof the old rule could not work for some targets.

## Needed no work

EDITOR-2 (`Object has been destroyed`) was fixed by 4f2a2620e on 2026-08-20; every event is on alpha.38, including three after the fix from users who had not updated. EDITOR-N/F (`decoded message length too large`) were fixed by the tool-result cap in c0a554dd8 — all five events are alpha.39 from a single session on 2026-08-28, ending 1h44m before that commit landed. That session is also where EDITOR-P came from: one oversized `fetchUrl` result produced both symptoms.

https://claude.ai/code/session_014Vno6pBkbfhcTFmWr52dro