### PR TITLE
feat(cooklang): open recipes the way a recipe editor should

### DIFF
--- a/packages/cooklang/src/browser/cooklang-frontend-module.ts
+++ b/packages/cooklang/src/browser/cooklang-frontend-module.ts
@@ -57,8 +57,25 @@ import { SearchRecipesTool } from './search-recipes-tool';
 import { GetPantryTool, CheckPantryTool } from './pantry-tools';
 import { GenerateShoppingListTool } from './generate-shopping-list-tool';
 import { bindCooklangPreferences } from '../common';
+import { EmptyFileDetector } from './empty-file-detector';
+import { PreviewTabManager } from './preview-tab-manager';
+import { CooklangWorkspaceCommandContribution } from './cooklang-workspace-command-contribution';
+import { createCooklangFileNavigatorWidget } from './cooklang-navigator-widget';
+import { WorkspaceCommandContribution } from '@theia/workspace/lib/browser/workspace-commands';
+import { FileNavigatorWidget } from '@theia/navigator/lib/browser/navigator-widget';
 
-export default new ContainerModule(bind => {
+export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
+    // Shared by both preview open handlers: an empty file opens in the editor,
+    // and a preview opened by a single click reuses one tab.
+    bind(EmptyFileDetector).toSelf().inSingletonScope();
+    bind(PreviewTabManager).toSelf().inSingletonScope();
+
+    // `New File...` proposes `Untitled.cook` rather than upstream's `Untitled.txt`.
+    rebind(WorkspaceCommandContribution).to(CooklangWorkspaceCommandContribution).inSingletonScope();
+
+    // Explorer with `alt`/`option` click opening the source of a recipe.
+    rebind(FileNavigatorWidget).toDynamicValue(ctx => createCooklangFileNavigatorWidget(ctx.container));
+
     // TextMate grammar
     bind(CooklangGrammarContribution).toSelf().inSingletonScope();
     bind(LanguageGrammarDefinitionContribution).toService(CooklangGrammarContribution);

--- a/packages/cooklang/src/browser/cooklang-navigator-widget.ts
+++ b/packages/cooklang/src/browser/cooklang-navigator-widget.ts
@@ -1,0 +1,97 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { Container, inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import * as React from '@theia/core/shared/react';
+import URI from '@theia/core/lib/common/uri';
+import { ContextMenuRenderer, SelectableTreeNode, TreeNode, TreeProps } from '@theia/core/lib/browser';
+import { createFileTreeContainer } from '@theia/filesystem/lib/browser';
+import { FileNode } from '@theia/filesystem/lib/browser/file-tree';
+import { EditorManager } from '@theia/editor/lib/browser';
+import { FileNavigatorTree } from '@theia/navigator/lib/browser/navigator-tree';
+import { FileNavigatorModel } from '@theia/navigator/lib/browser/navigator-model';
+import { FileNavigatorWidget } from '@theia/navigator/lib/browser/navigator-widget';
+import { NavigatorDecoratorService } from '@theia/navigator/lib/browser/navigator-decorator-service';
+import { FILE_NAVIGATOR_PROPS } from '@theia/navigator/lib/browser/navigator-container';
+import { CooklangUri } from '../common/cooklang-uri';
+
+/**
+ * The explorer, with `alt`/`option` as the "give me the source" modifier.
+ *
+ * Cooklang files open in their preview, which is what you want when reading a
+ * recipe and in the way when editing one. Holding `alt` while opening a recipe
+ * or menu from the explorer opens the text editor instead - the same gesture
+ * as the `Open Source` command, without hunting through the context menu.
+ */
+@injectable()
+export class CooklangFileNavigatorWidget extends FileNavigatorWidget {
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    constructor(
+        @inject(TreeProps) props: TreeProps,
+        @inject(FileNavigatorModel) override readonly model: FileNavigatorModel,
+        @inject(ContextMenuRenderer) contextMenuRenderer: ContextMenuRenderer
+    ) {
+        super(props, model, contextMenuRenderer);
+    }
+
+    protected override handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        if (this.opensSource(node, event)) {
+            event.stopPropagation();
+            if (SelectableTreeNode.is(node)) {
+                this.model.selectNode(node);
+            }
+            // A single click opens only if the user asked for that open mode,
+            // exactly as it does without the modifier.
+            if (this.corePreferences['workbench.list.openMode'] === 'singleClick') {
+                this.openSource(node.uri, true);
+            }
+            return;
+        }
+        super.handleClickEvent(node, event);
+    }
+
+    protected override handleDblClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
+        if (this.opensSource(node, event)) {
+            event.stopPropagation();
+            this.openSource(node.uri, false);
+            return;
+        }
+        super.handleDblClickEvent(node, event);
+    }
+
+    /** Whether this click asks for the source of a Cooklang file. */
+    protected opensSource(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): node is FileNode {
+        return event.altKey && FileNode.is(node) && CooklangUri.isCooklang(node.uri);
+    }
+
+    protected openSource(uri: URI, preview: boolean): void {
+        this.editorManager.open(uri, { mode: 'activate', preview });
+    }
+}
+
+export function createCooklangFileNavigatorContainer(parent: interfaces.Container): Container {
+    return createFileTreeContainer(parent, {
+        tree: FileNavigatorTree,
+        model: FileNavigatorModel,
+        widget: CooklangFileNavigatorWidget,
+        decoratorService: NavigatorDecoratorService,
+        props: FILE_NAVIGATOR_PROPS,
+    });
+}
+
+export function createCooklangFileNavigatorWidget(parent: interfaces.Container): FileNavigatorWidget {
+    return createCooklangFileNavigatorContainer(parent).get(CooklangFileNavigatorWidget);
+}

--- a/packages/cooklang/src/browser/cooklang-workspace-command-contribution.ts
+++ b/packages/cooklang/src/browser/cooklang-workspace-command-contribution.ts
@@ -1,0 +1,34 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { WorkspaceCommandContribution } from '@theia/workspace/lib/browser/workspace-commands';
+import { CooklangUri } from '../common/cooklang-uri';
+
+/**
+ * `New File...` in a recipe editor defaults to a recipe.
+ *
+ * Upstream proposes `Untitled.txt`, which is never what someone writing in a
+ * Cooklang editor wants; every new file here starts life as a recipe unless
+ * the name says otherwise.
+ */
+@injectable()
+export class CooklangWorkspaceCommandContribution extends WorkspaceCommandContribution {
+
+    protected override getDefaultFileConfig(): { fileName: string, fileExtension: string } {
+        return {
+            fileName: 'Untitled',
+            fileExtension: CooklangUri.RECIPE_EXTENSION
+        };
+    }
+}

--- a/packages/cooklang/src/browser/empty-file-detector.spec.ts
+++ b/packages/cooklang/src/browser/empty-file-detector.spec.ts
@@ -1,0 +1,57 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+// `EmptyFileDetector` injects `FileService`, whose module graph reaches the
+// Lumino widgets and touches `document` while loading. Left enabled for the
+// rest of the run: mocha loads every spec file before running any test, so the
+// sibling specs loaded after this one capture the DOM this sets up.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+enableJSDOM();
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { EmptyFileDetector } from './empty-file-detector';
+
+function detectorFor(stat: { size?: number, isDirectory?: boolean } | Error): EmptyFileDetector {
+    const detector = new EmptyFileDetector();
+    (detector as unknown as { fileService: unknown }).fileService = {
+        resolve: async () => {
+            if (stat instanceof Error) {
+                throw stat;
+            }
+            return { size: stat.size ?? 0, isDirectory: stat.isDirectory ?? false };
+        }
+    };
+    return detector;
+}
+
+const uri = new URI('file:///ws/Untitled.cook');
+
+describe('EmptyFileDetector', () => {
+
+    it('reports a zero byte file as empty', async () => {
+        expect(await detectorFor({ size: 0 }).isEmpty(uri)).to.be.true;
+    });
+
+    it('reports a file with content as non-empty', async () => {
+        expect(await detectorFor({ size: 42 }).isEmpty(uri)).to.be.false;
+    });
+
+    it('reports a directory as non-empty', async () => {
+        expect(await detectorFor({ size: 0, isDirectory: true }).isEmpty(uri)).to.be.false;
+    });
+
+    it('reports a file it cannot stat as non-empty', async () => {
+        expect(await detectorFor(new Error('ENOENT')).isEmpty(uri)).to.be.false;
+    });
+});

--- a/packages/cooklang/src/browser/empty-file-detector.ts
+++ b/packages/cooklang/src/browser/empty-file-detector.ts
@@ -1,0 +1,49 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import URI from '@theia/core/lib/common/uri';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+
+/**
+ * Tells whether a file has any content yet.
+ *
+ * The previews open by default for `.cook` and `.menu` files, which is the
+ * right thing for a recipe that exists but useless for one that does not: a
+ * file straight out of `New File...` renders as an empty preview with no way
+ * to type into it. The preview open handlers therefore stand down for empty
+ * files so the text editor takes over.
+ */
+@injectable()
+export class EmptyFileDetector {
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    /**
+     * Whether `uri` is an existing file with no content.
+     *
+     * Never rejects: a file that cannot be stat'ed is reported as non-empty so
+     * that opening behaves as it did before, rather than degrading to the
+     * editor on a transient filesystem error.
+     */
+    async isEmpty(uri: URI): Promise<boolean> {
+        try {
+            const stat = await this.fileService.resolve(uri, { resolveMetadata: true });
+            return !stat.isDirectory && stat.size === 0;
+        } catch (e) {
+            console.warn(`[cooklang] could not stat ${uri.toString()}:`, e);
+            return false;
+        }
+    }
+}

--- a/packages/cooklang/src/browser/menu-preview-contribution.ts
+++ b/packages/cooklang/src/browser/menu-preview-contribution.ts
@@ -21,10 +21,12 @@ import { NavigatableWidget } from '@theia/core/lib/browser/navigatable-types';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import URI from '@theia/core/lib/common/uri';
-import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import { OpenerOptions, OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { COOKLANG_LANGUAGE_ID, CooklangUri } from '../common';
+import { EmptyFileDetector } from './empty-file-detector';
+import { PreviewTabManager } from './preview-tab-manager';
 import {
     MenuPreviewWidget,
     MENU_PREVIEW_WIDGET_ID,
@@ -72,21 +74,31 @@ export class MenuPreviewContribution implements CommandContribution, KeybindingC
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
+    @inject(EmptyFileDetector)
+    protected readonly emptyFileDetector: EmptyFileDetector;
+
+    @inject(PreviewTabManager)
+    protected readonly previewTabs: PreviewTabManager;
+
     readonly id = 'cooklang-menu-preview-open-handler';
     readonly label = 'Cooklang: Menu Preview';
 
-    canHandle(uri: URI): number {
+    async canHandle(uri: URI): Promise<number> {
         if (uri.scheme === 'file' && CooklangUri.isMenu(uri)) {
-            return 200;
+            // An empty menu has nothing to preview and no way to type into
+            // one, so a file straight out of `New File...` opens in the editor.
+            return await this.emptyFileDetector.isEmpty(uri) ? 0 : 200;
         }
         return 0;
     }
 
-    async open(uri: URI): Promise<MenuPreviewWidget> {
+    async open(uri: URI, options?: OpenerOptions): Promise<MenuPreviewWidget> {
+        const created = this.widgetManager.tryGetWidget(createMenuPreviewWidgetId(uri)) === undefined;
         const preview = await this.getOrCreatePreview(uri);
         if (!preview.isAttached) {
-            await this.shell.addWidget(preview, { area: 'main' });
+            await this.shell.addWidget(preview, this.previewTabs.placement());
         }
+        this.previewTabs.apply(preview, options, created);
         this.shell.activateWidget(preview.id);
         return preview;
     }

--- a/packages/cooklang/src/browser/preview-tab-manager.spec.ts
+++ b/packages/cooklang/src/browser/preview-tab-manager.spec.ts
@@ -1,0 +1,155 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+// The shell types this pulls in reach the Lumino widgets, which touch
+// `document` while loading. See empty-file-detector.spec.ts.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+enableJSDOM();
+
+import { expect } from 'chai';
+import { Disposable } from '@theia/core/lib/common';
+import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
+import { PreviewTabManager } from './preview-tab-manager';
+
+const TEMPORARY_CLASS = 'cooklang-preview-tab-temporary';
+
+/** A stand-in for a preview widget: a tab title and a DOM node are all the manager touches. */
+function widgetWith(html: string = '<p>Boil water</p>'): BaseWidget {
+    const node = document.createElement('div');
+    node.innerHTML = html;
+    return {
+        node,
+        isAttached: true,
+        title: { className: '' },
+        onDidDispose: () => Disposable.NULL
+    } as unknown as BaseWidget;
+}
+
+function isTemporary(widget: BaseWidget): boolean {
+    return widget.title.className.includes(TEMPORARY_CLASS);
+}
+
+interface Handlers {
+    handleClick(event: unknown): void;
+    handleDoubleClick(event: unknown): void;
+}
+
+function managerWith(enablePreview: boolean = true): PreviewTabManager & Handlers {
+    const manager = new PreviewTabManager();
+    (manager as unknown as { preferenceService: unknown }).preferenceService = {
+        get: (_name: string, defaultValue: boolean) => enablePreview ? defaultValue : false
+    };
+    return manager as PreviewTabManager & Handlers;
+}
+
+/** A click on `selector` within `widget`, shaped like the DOM events the manager listens for. */
+function clickOn(widget: BaseWidget, selector: string): unknown {
+    return { target: widget.node.querySelector(selector) };
+}
+
+describe('PreviewTabManager', () => {
+
+    it('places the first preview in a tab of its own', () => {
+        expect(managerWith().placement()).to.deep.equal({ area: 'main' });
+    });
+
+    it('gives a single-click preview the reusable tab', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        manager.apply(recipe, { preview: true }, true);
+        expect(isTemporary(recipe)).to.be.true;
+        expect(manager.placement()).to.deep.equal({ area: 'main', mode: 'tab-replace', ref: recipe });
+    });
+
+    it('hands the reusable tab to the next single-click preview', () => {
+        const manager = managerWith();
+        const first = widgetWith();
+        const second = widgetWith();
+        manager.apply(first, { preview: true }, true);
+        manager.apply(second, { preview: true }, true);
+        expect(manager.placement()).to.deep.equal({ area: 'main', mode: 'tab-replace', ref: second });
+        expect(isTemporary(second)).to.be.true;
+    });
+
+    it('opens a deliberately opened recipe in its own tab', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        manager.apply(recipe, undefined, true);
+        expect(isTemporary(recipe)).to.be.false;
+        expect(manager.placement()).to.deep.equal({ area: 'main' });
+    });
+
+    it('keeps the tab reusable when the same recipe is single-clicked again', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        manager.apply(recipe, { preview: true }, true);
+        manager.apply(recipe, { preview: true }, false);
+        expect(isTemporary(recipe)).to.be.true;
+    });
+
+    it('pins the tab when the same recipe is opened deliberately', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        manager.apply(recipe, { preview: true }, true);
+        manager.apply(recipe, undefined, false);
+        expect(isTemporary(recipe)).to.be.false;
+        expect(manager.placement()).to.deep.equal({ area: 'main' });
+    });
+
+    it('leaves a tab that was already open alone', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        manager.apply(recipe, { preview: true }, false);
+        expect(isTemporary(recipe)).to.be.false;
+    });
+
+    it('pins the tab on an interaction with the recipe', () => {
+        const manager = managerWith();
+        const recipe = widgetWith('<p>Boil <span role="button">10 min</span></p>');
+        manager.apply(recipe, { preview: true }, true);
+        manager.handleClick(clickOn(recipe, '[role="button"]'));
+        expect(isTemporary(recipe)).to.be.false;
+    });
+
+    it('keeps the tab reusable when the recipe is only read', () => {
+        const manager = managerWith();
+        const recipe = widgetWith('<p>Boil <span role="button">10 min</span></p>');
+        manager.apply(recipe, { preview: true }, true);
+        manager.handleClick(clickOn(recipe, 'p'));
+        expect(isTemporary(recipe)).to.be.true;
+    });
+
+    it('pins the tab on a double click anywhere in the recipe', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        manager.apply(recipe, { preview: true }, true);
+        manager.handleDoubleClick(clickOn(recipe, 'p'));
+        expect(isTemporary(recipe)).to.be.false;
+    });
+
+    it('ignores events outside the reusable tab', () => {
+        const manager = managerWith();
+        const recipe = widgetWith();
+        const elsewhere = widgetWith();
+        manager.apply(recipe, { preview: true }, true);
+        manager.handleDoubleClick(clickOn(elsewhere, 'p'));
+        expect(isTemporary(recipe)).to.be.true;
+    });
+
+    it('opens every recipe in its own tab when preview tabs are turned off', () => {
+        const manager = managerWith(false);
+        const recipe = widgetWith();
+        manager.apply(recipe, { preview: true }, true);
+        expect(isTemporary(recipe)).to.be.false;
+    });
+});

--- a/packages/cooklang/src/browser/preview-tab-manager.ts
+++ b/packages/cooklang/src/browser/preview-tab-manager.ts
@@ -1,0 +1,157 @@
+// *****************************************************************************
+// Copyright (C) 2024-2026 cook.md and contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU Affero General Public License version 3 as
+// published by the Free Software Foundation, with the linking exception
+// documented in NOTICE.md.
+//
+// See LICENSE-AGPL for the full license text.
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
+import { PreferenceService } from '@theia/core/lib/common/preferences';
+import { OpenerOptions } from '@theia/core/lib/browser/opener-service';
+import { Disposable } from '@theia/core/lib/common';
+
+import '../../src/browser/style/preview-tab.css';
+
+/**
+ * Opener options carrying the "preview tab" flag: the explorer sets it for a
+ * single click and leaves it off for a double click, and Theia's text editors
+ * read the same flag.
+ */
+export interface PreviewTabOpenerOptions extends OpenerOptions {
+    preview?: boolean;
+}
+
+/** Marks the tab title of the reusable preview, rendering its label in italics. */
+const TEMPORARY_TITLE_CLASS = 'cooklang-preview-tab-temporary';
+
+/** What counts as using a preview rather than glancing at it. */
+const INTERACTIVE_SELECTOR = 'a, button, input, select, textarea, [role="button"], [role="checkbox"], [role="link"]';
+
+/**
+ * Keeps browsing recipes down to a single tab.
+ *
+ * A recipe or menu opened by a single click lands in one reusable tab, the way
+ * VS Code and Theia's own text editors treat a preview: the next recipe opened
+ * the same way takes its place. The tab stops being reusable as soon as it is
+ * used for real - a double click, a started timer, a followed link, a changed
+ * scale - or when the recipe is opened deliberately (a double click in the
+ * explorer, a command, the preview toolbar).
+ */
+@injectable()
+export class PreviewTabManager {
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    /** The preview currently occupying the reusable tab, if any. */
+    protected temporary: BaseWidget | undefined;
+
+    /** Untracks {@link temporary} when it goes away on its own. */
+    protected toReset: Disposable | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        document.addEventListener('dblclick', this.handleDoubleClick, true);
+        document.addEventListener('click', this.handleClick, true);
+        document.addEventListener('keydown', this.handleKeyDown, true);
+    }
+
+    /**
+     * Where to attach a preview that is about to open. A reusable tab is passed
+     * as the reference of a `tab-replace`, so the shell puts the new preview in
+     * its place and closes it.
+     */
+    placement(): ApplicationShell.WidgetOptions {
+        const reused = this.temporary;
+        return reused?.isAttached
+            ? { area: 'main', mode: 'tab-replace', ref: reused }
+            : { area: 'main' };
+    }
+
+    /**
+     * Record what `widget` became now that it is open.
+     *
+     * @param options the opener options it was opened with.
+     * @param created whether this open created the widget. A tab that was
+     * already open keeps the state it had: reopening never turns a tab the user
+     * has settled into back into a reusable one.
+     */
+    apply(widget: BaseWidget, options: OpenerOptions | undefined, created: boolean): void {
+        const requested = this.isTemporaryRequested(options);
+        if (this.temporary === widget) {
+            if (!requested) {
+                this.pin(widget);
+            }
+            return;
+        }
+        if (!requested || !created) {
+            return;
+        }
+        this.reset();
+        this.temporary = widget;
+        widget.title.className += ` ${TEMPORARY_TITLE_CLASS}`;
+        this.toReset = widget.onDidDispose(() => this.reset());
+    }
+
+    /** Make `widget` a tab of its own, if it is the reusable one. */
+    pin(widget: BaseWidget): void {
+        if (this.temporary !== widget) {
+            return;
+        }
+        widget.title.className = widget.title.className.replace(TEMPORARY_TITLE_CLASS, '').trim();
+        this.reset();
+    }
+
+    protected isTemporaryRequested(options: OpenerOptions | undefined): boolean {
+        return !!(options as PreviewTabOpenerOptions | undefined)?.preview
+            && this.preferenceService.get<boolean>('editor.enablePreview', true);
+    }
+
+    protected reset(): void {
+        this.temporary = undefined;
+        this.toReset?.dispose();
+        this.toReset = undefined;
+    }
+
+    protected readonly handleDoubleClick = (event: MouseEvent): void => {
+        if (this.isInsideTemporary(event)) {
+            this.pin(this.temporary!);
+        }
+    };
+
+    protected readonly handleClick = (event: MouseEvent): void => {
+        if (this.isInsideTemporary(event) && this.isInteractive(event.target)) {
+            this.pin(this.temporary!);
+        }
+    };
+
+    protected readonly handleKeyDown = (event: KeyboardEvent): void => {
+        if ((event.key === 'Enter' || event.key === ' ') && this.isInsideTemporary(event) && this.isInteractive(event.target)) {
+            this.pin(this.temporary!);
+        }
+    };
+
+    /**
+     * Whether the event happened in the reusable preview itself. Clicks on its
+     * tab are deliberately not "inside": picking a tab is not using it.
+     */
+    protected isInsideTemporary(event: Event): boolean {
+        const widget = this.temporary;
+        return !!widget && event.target instanceof Node && widget.node.contains(event.target);
+    }
+
+    protected isInteractive(target: EventTarget | null): boolean {
+        return target instanceof Element && !!target.closest(INTERACTIVE_SELECTOR);
+    }
+}

--- a/packages/cooklang/src/browser/recipe-preview-contribution.ts
+++ b/packages/cooklang/src/browser/recipe-preview-contribution.ts
@@ -21,10 +21,12 @@ import { NavigatableWidget } from '@theia/core/lib/browser/navigatable-types';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { NavigatorContextMenu } from '@theia/navigator/lib/browser/navigator-contribution';
 import URI from '@theia/core/lib/common/uri';
-import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import { OpenerOptions, OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
 import { COOKLANG_LANGUAGE_ID, CooklangPreferences, CooklangUri } from '../common';
+import { EmptyFileDetector } from './empty-file-detector';
+import { PreviewTabManager } from './preview-tab-manager';
 import {
     RecipePreviewWidget,
     RECIPE_PREVIEW_WIDGET_ID,
@@ -79,21 +81,31 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
     @inject(SelectionService)
     protected readonly selectionService: SelectionService;
 
+    @inject(EmptyFileDetector)
+    protected readonly emptyFileDetector: EmptyFileDetector;
+
+    @inject(PreviewTabManager)
+    protected readonly previewTabs: PreviewTabManager;
+
     readonly id = 'cooklang-preview-open-handler';
     readonly label = 'Cooklang: Recipe Preview';
 
-    canHandle(uri: URI): number {
+    async canHandle(uri: URI): Promise<number> {
         if (uri.scheme === 'file' && CooklangUri.isRecipe(uri) && this.preferences['cooklang.openInPreviewMode']) {
-            return 200;
+            // An empty recipe has nothing to preview and no way to type into
+            // one, so a file straight out of `New File...` opens in the editor.
+            return await this.emptyFileDetector.isEmpty(uri) ? 0 : 200;
         }
         return 0;
     }
 
-    async open(uri: URI): Promise<RecipePreviewWidget> {
+    async open(uri: URI, options?: OpenerOptions): Promise<RecipePreviewWidget> {
+        const created = this.widgetManager.tryGetWidget(createRecipePreviewWidgetId(uri)) === undefined;
         const preview = await this.getOrCreatePreview(uri);
         if (!preview.isAttached) {
-            await this.shell.addWidget(preview, { area: 'main' });
+            await this.shell.addWidget(preview, this.previewTabs.placement());
         }
+        this.previewTabs.apply(preview, options, created);
         this.shell.activateWidget(preview.id);
         return preview;
     }
@@ -256,6 +268,7 @@ export class RecipePreviewContribution implements CommandContribution, Keybindin
         }
         const preview = await this.getOrCreatePreview(target);
         preview.setScale(scale);
+        this.previewTabs.pin(preview);
         await this.shell.addWidget(preview, { area: 'main' });
         this.shell.activateWidget(preview.id);
     }

--- a/packages/cooklang/src/browser/style/preview-tab.css
+++ b/packages/cooklang/src/browser/style/preview-tab.css
@@ -1,0 +1,10 @@
+/********************************************************************************
+ * Copyright (C) 2024-2026 cook.md and contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only WITH LicenseRef-cooklang-theia-linking-exception
+ ********************************************************************************/
+
+/* The reusable preview tab, shown the way Theia renders preview editors. */
+.cooklang-preview-tab-temporary .lm-TabBar-tabLabel {
+    font-style: italic;
+}


### PR DESCRIPTION
Four changes to how a recipe reaches a tab, all in `packages/cooklang` — no upstream Theia files touched.

### `New File...` proposes a recipe

`CooklangWorkspaceCommandContribution` overrides `getDefaultFileConfig()`, so the dialog offers `Untitled.cook` instead of upstream's `Untitled.txt`.

### An empty recipe opens in the editor

A file straight out of `New File...` has nothing to preview and no way to type into it. `EmptyFileDetector` stats the file and both preview open handlers stand down for a zero-byte one, so the editor takes over. A file that cannot be stat'ed counts as non-empty, so a transient filesystem error leaves opening exactly as it was.

### `alt`/`option` click opens the source

`CooklangFileNavigatorWidget` handles an `alt` click (and `alt` double click) on a `.cook`/`.menu` node by opening the text editor — the `Open Source` command's effect, without hunting through the context menu. Everything else falls through to upstream.

### One reusable tab while browsing recipes

A recipe opened by a single click lands in one reusable tab, italic like Theia's own preview editors; the next recipe opened the same way takes its place (`mode: 'tab-replace'`, so it keeps the position). The tab stops being reusable as soon as it is used for real:

- a double click anywhere in the preview,
- a click or Enter/Space on something interactive in it (timer badge, scale input, link, add-to-shopping-list),
- a deliberate open (double click in the explorer, a command, a scale set from the Timers panel),
- and the whole behaviour is off when `editor.enablePreview` is false.

A tab that was already open keeps the state it had: reopening never demotes a tab you have settled into. Reading — clicking text, scrolling — deliberately does not pin, so browsing stays in one tab.

## Testing

`npm run lint` and the package tests pass (326 passing, 16 new specs across `EmptyFileDetector` and `PreviewTabManager`).

Driven against the running Electron app over CDP, 9/9:

```
PASS  single click opens the recipe preview
PASS  the preview tab is marked reusable (italic)   {"label":"Preview: Carbonara.cook","reusable":true,"italic":true}
PASS  the next recipe reuses the tab                ["Preview: Pancakes.cook"]
PASS  using the recipe (started the "01:42" timer) pins its tab
PASS  a pinned tab survives the next recipe         ["Preview: Pancakes.cook","Preview: Soup.cook"]
PASS  alt click opens the source editor
PASS  an empty recipe opens in the editor
PASS  New File... proposes a .cook file             dialog value: Untitled.cook
```

https://claude.ai/code/session_019BmsupnvHrCpiRAZ59dGGL
