### PR TITLE
feat(cooklang,cooklang-ai): batch arguments for the read tools

### DIFF
--- a/packages/cooklang-ai/src/browser/file-tools/batch-args.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/batch-args.ts
@@ -1,0 +1,60 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * The most items one batched tool call may carry.
+ *
+ * A screening pass over a recipe library is the case these batches exist for,
+ * and it is a shortlist by construction. The cap is a guard against a model
+ * that asks for the whole workspace in one call and gets back a result too
+ * large to be useful — not a performance limit.
+ */
+export const MAX_BATCH_ITEMS = 25;
+
+/**
+ * Validates the array form of a batched tool argument.
+ *
+ * Returns the trimmed values, or a message explaining what is wrong in terms
+ * the model can act on. Duplicates are collapsed: rendering or reading the same
+ * path twice in one call is always waste, and silently returning it twice would
+ * teach the model that it worked.
+ *
+ * (`packages/cooklang` carries its own copy: the two packages do not depend
+ * on each other, and a shared dependency for twenty lines is not worth the
+ * coupling.)
+ */
+export function parseBatchArg(value: unknown, name: string): string[] | { error: string } {
+    if (!Array.isArray(value)) {
+        return { error: `${name} must be an array of strings.` };
+    }
+    if (value.length === 0) {
+        return { error: `${name} must not be empty.` };
+    }
+    if (value.length > MAX_BATCH_ITEMS) {
+        return {
+            error: `${name} accepts at most ${MAX_BATCH_ITEMS} items, got ${value.length}. `
+                + 'Narrow the shortlist first, then batch a second call if you still need more.',
+        };
+    }
+    const items: string[] = [];
+    for (const entry of value) {
+        if (typeof entry !== 'string' || !entry.trim()) {
+            return { error: `${name} must contain only non-empty strings.` };
+        }
+        const trimmed = entry.trim();
+        if (!items.includes(trimmed)) {
+            items.push(trimmed);
+        }
+    }
+    return items;
+}

--- a/packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/workspace-functions.spec.ts
@@ -1,0 +1,308 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { FileContentFunction, FindFilesByPattern, GetWorkspaceFileList } from './workspace-functions';
+
+after(() => disableJSDOM());
+
+// ── Test fakes ──────────────────────────────────────────────────────────
+
+interface FakeStat {
+    resource: URI;
+    isDirectory: boolean;
+    size?: number;
+    children?: FakeStat[];
+}
+
+/** Nested tree spec: a string value is a file's content, an object is a directory. */
+interface TreeSpec { [name: string]: TreeSpec | string }
+
+function buildStats(rootUri: URI, spec: TreeSpec): { stats: Map<string, FakeStat>; contents: Map<string, string> } {
+    const stats = new Map<string, FakeStat>();
+    const contents = new Map<string, string>();
+    const build = (uri: URI, node: TreeSpec): FakeStat => {
+        const children: FakeStat[] = [];
+        for (const [name, child] of Object.entries(node)) {
+            const childUri = uri.resolve(name);
+            if (typeof child === 'string') {
+                const fileStat: FakeStat = { resource: childUri, isDirectory: false, size: child.length };
+                stats.set(childUri.toString(), fileStat);
+                contents.set(childUri.toString(), child);
+                children.push(fileStat);
+            } else {
+                children.push(build(childUri, child));
+            }
+        }
+        const stat: FakeStat = { resource: uri, isDirectory: true, children };
+        stats.set(uri.toString(), stat);
+        return stat;
+    };
+    build(rootUri, spec);
+    return { stats, contents };
+}
+
+class FakeFileService {
+    /** Directories walked, so a test can prove the tree is visited once. */
+    resolvedDirectories: string[] = [];
+    constructor(private readonly stats: Map<string, FakeStat>, private readonly contents: Map<string, string>) { }
+    async resolve(uri: URI): Promise<FakeStat> {
+        const stat = this.stats.get(uri.toString());
+        if (!stat) {
+            throw new Error('ENOENT');
+        }
+        if (stat.isDirectory) {
+            this.resolvedDirectories.push(uri.toString());
+        }
+        return stat;
+    }
+    async read(uri: URI): Promise<{ value: string }> {
+        const value = this.contents.get(uri.toString());
+        if (value === undefined) {
+            throw new Error('ENOENT');
+        }
+        return { value };
+    }
+}
+
+class FakeWorkspaceScope {
+    constructor(private readonly root: URI | undefined) { }
+    async getWorkspaceRoot(): Promise<URI> {
+        if (!this.root) {
+            throw new Error('No workspace open');
+        }
+        return this.root;
+    }
+    /** Normalizes first, as the real scope does: `ws/../secrets` escapes the root. */
+    ensureWithinWorkspace(target: URI, root: URI): void {
+        if (!target.normalizePath().toString().startsWith(root.toString())) {
+            throw new Error('Access outside of the workspace is not allowed');
+        }
+    }
+    async shouldExclude(stat: FakeStat): Promise<boolean> {
+        return stat.resource.path.base === 'node_modules';
+    }
+}
+
+class FakeMonacoWorkspace {
+    getTextDocument(): undefined { return undefined; }
+}
+
+class FakePreferences {
+    get<T>(_key: string, fallback: T): T { return fallback; }
+}
+
+const ROOT = new URI('file:///ws');
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function wire<T>(tool: T, spec: TreeSpec, noWorkspace = false): { tool: T; files: FakeFileService } {
+    const { stats, contents } = buildStats(ROOT, spec);
+    const files = new FakeFileService(stats, contents);
+    (tool as any).fileService = files;
+    (tool as any).workspaceScope = new FakeWorkspaceScope(noWorkspace ? undefined : ROOT);
+    (tool as any).monacoWorkspace = new FakeMonacoWorkspace();
+    (tool as any).preferences = new FakePreferences();
+    return { tool, files };
+}
+
+async function call(tool: { getTool(): { handler: Function } }, args: object): Promise<string> {
+    return await tool.getTool().handler(JSON.stringify(args), undefined as any) as string;
+}
+
+async function callJson<T>(tool: { getTool(): { handler: Function } }, args: object): Promise<T> {
+    return JSON.parse(await call(tool, args)) as T;
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const TREE: TreeSpec = {
+    'Napoleon.cook': 'Add @flour{200%g}',
+    Dinners: { 'Chilli.cook': 'Brown @beef{500%g}', 'notes.txt': 'not a recipe' },
+    Plans: { 'Week.menu': 'Day 1' },
+    node_modules: { 'ignored.cook': 'nope' },
+};
+
+// ── getFileContent ──────────────────────────────────────────────────────
+
+describe('FileContentFunction', () => {
+
+    it('returns raw content for a single file, unchanged by the batch support', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        expect(await call(tool, { file: 'Napoleon.cook' })).to.equal('Add @flour{200%g}');
+    });
+
+    it('reads several files in one call, in the order given', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        const result = await callJson<{ files: Array<{ file: string; content?: string; error?: string }> }>(
+            tool, { files: ['Napoleon.cook', 'Dinners/Chilli.cook'] });
+        expect(result.files).to.deep.equal([
+            { file: 'Napoleon.cook', content: 'Add @flour{200%g}' },
+            { file: 'Dinners/Chilli.cook', content: 'Brown @beef{500%g}' },
+        ]);
+    });
+
+    it('reports a missing file in its own entry and still returns the others', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        const result = await callJson<{ files: Array<{ file: string; content?: string; error?: string }> }>(
+            tool, { files: ['nope.cook', 'Napoleon.cook'] });
+        expect(result.files[0].error).to.equal('File not found');
+        expect(result.files[0].content).to.equal(undefined);
+        expect(result.files[1].content).to.equal('Add @flour{200%g}');
+    });
+
+    it('collapses duplicate paths', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        const result = await callJson<{ files: unknown[] }>(tool, { files: ['Napoleon.cook', 'Napoleon.cook'] });
+        expect(result.files).to.have.length(1);
+    });
+
+    it('rejects file and files together', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        const result = await callJson<{ error: string }>(tool, { file: 'a.cook', files: ['b.cook'] });
+        expect(result.error).to.match(/not both/);
+    });
+
+    it('rejects offset/limit with a batch and says to use file instead', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        const result = await callJson<{ error: string }>(tool, { files: ['Napoleon.cook'], offset: 2 });
+        expect(result.error).to.match(/page through a single file/);
+    });
+
+    it('rejects a call with neither file nor files', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        const result = await callJson<{ error: string }>(tool, {});
+        expect(result.error).to.match(/either file .* or files/);
+    });
+
+    it('rejects an empty array and a batch over the cap', async () => {
+        const { tool } = wire(new FileContentFunction(), TREE);
+        expect((await callJson<{ error: string }>(tool, { files: [] })).error).to.match(/must not be empty/);
+        const many = Array.from({ length: 26 }, (_, i) => `r${i}.cook`);
+        expect((await callJson<{ error: string }>(tool, { files: many })).error).to.match(/at most 25 items/);
+    });
+});
+
+// ── getWorkspaceFileList ────────────────────────────────────────────────
+
+describe('GetWorkspaceFileList', () => {
+
+    it('lists a single directory as a bare array, unchanged', async () => {
+        const { tool } = wire(new GetWorkspaceFileList(), TREE);
+        const result = await tool.getTool().handler(JSON.stringify({ path: 'Dinners' }), undefined!) as string[];
+        expect(result).to.have.members(['Chilli.cook', 'notes.txt']);
+    });
+
+    it('lists several directories in one call', async () => {
+        const { tool } = wire(new GetWorkspaceFileList(), TREE);
+        const result = await callJson<{ directories: Array<{ path: string; entries?: string[]; error?: string }> }>(
+            tool, { paths: ['Dinners', 'Plans'] });
+        expect(result.directories.map(d => d.path)).to.deep.equal(['Dinners', 'Plans']);
+        expect(result.directories[0].entries).to.have.members(['Chilli.cook', 'notes.txt']);
+        expect(result.directories[1].entries).to.deep.equal(['Week.menu']);
+    });
+
+    it('reports a missing directory in its own entry and still lists the rest', async () => {
+        const { tool } = wire(new GetWorkspaceFileList(), TREE);
+        const result = await callJson<{ directories: Array<{ path: string; entries?: string[]; error?: string }> }>(
+            tool, { paths: ['Nope', 'Plans'] });
+        expect(result.directories[0].error).to.equal('Directory not found');
+        expect(result.directories[1].entries).to.deep.equal(['Week.menu']);
+    });
+
+    it('keeps a path outside the workspace inside its own entry rather than failing the batch', async () => {
+        const { tool } = wire(new GetWorkspaceFileList(), TREE);
+        const result = await callJson<{ directories: Array<{ path: string; error?: string }> }>(
+            tool, { paths: ['../secrets', 'Plans'] });
+        expect(result.directories[0].error).to.match(/outside of the workspace/);
+        expect(result.directories).to.have.length(2);
+    });
+
+    it('rejects path and paths together', async () => {
+        const { tool } = wire(new GetWorkspaceFileList(), TREE);
+        const result = await callJson<{ error: string }>(tool, { path: 'Dinners', paths: ['Plans'] });
+        expect(result.error).to.match(/not both/);
+    });
+});
+
+// ── findFilesByPattern ──────────────────────────────────────────────────
+
+describe('FindFilesByPattern', () => {
+
+    it('matches a single glob exactly as before', async () => {
+        const { tool } = wire(new FindFilesByPattern(), TREE);
+        const result = await callJson<{ files: string[] }>(tool, { pattern: '**/*.cook' });
+        expect(result.files).to.have.members(['Napoleon.cook', 'Dinners/Chilli.cook']);
+        expect(result.files).to.not.include('node_modules/ignored.cook');
+    });
+
+    it('matches several globs in one call, in the order given', async () => {
+        const { tool } = wire(new FindFilesByPattern(), TREE);
+        const result = await callJson<{ patterns: Array<{ pattern: string; files: string[] }> }>(
+            tool, { patterns: ['**/*.cook', '**/*.menu'] });
+        expect(result.patterns.map(p => p.pattern)).to.deep.equal(['**/*.cook', '**/*.menu']);
+        expect(result.patterns[0].files).to.have.members(['Napoleon.cook', 'Dinners/Chilli.cook']);
+        expect(result.patterns[1].files).to.deep.equal(['Plans/Week.menu']);
+    });
+
+    it('walks the workspace once for many globs, not once per glob', async () => {
+        const single = wire(new FindFilesByPattern(), TREE);
+        await call(single.tool, { pattern: '**/*.cook' });
+        const walkedOnce = single.files.resolvedDirectories.length;
+
+        const batched = wire(new FindFilesByPattern(), TREE);
+        await call(batched.tool, { patterns: ['**/*.cook', '**/*.menu', '**/*.txt'] });
+
+        // Three globs must not cost three traversals — that is the saving.
+        expect(batched.files.resolvedDirectories.length).to.equal(walkedOnce);
+    });
+
+    it('returns an empty file list for a glob that matches nothing', async () => {
+        const { tool } = wire(new FindFilesByPattern(), TREE);
+        const result = await callJson<{ patterns: Array<{ pattern: string; files: string[] }> }>(
+            tool, { patterns: ['**/*.cook', '**/*.pdf'] });
+        expect(result.patterns[1].files).to.deep.equal([]);
+    });
+
+    it('rejects pattern and patterns together', async () => {
+        const { tool } = wire(new FindFilesByPattern(), TREE);
+        const result = await callJson<{ error: string }>(tool, { pattern: '**/*.cook', patterns: ['**/*.menu'] });
+        expect(result.error).to.match(/not both/);
+    });
+
+    it('rejects a call with neither pattern nor patterns', async () => {
+        const { tool } = wire(new FindFilesByPattern(), TREE);
+        const result = await callJson<{ error: string }>(tool, {});
+        expect(result.error).to.match(/either pattern .* or patterns/);
+    });
+
+    it('reports no workspace as an error for both forms', async () => {
+        const single = wire(new FindFilesByPattern(), TREE, true);
+        expect((await callJson<{ error: string }>(single.tool, { pattern: '**/*' })).error).to.match(/No workspace open/);
+        const batched = wire(new FindFilesByPattern(), TREE, true);
+        expect((await callJson<{ error: string }>(batched.tool, { patterns: ['**/*'] })).error).to.match(/No workspace open/);
+    });
+});

--- a/packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts
+++ b/packages/cooklang-ai/src/browser/file-tools/workspace-functions.ts
@@ -28,6 +28,31 @@ import {
     FIND_FILES_BY_PATTERN_FUNCTION_ID,
 } from './function-ids';
 import { CONSIDER_GITIGNORE_PREF, FILE_CONTENT_MAX_SIZE_KB_PREF, USER_EXCLUDE_PATTERN_PREF } from './workspace-preferences';
+import { MAX_BATCH_ITEMS, parseBatchArg } from './batch-args';
+
+/** One file's outcome in a batched read. */
+interface BatchFileEntry {
+    file: string;
+    content?: string;
+    error?: string;
+}
+
+/** Maximum files reported per glob. */
+const MAX_FIND_RESULTS = 200;
+
+/** One glob and the files it has matched so far during a workspace walk. */
+interface PatternBucket {
+    pattern: string;
+    matcher: Minimatch;
+    results: string[];
+}
+
+/** One directory's outcome in a batched listing. */
+interface BatchDirEntry {
+    path: string;
+    entries?: string[];
+    error?: string;
+}
 
 // ── FileContentFunction ─────────────────────────────────────────────────
 
@@ -74,6 +99,16 @@ export class FileContentFunction implements ToolProvider {
                             'The relative path to the target file within the workspace (e.g., "src/index.ts", "package.json"). ' +
                             'Must be relative to the workspace root. Absolute paths and paths outside the workspace will result in an error.',
                     },
+                    files: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            `Read several files in one call (max ${MAX_BATCH_ITEMS}) instead of one call per file — always prefer ` +
+                            'this when you already know which files you need. Returns ' +
+                            '{ files: [{ file, content } | { file, error }] } in the order given; a file that cannot be read ' +
+                            'reports its error in its own entry and the others still come back. Mutually exclusive with `file`, ' +
+                            'and cannot be combined with offset/limit (those page through a single file).',
+                    },
                     offset: {
                         type: 'number',
                         description: 'Zero-based line offset to start reading from (default: 0). ' +
@@ -84,10 +119,15 @@ export class FileContentFunction implements ToolProvider {
                         description: 'Maximum number of lines to return. Defaults to the rest of the file.',
                     },
                 },
-                required: ['file'],
             },
             handler: (argString, ctx) => {
-                const { file, offset, limit } = this.parseArg(argString);
+                const { file, files, offset, limit } = this.parseArg(argString);
+                if (files !== undefined) {
+                    return this.getFileContentBatch(files, file, offset, limit, ctx?.cancellationToken);
+                }
+                if (typeof file !== 'string' || !file) {
+                    return Promise.resolve(JSON.stringify({ error: 'Pass either file (one path) or files (an array of paths).' }));
+                }
                 return this.getFileContent(file, ctx?.cancellationToken, offset, limit);
             },
             providerName: undefined,
@@ -106,9 +146,73 @@ export class FileContentFunction implements ToolProvider {
         };
     }
 
-    protected parseArg(argString: string): { file: string; offset?: number; limit?: number } {
+    protected parseArg(argString: string): { file?: string; files?: unknown; offset?: number; limit?: number } {
         const result = JSON.parse(argString);
-        return { file: result.file, offset: result.offset, limit: result.limit };
+        return { file: result.file, files: result.files, offset: result.offset, limit: result.limit };
+    }
+
+    /**
+     * Reads several files under one tool call.
+     *
+     * A file that cannot be read fails in its own slot — a shortlist where one
+     * path was mistyped should not cost a retry of the whole batch, which is
+     * the round trip the batch was there to save.
+     *
+     * `offset`/`limit` page through one file, so they are rejected here rather
+     * than silently applied to every entry.
+     */
+    protected async getFileContentBatch(
+        files: unknown,
+        file: string | undefined,
+        offset: number | undefined,
+        limit: number | undefined,
+        cancellationToken?: CancellationToken,
+    ): Promise<string> {
+        if (typeof file === 'string' && file) {
+            return JSON.stringify({ error: 'Pass either file or files, not both.' });
+        }
+        if (offset !== undefined || limit !== undefined) {
+            return JSON.stringify({
+                error: 'offset and limit page through a single file; read that one with `file` instead of `files`.',
+            });
+        }
+        const paths = parseBatchArg(files, 'files');
+        if ('error' in paths) {
+            return JSON.stringify(paths);
+        }
+        const results: BatchFileEntry[] = [];
+        for (const path of paths) {
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            const raw = await this.getFileContent(path, cancellationToken);
+            const failure = this.errorPayload(raw);
+            results.push(failure !== undefined ? { file: path, error: failure } : { file: path, content: raw });
+        }
+        return JSON.stringify({ files: results });
+    }
+
+    /**
+     * The message from a `{ "error": ... }` reply, or undefined for content.
+     *
+     * `getFileContent` answers with the raw file body on success and a JSON
+     * error object on failure, so the batch has to tell them apart to place an
+     * entry. Narrow on purpose: a recipe whose entire body happens to parse as
+     * an object with a non-empty string `error` is indistinguishable, and that
+     * is not a file anyone has.
+     */
+    protected errorPayload(raw: string): string | undefined {
+        const trimmed = raw.trimStart();
+        if (!trimmed.startsWith('{')) {
+            return undefined;
+        }
+        try {
+            const parsed = JSON.parse(trimmed);
+            const message = parsed?.error;
+            return typeof message === 'string' && message.trim() ? message : undefined;
+        } catch {
+            return undefined;
+        }
     }
 
     async getFileContent(file: string, cancellationToken?: CancellationToken, offset?: number, limit?: number): Promise<string> {
@@ -309,8 +413,15 @@ export class GetWorkspaceFileList implements ToolProvider {
                             'Relative path to a directory within the workspace (e.g., "src", "src/components"). ' +
                             'Use "" or "." to list the workspace root. Paths outside the workspace will result in an error.',
                     },
+                    paths: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            `List several directories in one call (max ${MAX_BATCH_ITEMS}) instead of one call each. Returns ` +
+                            '{ directories: [{ path, entries } | { path, error }] } in the order given; a directory that cannot ' +
+                            'be listed reports its error in its own entry. Mutually exclusive with `path`.',
+                    },
                 },
-                required: ['path'],
             },
             description:
                 'Lists files and directories within a specified workspace directory. ' +
@@ -319,9 +430,59 @@ export class GetWorkspaceFileList implements ToolProvider {
                 'For finding specific files by pattern, use findFilesByPattern instead.',
             handler: (argString, ctx) => {
                 const args = JSON.parse(argString);
+                if (args.paths !== undefined) {
+                    return this.getProjectFileListBatch(args.paths, args.path, ctx?.cancellationToken);
+                }
                 return this.getProjectFileList(args.path, ctx?.cancellationToken);
             },
         };
+    }
+
+    /**
+     * Lists several directories under one tool call.
+     *
+     * As with the batched read, a directory that cannot be listed fails in its
+     * own slot so one bad path does not discard the rest.
+     */
+    protected async getProjectFileListBatch(paths: unknown, path: unknown, cancellationToken?: CancellationToken): Promise<string> {
+        if (typeof path === 'string' && path) {
+            return JSON.stringify({ error: 'Pass either path or paths, not both.' });
+        }
+        const dirs = parseBatchArg(paths, 'paths');
+        if ('error' in dirs) {
+            return JSON.stringify(dirs);
+        }
+        const directories: BatchDirEntry[] = [];
+        for (const dir of dirs) {
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            let listed: string | string[];
+            try {
+                listed = await this.getProjectFileList(dir, cancellationToken);
+            } catch (error) {
+                // `ensureWithinWorkspace` throws rather than returning; in a
+                // batch that must land in the entry, not abort the call.
+                directories.push({ path: dir, error: (error as Error).message });
+                continue;
+            }
+            if (Array.isArray(listed)) {
+                directories.push({ path: dir, entries: listed });
+            } else {
+                const parsed = this.tryParseError(listed);
+                directories.push({ path: dir, error: parsed ?? 'Directory not found' });
+            }
+        }
+        return JSON.stringify({ directories });
+    }
+
+    protected tryParseError(raw: string): string | undefined {
+        try {
+            const parsed = JSON.parse(raw);
+            return typeof parsed?.error === 'string' ? parsed.error : undefined;
+        } catch {
+            return undefined;
+        }
     }
 
     async getProjectFileList(path?: string, cancellationToken?: CancellationToken): Promise<string | string[]> {
@@ -417,6 +578,16 @@ export class FindFilesByPattern implements ToolProvider {
                             '\'**/*.{js,ts}\' (JS or TS files), \'**/test/**/*.spec.ts\' (test files). ' +
                             'Use specific subdirectory prefixes for better performance.',
                     },
+                    patterns: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description:
+                            `Match several globs in one call (max ${MAX_BATCH_ITEMS}), e.g. ['**/*.cook', '**/*.menu']. ` +
+                            'Much cheaper than one call per pattern: the workspace is walked ONCE and every pattern is tested ' +
+                            'against each file, rather than a fresh recursive traversal per glob. Returns ' +
+                            '{ patterns: [{ pattern, files, totalFound?, truncated? }] } in the order given. ' +
+                            'Mutually exclusive with `pattern`; `exclude` applies to every pattern.',
+                    },
                     exclude: {
                         type: 'array',
                         items: { type: 'string' },
@@ -426,10 +597,15 @@ export class FindFilesByPattern implements ToolProvider {
                             'Common exclusions (node_modules, .git) are applied automatically via gitignore.',
                     },
                 },
-                required: ['pattern'],
             },
             handler: (argString, ctx) => {
                 const args = JSON.parse(argString);
+                if (args.patterns !== undefined) {
+                    return this.findFilesBatch(args.patterns, args.pattern, args.exclude, ctx?.cancellationToken);
+                }
+                if (typeof args.pattern !== 'string' || !args.pattern) {
+                    return Promise.resolve(JSON.stringify({ error: 'Pass either pattern (one glob) or patterns (an array of globs).' }));
+                }
                 return this.findFiles(args.pattern, args.exclude, ctx?.cancellationToken);
             },
             providerName: undefined,
@@ -467,25 +643,74 @@ export class FindFilesByPattern implements ToolProvider {
             if (cancellationToken?.isCancellationRequested) {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
             }
-            const patternMatcher = new Minimatch(pattern, { dot: false });
             const excludeMatchers = allExcludes.map(ep => new Minimatch(ep, { dot: true }));
-            const files: string[] = [];
-            const maxResults = 200;
-            await this.traverseDirectory(workspaceRoot, workspaceRoot, patternMatcher, excludeMatchers, files, maxResults, cancellationToken);
+            const buckets = [this.bucketFor(pattern)];
+            await this.traverseDirectory(workspaceRoot, workspaceRoot, buckets, excludeMatchers, MAX_FIND_RESULTS, cancellationToken);
             if (cancellationToken?.isCancellationRequested) {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
             }
-            const result: Record<string, unknown> = {
-                files: files.slice(0, maxResults),
-            };
-            if (files.length > maxResults) {
-                result.totalFound = files.length;
-                result.truncated = true;
-            }
-            return JSON.stringify(result);
+            return JSON.stringify(this.summarise(buckets[0]));
         } catch (error) {
             return JSON.stringify({ error: `Failed to find files: ${(error as Error).message}` });
         }
+    }
+
+    /**
+     * Matches several globs in ONE workspace walk.
+     *
+     * The saving here is not just the round trip: `findFiles` traverses the
+     * whole tree recursively per glob, so asking for `**​/*.cook` and
+     * `**​/*.menu` separately walked it twice. Every pattern is tested against
+     * each file as the walk passes it instead.
+     */
+    protected async findFilesBatch(
+        patterns: unknown,
+        pattern: unknown,
+        excludePatterns?: string[],
+        cancellationToken?: CancellationToken,
+    ): Promise<string> {
+        if (typeof pattern === 'string' && pattern) {
+            return JSON.stringify({ error: 'Pass either pattern or patterns, not both.' });
+        }
+        const globs = parseBatchArg(patterns, 'patterns');
+        if ('error' in globs) {
+            return JSON.stringify(globs);
+        }
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+        let workspaceRoot: URI;
+        try {
+            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+        } catch (error) {
+            return JSON.stringify({ error: (error as Error).message });
+        }
+        try {
+            const ignorePatterns = await this.buildIgnorePatterns(workspaceRoot);
+            const allExcludes = [...ignorePatterns, ...(excludePatterns ?? [])];
+            const excludeMatchers = allExcludes.map(ep => new Minimatch(ep, { dot: true }));
+            const buckets = globs.map(glob => this.bucketFor(glob));
+            await this.traverseDirectory(workspaceRoot, workspaceRoot, buckets, excludeMatchers, MAX_FIND_RESULTS, cancellationToken);
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+            return JSON.stringify({ patterns: buckets.map(bucket => ({ pattern: bucket.pattern, ...this.summarise(bucket) })) });
+        } catch (error) {
+            return JSON.stringify({ error: `Failed to find files: ${(error as Error).message}` });
+        }
+    }
+
+    protected bucketFor(pattern: string): PatternBucket {
+        return { pattern, matcher: new Minimatch(pattern, { dot: false }), results: [] };
+    }
+
+    protected summarise(bucket: PatternBucket): Record<string, unknown> {
+        const result: Record<string, unknown> = { files: bucket.results.slice(0, MAX_FIND_RESULTS) };
+        if (bucket.results.length > MAX_FIND_RESULTS) {
+            result.totalFound = bucket.results.length;
+            result.truncated = true;
+        }
+        return result;
     }
 
     protected async buildIgnorePatterns(workspaceRoot: URI): Promise<string[]> {
@@ -509,16 +734,21 @@ export class FindFilesByPattern implements ToolProvider {
         return patterns;
     }
 
+    /**
+     * Walks the workspace once, filling every bucket whose glob matches.
+     *
+     * The walk stops early only when *all* buckets are full: with one bucket
+     * that is the original single-pattern behaviour unchanged.
+     */
     protected async traverseDirectory(
         currentUri: URI,
         workspaceRoot: URI,
-        patternMatcher: Minimatch,
+        buckets: PatternBucket[],
         excludeMatchers: Minimatch[],
-        results: string[],
         maxResults: number,
         cancellationToken?: CancellationToken,
     ): Promise<void> {
-        if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
+        if (cancellationToken?.isCancellationRequested || this.allFull(buckets, maxResults)) {
             return;
         }
         try {
@@ -527,7 +757,7 @@ export class FindFilesByPattern implements ToolProvider {
                 return;
             }
             for (const child of stat.children) {
-                if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
+                if (cancellationToken?.isCancellationRequested || this.allFull(buckets, maxResults)) {
                     break;
                 }
                 const relativePath = workspaceRoot.relative(child.resource)?.toString();
@@ -541,13 +771,21 @@ export class FindFilesByPattern implements ToolProvider {
                     continue;
                 }
                 if (child.isDirectory) {
-                    await this.traverseDirectory(child.resource, workspaceRoot, patternMatcher, excludeMatchers, results, maxResults, cancellationToken);
-                } else if (patternMatcher.match(relativePath)) {
-                    results.push(relativePath);
+                    await this.traverseDirectory(child.resource, workspaceRoot, buckets, excludeMatchers, maxResults, cancellationToken);
+                } else {
+                    for (const bucket of buckets) {
+                        if (bucket.results.length < maxResults && bucket.matcher.match(relativePath)) {
+                            bucket.results.push(relativePath);
+                        }
+                    }
                 }
             }
         } catch {
             // If we can't access a directory, skip it
         }
+    }
+
+    protected allFull(buckets: PatternBucket[], maxResults: number): boolean {
+        return buckets.every(bucket => bucket.results.length >= maxResults);
     }
 }

--- a/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.spec.ts
@@ -515,3 +515,33 @@ describe('CookbotLanguageModel thinking blocks', () => {
     });
 
 });
+
+describe('CookbotLanguageModel tool error detection', () => {
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const hasError = (result: unknown): boolean =>
+        (CookbotLanguageModel.prototype as any).hasError.call(
+            Object.create(CookbotLanguageModel.prototype), result);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    it('flags a structured Theia error part', () => {
+        expect(hasError({ content: [{ type: 'error', data: 'boom' }] })).to.equal(true);
+    });
+
+    it('flags the { error } payload the workspace and cooklang tools return', () => {
+        // These handlers return a plain string; the flag was always false for
+        // them, which is why the tool_calls table recorded no failures at all.
+        expect(hasError('{"error":"File not found"}')).to.equal(true);
+        expect(hasError({ content: [{ type: 'text', text: '{"error":"Directory not found"}' }] })).to.equal(true);
+    });
+
+    it('does not flag ordinary results', () => {
+        expect(hasError('Add @flour{200%g}')).to.equal(false);
+        expect(hasError('{"files":["a.cook"]}')).to.equal(false);
+        expect(hasError('{"error":null}')).to.equal(false);
+        expect(hasError('{"error":""}')).to.equal(false);
+        expect(hasError('Common error: adding the salt too early.')).to.equal(false);
+        expect(hasError('{not json')).to.equal(false);
+        expect(hasError(undefined)).to.equal(false);
+    });
+});

--- a/packages/cooklang-ai/src/node/cookbot-language-model.ts
+++ b/packages/cooklang-ai/src/node/cookbot-language-model.ts
@@ -536,8 +536,41 @@ export class CookbotLanguageModel implements LanguageModel {
 
     /**
      * Check if a tool call result contains an error.
+     *
+     * A Theia `error` content part is the structured case, but none of the
+     * cooklang or workspace tools produce one: their handlers return a plain
+     * string, and a failure is `{"error": "..."}` inside it (see
+     * `workspace-functions.ts`). Reading only the structured part reported
+     * every one of those as a success — a run of six "File not found" replies
+     * logged clean, and the server-side `tool_calls` table held zero errors
+     * across every session it had ever recorded. Inspect the payload too.
      */
     private hasError(result: ToolCallResult): boolean {
-        return isToolCallContent(result) && result.content.some(part => part.type === 'error');
+        if (isToolCallContent(result) && result.content.some(part => part.type === 'error')) {
+            return true;
+        }
+        return this.payloadReportsError(this.formatToolCallResult(result));
+    }
+
+    /**
+     * Whether a formatted tool result is a `{"error": "..."}` failure report.
+     *
+     * Narrow on purpose: only a JSON object whose top-level `error` is a
+     * non-empty string counts. A recipe that merely mentions the word, or a
+     * success carrying `"error": null`, is not a failure. Mirrored in the
+     * server's `payload_reports_error` (`crates/server/src/grpc/tool_log.rs`),
+     * which is the backstop for clients that never set the flag at all.
+     */
+    private payloadReportsError(content: string): boolean {
+        const trimmed = content.trimStart();
+        if (!trimmed.startsWith('{')) {
+            return false;
+        }
+        try {
+            const message = JSON.parse(trimmed)?.error;
+            return typeof message === 'string' && message.trim().length > 0;
+        } catch {
+            return false;
+        }
     }
 }

--- a/packages/cooklang/src/browser/batch-args.ts
+++ b/packages/cooklang/src/browser/batch-args.ts
@@ -1,0 +1,60 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+/**
+ * The most items one batched tool call may carry.
+ *
+ * A screening pass over a recipe library is the case these batches exist for,
+ * and it is a shortlist by construction. The cap is a guard against a model
+ * that asks for the whole workspace in one call and gets back a result too
+ * large to be useful — not a performance limit.
+ */
+export const MAX_BATCH_ITEMS = 25;
+
+/**
+ * Validates the array form of a batched tool argument.
+ *
+ * Returns the trimmed values, or a message explaining what is wrong in terms
+ * the model can act on. Duplicates are collapsed: rendering or reading the same
+ * path twice in one call is always waste, and silently returning it twice would
+ * teach the model that it worked.
+ *
+ * (`packages/cooklang-ai` carries its own copy: the two packages do not depend
+ * on each other, and a shared dependency for twenty lines is not worth the
+ * coupling.)
+ */
+export function parseBatchArg(value: unknown, name: string): string[] | { error: string } {
+    if (!Array.isArray(value)) {
+        return { error: `${name} must be an array of strings.` };
+    }
+    if (value.length === 0) {
+        return { error: `${name} must not be empty.` };
+    }
+    if (value.length > MAX_BATCH_ITEMS) {
+        return {
+            error: `${name} accepts at most ${MAX_BATCH_ITEMS} items, got ${value.length}. `
+                + 'Narrow the shortlist first, then batch a second call if you still need more.',
+        };
+    }
+    const items: string[] = [];
+    for (const entry of value) {
+        if (typeof entry !== 'string' || !entry.trim()) {
+            return { error: `${name} must contain only non-empty strings.` };
+        }
+        const trimmed = entry.trim();
+        if (!items.includes(trimmed)) {
+            items.push(trimmed);
+        }
+    }
+    return items;
+}

--- a/packages/cooklang/src/browser/render-template-tool.spec.ts
+++ b/packages/cooklang/src/browser/render-template-tool.spec.ts
@@ -53,11 +53,13 @@ class FakeConfigService {
 class FakeLanguageService {
     calls: Array<{ recipe: string; template: string; config: string }> = [];
     response = JSON.stringify({ output: 'RENDERED' });
+    /** Overrides `response` per call when set, so a batch can vary by recipe. */
+    responder: ((recipe: string) => string) | undefined;
     throwError: Error | undefined;
     async renderReport(recipe: string, template: string, config: string): Promise<string> {
         if (this.throwError) { throw this.throwError; }
         this.calls.push({ recipe, template, config });
-        return this.response;
+        return this.responder ? this.responder(recipe) : this.response;
     }
 }
 
@@ -98,6 +100,15 @@ function createTool(): {
 
 /** Invokes the registered tool handler with a JSON argument string. */
 async function invoke(tool: RenderTemplateTool, args: object): Promise<{ output?: string; error?: string }> {
+    const result = await tool.getTool().handler(JSON.stringify(args));
+    return JSON.parse(result as string);
+}
+
+/** Invokes the handler and parses a batched `{ results: [...] }` envelope. */
+async function invokeBatch(tool: RenderTemplateTool, args: object): Promise<{
+    results?: Array<{ recipeUri: string; output?: string; error?: string }>;
+    error?: string;
+}> {
     const result = await tool.getTool().handler(JSON.stringify(args));
     return JSON.parse(result as string);
 }
@@ -332,6 +343,137 @@ describe('RenderTemplateTool', () => {
             expect(shown.templateLabel).to.equal('AI Template');
             expect(shown.inlineTemplateContent).to.equal('TPL');
             expect(shown.outputFormat).to.equal('markdown');
+        });
+    });
+
+    describe('recipeUris (batch)', () => {
+
+        it('advertises recipeUris as an array parameter', () => {
+            const { tool } = createTool();
+            const props = tool.getTool().parameters.properties as Record<string, { type?: string }>;
+            expect(props.recipeUris.type).to.equal('array');
+        });
+
+        it('renders one template against several recipes and keeps the input order', async () => {
+            const { tool, config, language, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/a.cook', 'A body');
+            files.files.set('file:///ws/b.cook', 'B body');
+            language.responder = recipe => JSON.stringify({ output: `OUT ${recipe}` });
+
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUris: ['a.cook', 'b.cook'] });
+
+            expect(result.results).to.deep.equal([
+                { recipeUri: 'a.cook', output: 'OUT A body' },
+                { recipeUri: 'b.cook', output: 'OUT B body' },
+            ]);
+        });
+
+        it('sends the template once per call, not once per recipe', async () => {
+            const { tool, config, language, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/a.cook', 'A');
+            files.files.set('file:///ws/b.cook', 'B');
+            files.files.set('file:///ws/config/reports/cost.jinja', 'COST TPL');
+
+            await invokeBatch(tool, { templateUri: 'config/reports/cost.jinja', recipeUris: ['a.cook', 'b.cook'] });
+
+            // The template file is resolved once and reused for every recipe —
+            // this is the whole point of the batch.
+            expect(language.calls.map(c => c.template)).to.deep.equal(['COST TPL', 'COST TPL']);
+        });
+
+        it('reports a failing recipe in its own entry and still renders the rest', async () => {
+            const { tool, config, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/good.cook', 'G');
+
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUris: ['missing.cook', 'good.cook'] });
+
+            expect(result.results).to.have.length(2);
+            expect(result.results![0].error).to.match(/Could not read recipe/);
+            expect(result.results![1].output).to.equal('RENDERED');
+        });
+
+        it('reports a per-recipe render error without failing the batch', async () => {
+            const { tool, config, language, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/a.cook', 'A');
+            files.files.set('file:///ws/b.cook', 'B');
+            language.responder = recipe =>
+                recipe === 'A' ? JSON.stringify({ error: 'unresolved ingredient' }) : JSON.stringify({ output: 'OK' });
+
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUris: ['a.cook', 'b.cook'] });
+
+            expect(result.results![0].error).to.equal('unresolved ingredient');
+            expect(result.results![1].output).to.equal('OK');
+        });
+
+        it('rejects a non-.cook entry in its own slot', async () => {
+            const { tool, config, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/a.cook', 'A');
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUris: ['notes.txt', 'a.cook'] });
+            expect(result.results![0].error).to.match(/\.cook or \.menu/);
+            expect(result.results![1].output).to.equal('RENDERED');
+        });
+
+        it('collapses duplicate recipes', async () => {
+            const { tool, config, language, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/a.cook', 'A');
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUris: ['a.cook', 'a.cook'] });
+            expect(result.results).to.have.length(1);
+            expect(language.calls).to.have.length(1);
+        });
+
+        it('rejects recipeUri and recipeUris together', async () => {
+            const { tool, config } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUri: 'a.cook', recipeUris: ['b.cook'] });
+            expect(result.error).to.match(/not both/);
+        });
+
+        it('rejects show with a batch and says how to present one result', async () => {
+            const { tool, config, presenter } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            const result = await invokeBatch(tool, { templateContent: 'TPL', recipeUris: ['a.cook'], show: true });
+            expect(result.error).to.match(/batch is headless/);
+            expect(presenter.shown).to.have.length(0);
+        });
+
+        it('rejects an empty array, a non-array, and non-string entries', async () => {
+            const { tool, config } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            expect((await invokeBatch(tool, { templateContent: 'T', recipeUris: [] })).error).to.match(/must not be empty/);
+            expect((await invokeBatch(tool, { templateContent: 'T', recipeUris: 'a.cook' })).error).to.match(/must be an array/);
+            expect((await invokeBatch(tool, { templateContent: 'T', recipeUris: ['a.cook', 3] })).error).to.match(/non-empty strings/);
+        });
+
+        it('rejects a batch larger than the cap and says to narrow first', async () => {
+            const { tool, config } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            const many = Array.from({ length: 26 }, (_, i) => `r${i}.cook`);
+            const result = await invokeBatch(tool, { templateContent: 'T', recipeUris: many });
+            expect(result.error).to.match(/at most 25 items, got 26/);
+            expect(result.error).to.match(/Narrow the shortlist/);
+        });
+
+        it('still validates the template before touching any recipe', async () => {
+            const { tool, config, language } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            const result = await invokeBatch(tool, { templateUri: 'builtin:nope', recipeUris: ['a.cook'] });
+            expect(result.error).to.match(/Unknown built-in template/);
+            expect(language.calls).to.have.length(0);
+        });
+
+        it('passes scale through for every recipe in the batch', async () => {
+            const { tool, config, files } = createTool();
+            config.workspaceRoot = new URI('file:///ws');
+            files.files.set('file:///ws/a.cook', 'A');
+            files.files.set('file:///ws/b.cook', 'B');
+            await invokeBatch(tool, { templateContent: 'T', recipeUris: ['a.cook', 'b.cook'], scale: 4 });
+            expect(config.lastScale).to.equal(4);
         });
     });
 });

--- a/packages/cooklang/src/browser/render-template-tool.ts
+++ b/packages/cooklang/src/browser/render-template-tool.ts
@@ -18,14 +18,23 @@ import URI from '@theia/core/lib/common/uri';
 import { CooklangLanguageService, CooklangUri, ReportOutputFormat, ReportTemplates } from '../common';
 import { ReportConfigService } from './report-config-service';
 import { ReportPresenter } from './report-presenter';
+import { MAX_BATCH_ITEMS, parseBatchArg } from './batch-args';
 
 interface RenderTemplateArgs {
     templateContent?: string;
     templateUri?: string;
     recipeUri?: string;
+    recipeUris?: string[];
     show?: boolean;
     outputFormat?: ReportOutputFormat;
     scale?: number;
+}
+
+/** One recipe's outcome in a batched render. */
+interface BatchEntry {
+    recipeUri: string;
+    output?: string;
+    error?: string;
 }
 
 /**
@@ -109,6 +118,16 @@ export class RenderTemplateTool implements ToolProvider {
                             + 'root (e.g. "Baking/Napoleon.cook"); an absolute path or file:// URI also works. Defaults to the '
                             + 'active recipe in the editor. Renders the file\'s saved content on disk (unsaved editor edits are not included).',
                     },
+                    recipeUris: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: `Render the SAME template against several recipes in one call (max ${MAX_BATCH_ITEMS}). `
+                            + 'Use this whenever you are screening a shortlist — "which of these are over 35% protein?" — instead of '
+                            + 'one call per recipe: the template is sent once rather than retyped for every candidate. '
+                            + 'Returns { results: [{ recipeUri, output } | { recipeUri, error }] } in the order given; a recipe that '
+                            + 'fails to read or render reports its error in its own entry and the rest still come back. '
+                            + 'Mutually exclusive with recipeUri, and cannot be combined with show (a batch is headless).',
+                    },
                     show: {
                         type: 'boolean',
                         description: 'When true, open or refresh a Report tab showing the output. Default false (headless; output only returned to you).',
@@ -146,6 +165,9 @@ export class RenderTemplateTool implements ToolProvider {
             : await this.resolveTemplate(args.templateUri ?? '');
         if ('error' in template) {
             return this.fail(template.error);
+        }
+        if (args.recipeUris !== undefined) {
+            return this.executeBatch(args, template);
         }
         let recipeUri: URI | undefined;
         if (args.recipeUri) {
@@ -196,6 +218,70 @@ export class RenderTemplateTool implements ToolProvider {
         }
         // renderReport already returns `{ output }` | `{ error }`; pass through.
         return resultJson;
+    }
+
+    /**
+     * Renders one already-resolved template against several recipes.
+     *
+     * The point of the batch is that the template is resolved and transmitted
+     * once. A screening pass used to re-send the same inline Jinja source with
+     * every candidate — in one observed session, 28 calls averaging 457 bytes
+     * of arguments, almost all of it the same template retyped.
+     *
+     * A recipe that cannot be read or rendered fails **in its own slot**; the
+     * others still come back. One bad candidate costing a retry of the whole
+     * shortlist would give the waste straight back.
+     */
+    protected async executeBatch(args: RenderTemplateArgs, template: ResolvedTemplate): Promise<string> {
+        if (args.recipeUri) {
+            return this.fail('Pass either recipeUri or recipeUris, not both.');
+        }
+        if (args.show) {
+            return this.fail('show renders a single recipe into the Report tab; a batch is headless. '
+                + 'Screen with recipeUris, then render the one you want to present with recipeUri and show:true.');
+        }
+        const refs = parseBatchArg(args.recipeUris, 'recipeUris');
+        if ('error' in refs) {
+            return this.fail(refs.error);
+        }
+        const results: BatchEntry[] = [];
+        for (const ref of refs) {
+            results.push(await this.renderOne(ref, template, args.scale ?? 1));
+        }
+        return JSON.stringify({ results });
+    }
+
+    /** Renders one recipe reference, mapping every failure into the entry itself. */
+    protected async renderOne(ref: string, template: ResolvedTemplate, scale: number): Promise<BatchEntry> {
+        const recipeUri = this.reportConfigService.resolveWorkspaceUri(ref);
+        if (!recipeUri) {
+            return {
+                recipeUri: ref,
+                error: `Could not resolve '${ref}': it is a relative path but no workspace is open.`,
+            };
+        }
+        if (!CooklangUri.isCooklang(recipeUri)) {
+            return { recipeUri: ref, error: `Must be a .cook or .menu file, got: ${recipeUri.path.base}` };
+        }
+        let recipeContent: string;
+        try {
+            recipeContent = (await this.fileService.read(recipeUri)).value;
+        } catch (e) {
+            return { recipeUri: ref, error: `Could not read recipe: ${this.message(e)}` };
+        }
+        try {
+            const configJson = await this.reportConfigService.buildConfigJson(scale, recipeUri);
+            const resultJson = await this.languageService.renderReport(recipeContent, template.content, configJson);
+            const parsed = this.tryParse(resultJson);
+            if (!parsed) {
+                return { recipeUri: ref, error: 'Render returned an unreadable result.' };
+            }
+            return parsed.error !== undefined
+                ? { recipeUri: ref, error: parsed.error }
+                : { recipeUri: ref, output: parsed.output };
+        } catch (e) {
+            return { recipeUri: ref, error: `Render failed: ${this.message(e)}` };
+        }
     }
 
     protected inlineTemplate(content: string): ResolvedTemplate {

--- a/packages/cooklang/src/browser/search-recipes-tool.spec.ts
+++ b/packages/cooklang/src/browser/search-recipes-tool.spec.ts
@@ -195,4 +195,72 @@ describe('SearchRecipesTool', () => {
         const result = await invoke(tool, { query: 'x' });
         expect(result.error).to.match(/boom/);
     });
+
+    describe('queries (batch)', () => {
+
+        it('runs every query in one call and keeps the input order', async () => {
+            const { tool, ls } = createTool();
+            ls.entries = [salmon];
+            const result = await invoke(tool, { queries: ['salmon', 'pancakes'] }) as unknown as {
+                searches: Array<{ query: string; recipes?: Array<{ path: string }>; total?: number }>;
+            };
+            expect(result.searches.map(s => s.query)).to.deep.equal(['salmon', 'pancakes']);
+            expect(ls.calls.map(c => c.query)).to.deep.equal(['salmon', 'pancakes']);
+            expect(result.searches[0].recipes?.[0].path).to.equal('Dinner/Salmon.cook');
+            expect(result.searches[0].total).to.equal(1);
+        });
+
+        it('applies tag and limit to every query', async () => {
+            const { tool, ls } = createTool();
+            ls.entries = [salmon, pancakes, menu];
+            const result = await invoke(tool, { queries: ['a', 'b'], tag: 'breakfast' }) as unknown as {
+                searches: Array<{ recipes?: Array<{ path: string }> }>;
+            };
+            expect(result.searches[0].recipes?.map(r => r.path)).to.deep.equal(['Pancakes.cook']);
+            expect(result.searches[1].recipes?.map(r => r.path)).to.deep.equal(['Pancakes.cook']);
+        });
+
+        it('reports a failing query in its own entry and still runs the rest', async () => {
+            const { tool, ls } = createTool();
+            ls.entries = [salmon];
+            ls.searchRecipes = async (_baseDir: string, query: string) => {
+                if (query === 'bad') { throw new Error('native boom'); }
+                return JSON.stringify([salmon]);
+            };
+            const result = await invoke(tool, { queries: ['bad', 'good'] }) as unknown as {
+                searches: Array<{ query: string; error?: string; total?: number }>;
+            };
+            expect(result.searches[0].error).to.match(/native boom/);
+            expect(result.searches[1].total).to.equal(1);
+        });
+
+        it('collapses duplicate queries', async () => {
+            const { tool, ls } = createTool();
+            const result = await invoke(tool, { queries: ['salmon', 'salmon'] }) as unknown as { searches: unknown[] };
+            expect(result.searches).to.have.length(1);
+            expect(ls.calls).to.have.length(1);
+        });
+
+        it('rejects query and queries together', async () => {
+            const { tool } = createTool();
+            const result = await invoke(tool, { query: 'a', queries: ['b'] });
+            expect(result.error).to.match(/not both/);
+        });
+
+        it('rejects an empty array and a batch over the cap', async () => {
+            const { tool } = createTool();
+            expect((await invoke(tool, { queries: [] })).error).to.match(/must not be empty/);
+            const many = Array.from({ length: 26 }, (_, i) => `q${i}`);
+            expect((await invoke(tool, { queries: many })).error).to.match(/at most 25 items/);
+        });
+
+        it('leaves the single-query result shape untouched', async () => {
+            const { tool, ls } = createTool();
+            ls.entries = [salmon];
+            const result = await invoke(tool, { query: 'salmon' });
+            expect(result.recipes).to.have.length(1);
+            expect(result.total).to.equal(1);
+            expect((result as unknown as { searches?: unknown }).searches).to.equal(undefined);
+        });
+    });
 });

--- a/packages/cooklang/src/browser/search-recipes-tool.ts
+++ b/packages/cooklang/src/browser/search-recipes-tool.ts
@@ -16,11 +16,21 @@ import { ToolProvider, ToolRequest } from '@theia/ai-core/lib/common';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import URI from '@theia/core/lib/common/uri';
 import { CooklangLanguageService } from '../common/cooklang-language-service';
+import { MAX_BATCH_ITEMS, parseBatchArg } from './batch-args';
 
 interface SearchRecipesArgs {
     query?: string;
+    queries?: string[];
     tag?: string;
     limit?: number;
+}
+
+/** One query's outcome in a batched search. */
+interface SearchResult {
+    query: string;
+    recipes?: ReturnType<SearchRecipesTool['toRecipe']>[];
+    total?: number;
+    error?: string;
 }
 
 /** Shape produced by the native `searchRecipes` export. */
@@ -70,6 +80,14 @@ export class SearchRecipesTool implements ToolProvider {
                         type: 'string',
                         description: 'Words to match against recipe file names and contents, e.g. "salmon", "chocolate cake".',
                     },
+                    queries: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        description: `Run several searches in one call (max ${MAX_BATCH_ITEMS}) instead of one call per query — `
+                            + 'use it when you are casting about for candidates ("chicken", "lentil", "salmon"). '
+                            + 'Returns { searches: [{ query, recipes, total }] } in the order given. `tag` and `limit` apply to '
+                            + 'every query. Mutually exclusive with query.',
+                    },
                     tag: {
                         type: 'string',
                         description: 'Keep only recipes whose tags include this value (case-insensitive), e.g. "vegetarian".',
@@ -100,33 +118,70 @@ export class SearchRecipesTool implements ToolProvider {
             return this.fail('No workspace is open.');
         }
 
-        const query = typeof args.query === 'string' ? args.query.trim() : '';
         const tag = typeof args.tag === 'string' ? args.tag.trim().toLowerCase() : '';
         const limit = this.normaliseLimit(args.limit);
 
+        if (args.queries !== undefined) {
+            if (typeof args.query === 'string' && args.query.trim()) {
+                return this.fail('Pass either query or queries, not both.');
+            }
+            const queries = parseBatchArg(args.queries, 'queries');
+            if ('error' in queries) {
+                return this.fail(queries.error);
+            }
+            const searches: SearchResult[] = [];
+            for (const each of queries) {
+                searches.push(await this.searchOne(root, each, tag, limit));
+            }
+            return JSON.stringify({ searches });
+        }
+
+        const query = typeof args.query === 'string' ? args.query.trim() : '';
+        const single = await this.searchOne(root, query, tag, limit);
+        return single.error !== undefined
+            ? this.fail(single.error)
+            : JSON.stringify({ recipes: single.recipes, total: single.total });
+    }
+
+    /**
+     * Runs one query, mapping a failure into the result rather than throwing.
+     *
+     * A batch reports each query in its own slot: one search that trips over a
+     * native error should not discard the others, which is the saving the batch
+     * exists for. The single-query path unwraps it back into a bare `{ error }`
+     * so its long-standing result shape is unchanged.
+     */
+    protected async searchOne(root: URI, query: string, tag: string, limit: number): Promise<SearchResult> {
         let entries: NativeRecipeEntry[];
         try {
             entries = JSON.parse(await this.languageService.searchRecipes(root.path.fsPath(), query));
         } catch (e) {
-            return this.fail(`Search failed: ${e instanceof Error ? e.message : String(e)}`);
+            return { query, error: `Search failed: ${e instanceof Error ? e.message : String(e)}` };
         }
         if (!Array.isArray(entries)) {
-            return this.fail('Search failed: unexpected result shape.');
+            return { query, error: 'Search failed: unexpected result shape.' };
         }
-
         const filtered = tag
             ? entries.filter(entry => entry.tags.some(t => t.toLowerCase() === tag))
             : entries;
+        return {
+            query,
+            recipes: filtered.slice(0, limit).map(entry => this.toRecipe(root, entry)),
+            total: filtered.length,
+        };
+    }
 
-        const recipes = filtered.slice(0, limit).map(entry => ({
+    protected toRecipe(root: URI, entry: NativeRecipeEntry): {
+        path: string; name: string | null; title: string | null; tags: string[]; isMenu: boolean; servings: number | null;
+    } {
+        return {
             path: this.relativePath(root, entry.path),
             name: entry.name,
             title: entry.title,
             tags: entry.tags,
             isMenu: entry.isMenu,
             servings: entry.servings,
-        }));
-        return JSON.stringify({ recipes, total: filtered.length });
+        };
     }
 
     protected normaliseLimit(value: unknown): number {


### PR DESCRIPTION
## Why

The AI fans out over the read tools one call at a time. In one cookbot session a single *"plan three dinners for two this week — quick on weeknights, 35%+ protein"* prompt produced **114 tool calls over 34 turns**:

```
getFileContent 61 · renderTemplate 28 · searchRecipes 11 · loadSkill 7 · other 7
renderTemplate arguments alone: 12,789 bytes generated (mean 457 B/call)
```

Those are output tokens — serial and expensive — and most of the render bytes were the same inline Jinja template retyped for every candidate, because `renderTemplate` takes one recipe per call.

## What

Each read tool gains a plural form that does the whole job in one call:

| tool | new arg | returns |
|---|---|---|
| `renderTemplate` | `recipeUris: []` | `{results:[{recipeUri, output\|error}]}` |
| `getFileContent` | `files: []` | `{files:[{file, content\|error}]}` |
| `searchRecipes` | `queries: []` | `{searches:[{query, recipes, total}]}` |
| `findFilesByPattern` | `patterns: []` | `{patterns:[{pattern, files}]}` |
| `getWorkspaceFileList` | `paths: []` | `{directories:[{path, entries\|error}]}` |

Two rules throughout, both tested:

- **A failure lands in its own slot.** One mistyped path must not fail the batch — the retry would hand the saved round trip straight back.
- **Single-argument result shapes are untouched**, so nothing downstream changes. Batches cap at 25 (with a message telling the model to narrow first) and collapse duplicates.

### `findFilesByPattern` gets more than a round trip

It traversed the workspace recursively **per glob**, so `['**/*.cook', '**/*.menu']` walked the tree twice. `traverseDirectory` now carries a bucket per pattern and tests each file against all of them in one walk. There's a test asserting three globs resolve exactly as many directories as one does.

## Also: `hasError` never fired

`hasError` only recognised a Theia `error` content part — and no cooklang or workspace tool emits one. They return a plain string with `{"error": ...}` inside it (`workspace-functions.ts` → `JSON.stringify({ error: 'File not found' })`). Every failure was reported to the server as a success, which is why the `tool_calls` table held **zero errors across every session it had ever recorded**. It now inspects the payload as well, narrowly: only a JSON object whose top-level `error` is a non-empty string counts, so `"error": null`, `""`, non-JSON and prose mentioning the word all stay successes.

Rows written before this fix under-report failures; a zero error count in an old export is a measurement artefact, not a clean run.

## Tests

`workspace-functions.ts` had **no coverage at all**, which was uncomfortable given the traversal restructure, so it gets a spec.

```
packages/cooklang       281 → 301   (+13 render batch, +7 search batch)
packages/cooklang-ai     97 → 120   (+20 file tools, +3 hasError)
```

Both packages lint clean.

## Merge order

Merge this **before** the matching cook.md PR (cook-md/cook-md), whose prompt changes tell the model to use these parameters. Tool schemas come from the editor, so the prompts describe arguments that only exist once this ships.

https://claude.ai/code/session_018qCxDyaiA4TCwyLPxF1uXP